### PR TITLE
Story 10: RPG Maker MZ spritesheets (full & part sheets)

### DIFF
--- a/src/RPGEngine/Sprites/CharacterPartType.cs
+++ b/src/RPGEngine/Sprites/CharacterPartType.cs
@@ -1,0 +1,28 @@
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// The layer of a character that an RPG Maker MZ part spritesheet provides.
+/// </summary>
+public enum CharacterPartType
+{
+    /// <summary>The character's body.</summary>
+    Body,
+
+    /// <summary>The character's armour layer.</summary>
+    Armour,
+
+    /// <summary>The character's face.</summary>
+    Face,
+
+    /// <summary>The hair attached to the face layer.</summary>
+    FaceHair,
+
+    /// <summary>The first (base) hair layer.</summary>
+    Hair1,
+
+    /// <summary>The second (overlay) hair layer.</summary>
+    Hair2,
+
+    /// <summary>The character's head.</summary>
+    Head,
+}

--- a/src/RPGEngine/Sprites/Direction.cs
+++ b/src/RPGEngine/Sprites/Direction.cs
@@ -1,0 +1,24 @@
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// The four facing directions used by RPG Maker MZ character spritesheets.
+/// </summary>
+/// <remarks>
+/// The numeric values match the row order within a character block on the sheet:
+/// <c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>
+/// (see <see cref="SpriteSheet.GetSprite"/>).
+/// </remarks>
+public enum Direction
+{
+    /// <summary>Facing down (row 0 of a character block).</summary>
+    Down = 0,
+
+    /// <summary>Facing left (row 1 of a character block).</summary>
+    Left = 1,
+
+    /// <summary>Facing right (row 2 of a character block).</summary>
+    Right = 2,
+
+    /// <summary>Facing up (row 3 of a character block).</summary>
+    Up = 3,
+}

