### PR TITLE
Story 2: Project scaffolding, solution structure & CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    name: Restore, build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore RPGEngine.sln
+
+      - name: Build (Release)
+        run: dotnet build RPGEngine.sln -c Release
+
+      - name: Test (Release)
+        run: dotnet test RPGEngine.sln -c Release --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Build output
+bin/
+obj/
+
+# IDE / editor
+.vs/
+.idea/
+*.user
+*.suo
+
+# Test results
+TestResults/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # rpg-engine
+
+A 2D RPG engine written in C# on the latest .NET, using SkiaSharp for rendering and DotTiled for Tiled map/tileset parsing.
+
+## Repository layout
+
+```
+RPGEngine.sln
+src/RPGEngine/          # The engine class library
+src/RPGEngine/Tiled/    # Tiled map/tileset types (RPGEngine.Tiled namespace)
+tests/RPGEngine.Tests/  # xUnit test project
+.github/workflows/ci.yml
+```
+
+## Build & test
+
+Requires the .NET 10 SDK.
+
+```bash
+dotnet restore RPGEngine.sln
+dotnet build RPGEngine.sln -c Release
+dotnet test RPGEngine.sln -c Release --no-build
+```
+
+The CI pipeline (`.github/workflows/ci.yml`) runs these same steps on every push and pull request to `main`.

--- a/RPGEngine.sln
+++ b/RPGEngine.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RPGEngine", "src\RPGEngine\RPGEngine.csproj", "{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RPGEngine.Tests", "tests\RPGEngine.Tests\RPGEngine.Tests.csproj", "{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Release|x64.Build.0 = Release|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED}.Release|x86.Build.0 = Release|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Debug|x64.Build.0 = Debug|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Debug|x86.Build.0 = Debug|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Release|x64.ActiveCfg = Release|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Release|x64.Build.0 = Release|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Release|x86.ActiveCfg = Release|Any CPU
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{98C7D07D-98A1-4CAD-ACED-ACEDDB20D1ED} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7EE64367-FFAB-4AD6-83E4-2DBB6D9D2851} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+EndGlobal

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -1,0 +1,12 @@
+namespace RPGEngine;
+
+/// <summary>
+/// Represents a character present in the game world.
+/// Movement, direction, base speed and sprite sheets are introduced by later
+/// stories of the epic; this story only establishes the type.
+/// </summary>
+public class Character
+{
+    // Deliberately empty: position, direction, base speed and sprite sheets
+    // are added by later stories.
+}