--- a/src/RPGEngine/Sprites/SpriteSheet.cs
+++ b/src/RPGEngine/Sprites/SpriteSheet.cs
@@ -1,0 +1,153 @@
+using SkiaSharp;
+
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// A single RPG Maker MZ spritesheet: a 576×384 image made of 48×48 cells arranged in a
+/// 12-column × 8-row grid. It contains 8 characters laid out as a 4×2 grid; each character
+/// occupies a 3×4 block of cells (3 animation frames × 4 directions).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both full sheets and part sheets use this same layout. The sheet is a plain data + slice
+/// object; the composition of part sheets into a complete character belongs to the
+/// <c>Character</c> renderer, not here.
+/// </para>
+/// <para>
+/// Instances are created through <see cref="SpriteSheetManager"/> (the constructor is internal)
+/// and own the single decoded <see cref="SKImage"/> that backs every sprite returned by
+/// <see cref="GetSprite"/>. The decoded image is never mutated.
+/// </para>
+/// </remarks>
+public sealed class SpriteSheet
+{
+    private const int CellsPerRow = 12;
+    private const int CellRows = 8;
+    private const int CharactersPerRow = 4;
+    private const int CharacterRowCount = 2;
+    private const int FramesPerCharacter = 3;
+    private const int DirectionsPerCharacter = 4;
+
+    /// <summary>The width and height of a single character cell in pixels (normative RPG Maker MZ value).</summary>
+    public const int CellSize = 48;
+
+    /// <summary>The width of a full or part spritesheet in pixels (normative RPG Maker MZ value: 12 cells).</summary>
+    public const int SheetWidth = CellsPerRow * CellSize; // 576
+
+    /// <summary>The height of a full or part spritesheet in pixels (normative RPG Maker MZ value: 8 cells).</summary>
+    public const int SheetHeight = CellRows * CellSize; // 384
+
+    private readonly SKImage _source;
+
+    /// <summary>Gets the unique name used to reference the sheet.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the kind of sheet (full or part).</summary>
+    public SpriteSheetType Type { get; }
+
+    /// <summary>
+    /// Gets the character layer this part sheet provides, or <see langword="null"/> when
+    /// <see cref="Type"/> is <see cref="SpriteSheetType.Full"/>.
+    /// </summary>
+    public CharacterPartType? PartType { get; }
+
+    /// <summary>Gets the width of a single cell in pixels (always 48).</summary>
+    public int CellWidth => CellSize;
+
+    /// <summary>Gets the height of a single cell in pixels (always 48).</summary>
+    public int CellHeight => CellSize;
+
+    /// <summary>Gets the number of characters contained in the sheet (always 8).</summary>
+    public int CharacterCount => CharactersPerRow * CharacterRowCount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpriteSheet"/> class. Sheets are created
+    /// through <see cref="SpriteSheetManager"/>.
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet.</param>
+    /// <param name="type">The kind of sheet (full or part).</param>
+    /// <param name="partType">The character layer for part sheets, or <see langword="null"/> for full sheets.</param>
+    /// <param name="source">The decoded sheet image, already validated as 576×384.</param>
+    internal SpriteSheet(string name, SpriteSheetType type, CharacterPartType? partType, SKImage source)
+    {
+        Name = name;
+        Type = type;
+        PartType = partType;
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    /// <summary>
+    /// Returns the 48×48 sprite at (<paramref name="direction"/>, <paramref name="frame"/>) for
+    /// the character <paramref name="characterIndex"/> (1-based) within the sheet.
+    /// </summary>
+    /// <param name="characterIndex">The 1-based index (1..8) of the character in the sheet.</param>
+    /// <param name="direction">The direction (down/left/right/up) the sprite faces.</param>
+    /// <param name="frame">The animation frame (0..2).</param>
+    /// <returns>
+    /// An <see cref="SKImage"/> cropped from the decoded source. The caller owns and disposes it.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="characterIndex"/> is outside 1..8 or <paramref name="frame"/> is outside 0..2.
+    /// </exception>
+    /// <remarks>
+    /// Character <c>i</c> is located at <c>charCol = (i - 1) % 4</c>, <c>charRow = (i - 1) / 4</c>;
+    /// its cell <c>(frame, direction)</c> is at column <c>charCol * 3 + frame</c> and row
+    /// <c>charRow * 4 + (int)direction</c>.
+    /// <para>
+    /// The returned image is an independent 48×48 raster crop of the decoded source, produced
+    /// with nearest-neighbour sampling (a 1:1 pixel copy, never a re-encode). We deliberately
+    /// avoid <c>SKImage.Subset</c> here: on SkiaSharp 3.119.4, subsets of an image decoded from
+    /// encoded data crash the native runtime once an earlier subset has been disposed (the same
+    /// reasoning as <c>TileSet.GetTileImage</c>).
+    /// </para>
+    /// </remarks>
+    public SKImage GetSprite(int characterIndex, Direction direction, int frame)
+    {
+        if (characterIndex < 1 || characterIndex > CharacterCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(characterIndex),
+                characterIndex,
+                $"Character index must be between 1 and {CharacterCount} for spritesheet '{Name}'.");
+        }
+
+        if (frame < 0 || frame >= FramesPerCharacter)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(frame),
+                frame,
+                $"Animation frame must be between 0 and {FramesPerCharacter - 1} for spritesheet '{Name}'.");
+        }
+
+        var charCol = (characterIndex - 1) % CharactersPerRow;
+        var charRow = (characterIndex - 1) / CharactersPerRow;
+        var col = (charCol * FramesPerCharacter) + frame;
+        var row = (charRow * DirectionsPerCharacter) + (int)direction;
+
+        var source = new SKRectI(
+            col * CellSize,
+            row * CellSize,
+            (col + 1) * CellSize,
+            (row + 1) * CellSize);
+
+        // Raster crop of the decoded source with nearest-neighbour sampling (1:1 pixel copy, no
+        // re-encode). SKImage.FromBitmap copies the pixels, so the returned image is independent
+        // of _source and of the temporary bitmap disposed below.
+        var spriteBitmap = new SKBitmap(CellSize, CellSize);
+        try
+        {
+            using var canvas = new SKCanvas(spriteBitmap);
+            canvas.Clear(SKColors.Transparent);
+
+            var destination = new SKRect(0, 0, CellSize, CellSize);
+            var sampling = new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
+            canvas.DrawImage(_source, source, destination, sampling);
+
+            return SKImage.FromBitmap(spriteBitmap);
+        }
+        finally
+        {
+            spriteBitmap.Dispose();
+        }
+    }
+}

--- a/src/RPGEngine/Sprites/SpriteSheetManager.cs
+++ b/src/RPGEngine/Sprites/SpriteSheetManager.cs
@@ -1,0 +1,214 @@
+using SkiaSharp;
+
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// Loads, validates and registers RPG Maker MZ spritesheets by unique name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every loaded sheet is decoded exactly once with <see cref="SKImage.FromEncodedData(Stream)"/>
+/// and kept alive for the lifetime of the sheet; <see cref="SpriteSheet.GetSprite"/> then crops
+/// from that decoded image without re-decoding or re-encoding.
+/// </para>
+/// <para>
+/// The sheet kind is never guessed from the file name. <see cref="Load(string, string)"/> and
+/// <see cref="Load(string, Stream)"/> load <em>full</em> sheets; <see cref="LoadPart(string, string, CharacterPartType)"/>
+/// and <see cref="LoadPart(string, Stream, CharacterPartType)"/> load <em>part</em> sheets of the
+/// given layer. The kind and part type are stored on the returned <see cref="SpriteSheet"/>.
+/// </para>
+/// <para>
+/// Names are case-sensitive and trimmed on registration, lookup and duplicate checks. Loading a
+/// name that is already registered throws <see cref="InvalidOperationException"/>.
+/// </para>
+/// </remarks>
+public sealed class SpriteSheetManager
+{
+    private readonly Dictionary<string, SpriteSheet> _sheets = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Loads the <em>full</em> character spritesheet at <paramref name="path"/> and registers it
+    /// under <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet (trimmed).</param>
+    /// <param name="path">The path to an image file (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>The loaded <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    public SpriteSheet Load(string name, string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var trimmedName = ValidateName(name);
+        EnsureNameAvailable(trimmedName);
+
+        using var stream = File.OpenRead(path);
+        return Register(trimmedName, SpriteSheetType.Full, null, Decode(stream, trimmedName, path));
+    }
+
+    /// <summary>
+    /// Loads the <em>full</em> character spritesheet from <paramref name="stream"/> and registers
+    /// it under <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet (trimmed).</param>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>The loaded <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    /// <remarks>
+    /// The caller remains the owner of <paramref name="stream"/>; it is not disposed here. This
+    /// overload is the file-system-free entry point (e.g. WebAssembly builds where assets are
+    /// fetched over HTTP).
+    /// </remarks>
+    public SpriteSheet Load(string name, Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var trimmedName = ValidateName(name);
+        EnsureNameAvailable(trimmedName);
+
+        return Register(trimmedName, SpriteSheetType.Full, null, Decode(stream, trimmedName, "<stream>"));
+    }
+
+    /// <summary>
+    /// Loads the <em>part</em> spritesheet of layer <paramref name="partType"/> at
+    /// <paramref name="path"/> and registers it under <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet (trimmed).</param>
+    /// <param name="path">The path to an image file (PNG or other SkiaSharp-supported format).</param>
+    /// <param name="partType">The character layer the sheet provides.</param>
+    /// <returns>The loaded <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    public SpriteSheet LoadPart(string name, string path, CharacterPartType partType)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var trimmedName = ValidateName(name);
+        EnsureNameAvailable(trimmedName);
+
+        using var stream = File.OpenRead(path);
+        return Register(trimmedName, SpriteSheetType.Part, partType, Decode(stream, trimmedName, path));
+    }
+
+    /// <summary>
+    /// Loads the <em>part</em> spritesheet of layer <paramref name="partType"/> from
+    /// <paramref name="stream"/> and registers it under <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet (trimmed).</param>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <param name="partType">The character layer the sheet provides.</param>
+    /// <returns>The loaded <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    /// <remarks>
+    /// The caller remains the owner of <paramref name="stream"/>; it is not disposed here.
+    /// </remarks>
+    public SpriteSheet LoadPart(string name, Stream stream, CharacterPartType partType)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var trimmedName = ValidateName(name);
+        EnsureNameAvailable(trimmedName);
+
+        return Register(trimmedName, SpriteSheetType.Part, partType, Decode(stream, trimmedName, "<stream>"));
+    }
+
+    /// <summary>
+    /// Returns the sheet registered under <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The unique name of the sheet (trimmed).</param>
+    /// <returns>The registered <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is empty after trimming.</exception>
+    /// <exception cref="KeyNotFoundException">No sheet named <paramref name="name"/> is loaded.</exception>
+    public SpriteSheet Get(string name)
+    {
+        var trimmedName = ValidateName(name);
+
+        if (!_sheets.TryGetValue(trimmedName, out var sheet))
+        {
+            throw new KeyNotFoundException($"No spritesheet named '{trimmedName}' is loaded.");
+        }
+
+        return sheet;
+    }
+
+    /// <summary>
+    /// Returns whether a sheet is registered under <paramref name="name"/> (case-sensitive, trimmed).
+    /// </summary>
+    /// <param name="name">The unique name of the sheet.</param>
+    /// <returns><see langword="true"/> if a sheet with that name is loaded; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    public bool Contains(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        return _sheets.ContainsKey(name.Trim());
+    }
+
+    private void EnsureNameAvailable(string name)
+    {
+        if (_sheets.ContainsKey(name))
+        {
+            throw new InvalidOperationException($"A spritesheet named '{name}' is already loaded.");
+        }
+    }
+
+    private SpriteSheet Register(string name, SpriteSheetType type, CharacterPartType? partType, SKImage source)
+    {
+        var sheet = new SpriteSheet(name, type, partType, source);
+        _sheets.Add(name, sheet);
+        return sheet;
+    }
+
+    private static string ValidateName(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var trimmed = name.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw new ArgumentException("Spritesheet name must not be empty after trimming.", nameof(name));
+        }
+
+        return trimmed;
+    }
+
+    private static SKImage Decode(Stream stream, string name, string sourceDescription)
+    {
+        var image = SKImage.FromEncodedData(stream)
+            ?? throw new ArgumentException($"The image '{sourceDescription}' could not be decoded as a spritesheet.");
+
+        // Capture the dimensions before any disposal: the decoded image must stay alive while
+        // its native properties are read (accessing it inside the exception message after
+        // Dispose() would be a native use-after-free).
+        var width = image.Width;
+        var height = image.Height;
+        if (width != SpriteSheet.SheetWidth || height != SpriteSheet.SheetHeight)
+        {
+            image.Dispose();
+            throw new ArgumentException(
+                $"Spritesheet '{name}' must be {SpriteSheet.SheetWidth}×{SpriteSheet.SheetHeight} pixels " +
+                $"(RPG Maker MZ full or part sheet), but was {width}×{height}.");
+        }
+
+        return image;
+    }
+}