--- a/src/RPGEngine/GameConfig.cs
+++ b/src/RPGEngine/GameConfig.cs
@@ -1,0 +1,21 @@
+namespace RPGEngine;
+
+/// <summary>
+/// Contains the configuration values used by the engine.
+/// For now it only holds the keys used for movement, which default to WASD.
+/// When the values are updated at runtime, they are taken into account by the engine.
+/// </summary>
+public sealed class GameConfig
+{
+    /// <summary>Gets or sets the key used to move up. Defaults to <see cref="Key.W"/>.</summary>
+    public Key MoveUp { get; set; } = Key.W;
+
+    /// <summary>Gets or sets the key used to move down. Defaults to <see cref="Key.S"/>.</summary>
+    public Key MoveDown { get; set; } = Key.S;
+
+    /// <summary>Gets or sets the key used to move left. Defaults to <see cref="Key.A"/>.</summary>
+    public Key MoveLeft { get; set; } = Key.A;
+
+    /// <summary>Gets or sets the key used to move right. Defaults to <see cref="Key.D"/>.</summary>
+    public Key MoveRight { get; set; } = Key.D;
+}

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -1,0 +1,44 @@
+using RPGEngine.Tiled;
+
+namespace RPGEngine;
+
+/// <summary>
+/// The root of the engine. Owns the game state (player, characters, map and
+/// configuration) and, in later stories, exposes the game-loop entry points
+/// (<c>Update</c>, <c>Render</c>, <c>Input</c>, asset loading) used by the host.
+/// </summary>
+public sealed class GameEngine
+{
+    private readonly List<Character> _characters = [];
+
+    /// <summary>
+    /// Gets the player character. The camera will always follow the player (later story).
+    /// </summary>
+    public Player Player { get; }
+
+    /// <summary>
+    /// Gets the characters present in the game world, excluding the player.
+    /// When the list is updated, it is taken into account by the engine.
+    /// </summary>
+    public IReadOnlyList<Character> Characters => _characters;
+
+    /// <summary>
+    /// Gets the tile map to be displayed, or <see langword="null"/> when no map is loaded.
+    /// When it is changed, the rendering is updated (later story).
+    /// </summary>
+    public TileMap? Map { get; }
+
+    /// <summary>
+    /// Gets the configuration values used by the engine. When the values are updated,
+    /// they are taken into account by the engine.
+    /// </summary>
+    public GameConfig Config { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="GameEngine"/> class with default state.</summary>
+    public GameEngine()
+    {
+        Player = new Player();
+        Map = null;
+        Config = new GameConfig();
+    }
+}

--- a/src/RPGEngine/Key.cs
+++ b/src/RPGEngine/Key.cs
@@ -1,0 +1,21 @@
+namespace RPGEngine;
+
+/// <summary>
+/// Represents a keyboard key that can be bound to an engine action.
+/// The full set of supported keys is completed by later stories; this story
+/// only needs the movement keys (WASD) used by the default <see cref="GameConfig"/>.
+/// </summary>
+public enum Key
+{
+    /// <summary>The W key (bound to moving up by default).</summary>
+    W,
+
+    /// <summary>The A key (bound to moving left by default).</summary>
+    A,
+
+    /// <summary>The S key (bound to moving down by default).</summary>
+    S,
+
+    /// <summary>The D key (bound to moving right by default).</summary>
+    D,
+}

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -1,0 +1,18 @@
+namespace RPGEngine;
+
+/// <summary>
+/// Represents the player controlled by the user. It is composed of a
+/// <see cref="Character"/> which represents the player in the game world,
+/// and it will be moved when the engine receives input events (later story).
+/// </summary>
+public sealed class Player
+{
+    /// <summary>Gets the <see cref="Character"/> that represents the player in the game world.</summary>
+    public Character Character { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="Player"/> class.</summary>
+    public Player()
+    {
+        Character = new Character();
+    }
+}

--- a/src/RPGEngine/RPGEngine.csproj
+++ b/src/RPGEngine/RPGEngine.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>RPGEngine</RootNamespace>
+    <AssemblyName>RPGEngine</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="3.119.4" />
+    <PackageReference Include="DotTiled" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Lets the test project exercise internal helpers (e.g. the character compositor)
+         without exposing them as public API. -->
+    <InternalsVisibleTo Include="RPGEngine.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -1,0 +1,10 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// Represents a tile map based on a Tiled TMX file.
+/// Loading and rendering of maps are introduced by later stories of the epic.
+/// </summary>
+public sealed class TileMap
+{
+    // Deliberately empty: map loading/rendering is added by later stories.
+}

--- a/tests/RPGEngine.Tests/GameEngineSmokeTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineSmokeTests.cs
@@ -1,0 +1,32 @@
+using RPGEngine;
+using Xunit;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Smoke tests that verify a freshly created <see cref="GameEngine"/> exposes a sane default state.
+/// </summary>
+public class GameEngineSmokeTests
+{
+    /// <summary>
+    /// Verifies that a new engine has a non-null player, an empty (non-null) character list,
+    /// a configuration with the default WASD bindings and no loaded map.
+    /// </summary>
+    [Fact]
+    public void NewGameEngine_HasExpectedDefaults()
+    {
+        var engine = new GameEngine();
+
+        Assert.NotNull(engine.Player);
+        Assert.NotNull(engine.Characters);
+        Assert.Empty(engine.Characters);
+
+        Assert.NotNull(engine.Config);
+        Assert.Equal(Key.W, engine.Config.MoveUp);
+        Assert.Equal(Key.S, engine.Config.MoveDown);
+        Assert.Equal(Key.A, engine.Config.MoveLeft);
+        Assert.Equal(Key.D, engine.Config.MoveRight);
+
+        Assert.Null(engine.Map);
+    }
+}

--- a/tests/RPGEngine.Tests/RPGEngine.Tests.csproj
+++ b/tests/RPGEngine.Tests/RPGEngine.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>RPGEngine.Tests</RootNamespace>
+    <AssemblyName>RPGEngine.Tests</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RPGEngine\RPGEngine.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #2

## Summary

Bootstraps the repository (previously only a README) with the solution, engine class library, test project and CI pipeline so subsequent stories can land on a green build.

### Repository layout
```
RPGEngine.sln
Directory.Build.props
src/RPGEngine/RPGEngine.csproj
tests/RPGEngine.Tests/RPGEngine.Tests.csproj
.github/workflows/ci.yml
```

### What was added
- **`RPGEngine.sln`** — solution with `src` and `tests` solution folders.
- **`Directory.Build.props`** — shared settings inherited by both projects: `ImplicitUsings`, `Nullable`, `LangVersion=latest`, `TreatWarningsAsErrors`, `GenerateDocumentationFile` (CS1591 for missing XML docs becomes an error).
- **`src/RPGEngine`** — `net10.0` class library referencing `SkiaSharp 3.119.4` and `DotTiled 1.0.0`. No platform-specific packages. Adds `InternalsVisibleTo("RPGEngine.Tests")`.
  - `GameEngine` (Player, Characters, Map, Config), `GameConfig` (WASD movement defaults), `Key` (W/A/S/D), `Character`, `Player` (composed of a `Character`, per the epic's "favour composition over inheritance"), and `RPGEngine.Tiled.TileMap`.
- **`tests/RPGEngine.Tests`** — xUnit (`Microsoft.NET.Test.Sdk 17.14.1`, `xunit 2.9.3`, `xunit.runner.visualstudio 2.8.2`), `net10.0`, referencing the engine.
  - `GameEngineSmokeTests`: instantiates `GameEngine` and asserts Player is non-null, Characters is an empty non-null list, Config is non-null with WASD defaults, and Map is null.
- **`.github/workflows/ci.yml`** — triggers on push and pull_request to `main`; runs `dotnet restore` → `dotnet build -c Release` → `dotnet test -c Release --no-build` on `ubuntu-latest` with the .NET 10 SDK.

### Validation (run locally with .NET SDK 10.0.400)
- `dotnet restore` ✅
- `dotnet build RPGEngine.sln -c Release` → **0 warnings / 0 errors** ✅
- `dotnet test RPGEngine.sln -c Release --no-build` → **1 passed, 0 failed** ✅
- `dotnet test --filter "FullyQualifiedName~GameEngineSmokeTests"` → **passed** ✅

Engine features (movement, rendering, assets, maps) are intentionally out of scope for this story.