--- a/src/RPGEngine/Sprites/SpriteSheetRef.cs
+++ b/src/RPGEngine/Sprites/SpriteSheetRef.cs
@@ -1,0 +1,16 @@
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// References a specific character within a named spritesheet.
+/// </summary>
+/// <param name="Name">The unique name of the spritesheet.</param>
+/// <param name="CharacterIndex">
+/// The 1-based index (1..8) of the character within the sheet, in row-major order over the
+/// sheet's 4×2 character grid.
+/// </param>
+/// <remarks>
+/// This is a dumb value type: the 1..8 range is intentionally not validated here. It is
+/// enforced where the reference is consumed (e.g. by <see cref="SpriteSheet.GetSprite"/> or by
+/// the character compositor introduced by a later story).
+/// </remarks>
+public readonly record struct SpriteSheetRef(string Name, int CharacterIndex);

--- a/src/RPGEngine/Sprites/SpriteSheetType.cs
+++ b/src/RPGEngine/Sprites/SpriteSheetType.cs
@@ -1,0 +1,19 @@
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// The kind of an RPG Maker MZ spritesheet.
+/// </summary>
+public enum SpriteSheetType
+{
+    /// <summary>
+    /// A complete character sheet: every layer (body, armour, face, hair, head) is baked into
+    /// one image.
+    /// </summary>
+    Full,
+
+    /// <summary>
+    /// A single character layer (see <see cref="CharacterPartType"/>) that is composed with
+    /// other part sheets to build a complete character.
+    /// </summary>
+    Part,
+}

--- a/tests/RPGEngine.Tests/Sprites/SpriteSheetTestHelper.cs
+++ b/tests/RPGEngine.Tests/Sprites/SpriteSheetTestHelper.cs
@@ -1,0 +1,54 @@
+using SkiaSharp;
+
+namespace RPGEngine.Tests.Sprites;
+
+/// <summary>
+/// Generates RPG Maker MZ spritesheet fixtures: 576×384 images whose 48×48 cells are uniquely
+/// colored by (row, column), so tests can assert exact crops without shipping binary assets.
+/// </summary>
+internal static class SpriteSheetTestHelper
+{
+    public const int SheetWidth = 576;
+    public const int SheetHeight = 384;
+    public const int CellSize = 48;
+    public const int Columns = 12;
+    public const int Rows = 8;
+
+    /// <summary>Returns the unique opaque color used for the cell at (row, col).</summary>
+    public static SKColor CellColor(int row, int col)
+        => new((byte)col, (byte)row, (byte)((row * Columns) + col), alpha: 255);
+
+    /// <summary>
+    /// Encodes a PNG of the requested dimensions. A 576×384 sheet gets the unique per-cell
+    /// colors; any other size is left transparent (only its dimensions matter for validation).
+    /// </summary>
+    public static byte[] CreateSheetPng(int width = SheetWidth, int height = SheetHeight)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+
+            if (width == SheetWidth && height == SheetHeight)
+            {
+                for (var row = 0; row < Rows; row++)
+                {
+                    for (var col = 0; col < Columns; col++)
+                    {
+                        using var paint = new SKPaint { Color = CellColor(row, col), IsAntialias = false };
+                        canvas.DrawRect(
+                            new SKRect(col * CellSize, row * CellSize, (col + 1) * CellSize, (row + 1) * CellSize),
+                            paint);
+                    }
+                }
+            }
+        }
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    /// <summary>Returns a read-only stream containing a standard 576×384 sheet encoded as PNG.</summary>
+    public static MemoryStream CreateSheetStream() => new(CreateSheetPng(), writable: false);
+}

--- a/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
+++ b/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
@@ -1,0 +1,262 @@
+using RPGEngine.Sprites;
+using SkiaSharp;
+using Xunit;
+
+namespace RPGEngine.Tests.Sprites;
+
+/// <summary>
+/// Acceptance tests for <see cref="SpriteSheet"/> and <see cref="SpriteSheetManager"/>
+/// (story 10: RPG Maker MZ spritesheets — full sheets &amp; part sheets).
+/// </summary>
+public class SpriteSheetTests
+{
+    // ---------------------------------------------------------------------
+    // Acceptance 1: a test sheet whose cells are uniquely colored by (row, col)
+    // slices correctly; GetSprite(1, Down, 0) is the exact expected crop and
+    // GetSprite(8, Up, 2) spot-checks the last character.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a full sheet slices to the exact expected crop for the first and last characters.</summary>
+    [Fact]
+    public void GetSprite_ReturnsExactCrop_ForFirstAndLastCharacter()
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.Load("hero", stream);
+
+        // Normative full-sheet metadata.
+        Assert.Equal(SpriteSheetType.Full, sheet.Type);
+        Assert.Null(sheet.PartType);
+        Assert.Equal(48, sheet.CellWidth);
+        Assert.Equal(48, sheet.CellHeight);
+        Assert.Equal(8, sheet.CharacterCount);
+
+        // Character 1, down, frame 0 → cell (row 0, col 0).
+        using (var sprite = sheet.GetSprite(1, Direction.Down, 0))
+        {
+            AssertCell(sprite, row: 0, col: 0);
+        }
+
+        // Character 8, up, frame 2 → charCol = 3, charRow = 1 → cell (row 7, col 11).
+        using (var sprite = sheet.GetSprite(8, Direction.Up, 2))
+        {
+            AssertCell(sprite, row: 7, col: 11);
+        }
+    }
+
+    /// <summary>Verifies the four direction rows map to rows 0..3 within a character block.</summary>
+    [Theory]
+    [InlineData(Direction.Down, 0)]
+    [InlineData(Direction.Left, 1)]
+    [InlineData(Direction.Right, 2)]
+    [InlineData(Direction.Up, 3)]
+    public void GetSprite_MapsDirectionsToRows(Direction direction, int expectedRow)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.Load("hero", stream);
+
+        using var sprite = sheet.GetSprite(1, direction, frame: 0);
+        AssertCell(sprite, expectedRow, col: 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 2 & 7: a part sheet is also 576×384 with CharacterCount == 8,
+    // reports Type == Part and round-trips PartType; GetSprite(3, ...) works
+    // (the index selects the character within the part sheet).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a part sheet reports part metadata and slices by character index.</summary>
+    [Fact]
+    public void LoadPart_ReportsPartMetadata_AndSlicesByCharacterIndex()
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.LoadPart("armour", stream, CharacterPartType.Armour);
+
+        Assert.Equal(SpriteSheetType.Part, sheet.Type);
+        Assert.Equal(CharacterPartType.Armour, sheet.PartType);
+        Assert.Equal(8, sheet.CharacterCount);
+
+        // Character 3, down, frame 0 → charCol = 2, charRow = 0 → cell (row 0, col 6).
+        using var sprite = sheet.GetSprite(3, Direction.Down, frame: 0);
+        AssertCell(sprite, row: 0, col: 6);
+    }
+
+    /// <summary>Verifies every character part type round-trips through LoadPart and PartType.</summary>
+    [Theory]
+    [InlineData(CharacterPartType.Body)]
+    [InlineData(CharacterPartType.Armour)]
+    [InlineData(CharacterPartType.Face)]
+    [InlineData(CharacterPartType.FaceHair)]
+    [InlineData(CharacterPartType.Hair1)]
+    [InlineData(CharacterPartType.Hair2)]
+    [InlineData(CharacterPartType.Head)]
+    public void LoadPart_RoundTripsPartType(CharacterPartType partType)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.LoadPart("part", stream, partType);
+
+        Assert.Equal(SpriteSheetType.Part, sheet.Type);
+        Assert.Equal(partType, sheet.PartType);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 3: invalid dimensions throw ArgumentException. The 144×192
+    // single-character '$' sheet variant is deliberately not supported.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies loading an image whose dimensions are not 576×384 throws ArgumentException.</summary>
+    [Theory]
+    [InlineData(144, 192)] // the single-character '$' sheet variant (out of scope)
+    [InlineData(100, 100)]
+    public void Load_ThrowsArgumentException_ForInvalidDimensions(int width, int height)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new MemoryStream(
+            SpriteSheetTestHelper.CreateSheetPng(width, height),
+            writable: false);
+
+        Assert.Throws<ArgumentException>(() => manager.Load("bad", stream));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 4: GetSprite rejects characterIndex outside 1..8 and frames
+    // outside 0..2 with ArgumentOutOfRangeException.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies GetSprite throws for character indices outside the 1..8 range.</summary>
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(9)]
+    public void GetSprite_ThrowsArgumentOutOfRange_ForInvalidCharacterIndex(int characterIndex)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.Load("hero", stream);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => sheet.GetSprite(characterIndex, Direction.Down, frame: 0));
+    }
+
+    /// <summary>Verifies GetSprite throws for animation frames outside the 0..2 range.</summary>
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(3)]
+    public void GetSprite_ThrowsArgumentOutOfRange_ForInvalidFrame(int frame)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.Load("hero", stream);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => sheet.GetSprite(1, Direction.Down, frame));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5: registering a duplicate name throws InvalidOperationException.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies loading a second sheet under an already-registered name throws InvalidOperationException.</summary>
+    [Fact]
+    public void Load_DuplicateName_ThrowsInvalidOperationException()
+    {
+        var manager = new SpriteSheetManager();
+        using (var stream = SpriteSheetTestHelper.CreateSheetStream())
+        {
+            manager.Load("hero", stream);
+        }
+
+        using var duplicate = SpriteSheetTestHelper.CreateSheetStream();
+        Assert.Throws<InvalidOperationException>(() => manager.Load("hero", duplicate));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 6: Get on an unknown name throws KeyNotFoundException.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Get throws KeyNotFoundException for a name that was never loaded.</summary>
+    [Fact]
+    public void Get_UnknownName_ThrowsKeyNotFoundException()
+    {
+        var manager = new SpriteSheetManager();
+
+        Assert.Throws<KeyNotFoundException>(() => manager.Get("missing"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Additional manager behaviour: the path overload, Contains, and that
+    // names are trimmed but case-sensitive.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the path overload loads a sheet and Contains reports it.</summary>
+    [Fact]
+    public void Load_FromPath_AndContains_Work()
+    {
+        var manager = new SpriteSheetManager();
+        var path = WriteTempPng(SpriteSheetTestHelper.CreateSheetPng());
+
+        try
+        {
+            var sheet = manager.Load("hero", path);
+
+            Assert.Equal("hero", sheet.Name);
+            Assert.True(manager.Contains("hero"));
+            Assert.False(manager.Contains("nope"));
+            Assert.Same(sheet, manager.Get("hero"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>Verifies names are trimmed on registration but still case-sensitive.</summary>
+    [Fact]
+    public void Load_TrimsNames_ButIsCaseSensitive()
+    {
+        var manager = new SpriteSheetManager();
+        using (var stream = SpriteSheetTestHelper.CreateSheetStream())
+        {
+            var sheet = manager.Load("  Hero  ", stream);
+            Assert.Equal("Hero", sheet.Name);
+        }
+
+        Assert.True(manager.Contains("Hero"));
+        Assert.False(manager.Contains("hero")); // case-sensitive lookup
+
+        // "Hero" is now registered, so a trimmed variant of the same name collides.
+        using var duplicate = SpriteSheetTestHelper.CreateSheetStream();
+        Assert.Throws<InvalidOperationException>(() => manager.Load(" Hero ", duplicate));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// <summary>Asserts the sprite is a 48×48 crop whose every pixel has the expected cell color.</summary>
+    private static void AssertCell(SKImage sprite, int row, int col)
+    {
+        Assert.Equal(48, sprite.Width);
+        Assert.Equal(48, sprite.Height);
+
+        var expected = SpriteSheetTestHelper.CellColor(row, col);
+        using var bitmap = new SKBitmap(48, 48);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawImage(sprite, new SKPoint(0, 0));
+        }
+
+        for (var y = 0; y < 48; y++)
+        {
+            for (var x = 0; x < 48; x++)
+            {
+                Assert.Equal(expected, bitmap.GetPixel(x, y));
+            }
+        }
+    }
+
+    /// <summary>Writes a PNG to a temporary file and returns its path.</summary>
+    private static string WriteTempPng(byte[] png)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "rpg-engine-sprite-" + Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllBytes(path, png);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Implements [Story 10](https://github.com/elliottv/rpg-engine/issues/10): loading, validating and slicing RPG Maker MZ spritesheets (full and part) in the new `RPGEngine.Sprites` namespace.

### New API (`RPGEngine.Sprites`)
- **`Direction`** enum — `Down = 0, Left = 1, Right = 2, Up = 3` (matches the row order of a character block).
- **`SpriteSheetType`** enum — `Full`, `Part`.
- **`CharacterPartType`** enum — `Body`, `Armour`, `Face`, `FaceHair`, `Hair1`, `Hair2`, `Head`.
- **`SpriteSheetRef`** — `readonly record struct (string Name, int CharacterIndex)`; a dumb value type (range validated where consumed).
- **`SpriteSheet`** — `Name`, `Type`, `PartType`, `CellWidth`/`CellHeight` (48), `CharacterCount` (8), and `GetSprite(characterIndex, direction, frame)`. Crops the 48×48 cell using the normative mapping (`charCol = (i-1) % 4`, `charRow = (i-1) / 4`; cell col `charCol*3 + frame`, row `charRow*4 + (int)direction`). Constructor is internal.
- **`SpriteSheetManager`** — `Load(name, path)` / `Load(name, stream)` load **full** sheets; `LoadPart(name, path|stream, CharacterPartType)` load **part** sheets (the kind is never guessed from the file name). Plus `Get` (throws `KeyNotFoundException`) and `Contains`. Names are case-sensitive and trimmed; duplicate registration throws `InvalidOperationException`. The image is decoded once with `SKImage.FromEncodedData` and dimension-validated to exactly 576×384 (`ArgumentException` otherwise; the 144×192 `$` variant is rejected).

### Tests
`tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs` (+ a `SpriteSheetTestHelper` that generates a 576×384 PNG with uniquely colored cells) covers all 7 acceptance criteria:
1. Exact crop for `GetSprite(1, Down, 0)` and `GetSprite(8, Up, 2)` (every pixel verified).
2. Part sheet is 576×384, `CharacterCount == 8`, `GetSprite(3, …)` slices by character index.
3. Invalid dimensions (144×192, 100×100) throw `ArgumentException`.
4. `characterIndex` 0/9/-1 and `frame` 3/-1 throw `ArgumentOutOfRangeException`.
5. Duplicate name throws `InvalidOperationException`.
6. `Get` on unknown name throws `KeyNotFoundException`.
7. `Type == Part` and `PartType` round-trips for every part type.

Plus direction-row mapping, the path overload, `Contains`, and name trimming/case-sensitivity.

### Verification
```bash
dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~SpriteSheetTests"
# 24 passed; full suite: 41 passed, 0 failed, no native crashes (verified across repeated runs)
```

### Notes / deviations
- `GetSprite` returns an independent raster crop (nearest-neighbour 1:1 pixel copy, no re-encode) rather than `SKImage.Subset`: the codebase already documents that `SKImage.Subset` on images decoded from encoded data crashes the native runtime on SkiaSharp 3.119.4 (see `TileSet.GetTileImage`), and I confirmed the crash in this environment. `SKImage.FromEncodedData` + `SKImage` storage is still used, so the decoded source stays GPU/raster friendly and is decoded exactly once.