### PR TITLE
Story 8: GameConfig — movement key mapping (WASD default)

### DIFF
--- a/src/RPGEngine/GameConfig.cs
+++ b/src/RPGEngine/GameConfig.cs
@@ -1,21 +1,140 @@
 namespace RPGEngine;
 
 /// <summary>
-/// Contains the configuration values used by the engine.
-/// For now it only holds the keys used for movement, which default to WASD.
-/// When the values are updated at runtime, they are taken into account by the engine.
+/// The configuration object of the engine. For this epic it only holds the
+/// keyboard keys used for movement, which default to WASD
+/// (<see cref="Key.W"/>, <see cref="Key.S"/>, <see cref="Key.A"/>, <see cref="Key.D"/>).
 /// </summary>
+/// <remarks>
+/// <para>
+/// The engine reads <see cref="GameConfig"/> at input time and never caches a
+/// snapshot of it, so changes to the values are taken into account immediately.
+/// No change-notification event mechanism is required for this epic because
+/// <c>Input()</c> is invoked once per key event and consults the configuration
+/// directly.
+/// </para>
+/// <para>
+/// The movement keys must be unique: no two directions may be bound to the same
+/// <see cref="Key"/>. Assigning a key that is already bound to another movement
+/// direction throws <see cref="ArgumentException"/> and leaves the configuration
+/// unchanged, which prevents ambiguous input (e.g. moving up and down with the
+/// same key). A later epic may relax this rule, for example for multi-touch
+/// input, but not now.
+/// </para>
+/// </remarks>
 public sealed class GameConfig
 {
-    /// <summary>Gets or sets the key used to move up. Defaults to <see cref="Key.W"/>.</summary>
-    public Key MoveUp { get; set; } = Key.W;
+    private Key _upKey = Key.W;
+    private Key _downKey = Key.S;
+    private Key _leftKey = Key.A;
+    private Key _rightKey = Key.D;
 
-    /// <summary>Gets or sets the key used to move down. Defaults to <see cref="Key.S"/>.</summary>
-    public Key MoveDown { get; set; } = Key.S;
+    /// <summary>
+    /// Gets or sets the key used to move up. Defaults to <see cref="Key.W"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The value is already bound to another movement direction.
+    /// </exception>
+    public Key UpKey
+    {
+        get => _upKey;
+        set
+        {
+            ThrowIfKeyAlreadyBoundToAnotherDirection(value, Direction.Up, nameof(value));
+            _upKey = value;
+        }
+    }
 
-    /// <summary>Gets or sets the key used to move left. Defaults to <see cref="Key.A"/>.</summary>
-    public Key MoveLeft { get; set; } = Key.A;
+    /// <summary>
+    /// Gets or sets the key used to move down. Defaults to <see cref="Key.S"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The value is already bound to another movement direction.
+    /// </exception>
+    public Key DownKey
+    {
+        get => _downKey;
+        set
+        {
+            ThrowIfKeyAlreadyBoundToAnotherDirection(value, Direction.Down, nameof(value));
+            _downKey = value;
+        }
+    }
 
-    /// <summary>Gets or sets the key used to move right. Defaults to <see cref="Key.D"/>.</summary>
-    public Key MoveRight { get; set; } = Key.D;
+    /// <summary>
+    /// Gets or sets the key used to move left. Defaults to <see cref="Key.A"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The value is already bound to another movement direction.
+    /// </exception>
+    public Key LeftKey
+    {
+        get => _leftKey;
+        set
+        {
+            ThrowIfKeyAlreadyBoundToAnotherDirection(value, Direction.Left, nameof(value));
+            _leftKey = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the key used to move right. Defaults to <see cref="Key.D"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The value is already bound to another movement direction.
+    /// </exception>
+    public Key RightKey
+    {
+        get => _rightKey;
+        set
+        {
+            ThrowIfKeyAlreadyBoundToAnotherDirection(value, Direction.Right, nameof(value));
+            _rightKey = value;
+        }
+    }
+
+    /// <summary>
+    /// Returns the movement direction currently bound to <paramref name="key"/>,
+    /// or <see langword="null"/> when the key is not bound to any direction.
+    /// </summary>
+    /// <param name="key">The key to look up.</param>
+    /// <returns>
+    /// The <see cref="Direction"/> the key is currently bound to, or
+    /// <see langword="null"/> when it is not bound. The result always reflects
+    /// the current values of the movement key properties: the engine reads the
+    /// configuration at input time and never uses a cached snapshot.
+    /// </returns>
+    public Direction? GetDirection(Key key) =>
+        key == _upKey ? Direction.Up :
+        key == _downKey ? Direction.Down :
+        key == _leftKey ? Direction.Left :
+        key == _rightKey ? Direction.Right :
+        null;
+
+    /// <summary>
+    /// Throws <see cref="ArgumentException"/> when <paramref name="key"/> is
+    /// already bound to a movement direction other than
+    /// <paramref name="direction"/>.
+    /// </summary>
+    /// <param name="key">The key being assigned.</param>
+    /// <param name="direction">The direction the key is being assigned to.</param>
+    /// <param name="paramName">The name of the property-setter value parameter.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="key"/> is already bound to another movement direction.
+    /// </exception>
+    private void ThrowIfKeyAlreadyBoundToAnotherDirection(Key key, Direction direction, string paramName)
+    {
+        var alreadyBound = (key == _upKey && direction != Direction.Up)
+            || (key == _downKey && direction != Direction.Down)
+            || (key == _leftKey && direction != Direction.Left)
+            || (key == _rightKey && direction != Direction.Right);
+
+        if (alreadyBound)
+        {
+            throw new ArgumentException(
+                $"The key '{key}' is already bound to another movement direction; " +
+                "each movement direction must use a distinct key.",
+                paramName);
+        }
+    }
 }

--- a/src/RPGEngine/Key.cs
+++ b/src/RPGEngine/Key.cs
@@ -1,21 +1,115 @@
 namespace RPGEngine;
 
 /// <summary>
-/// Represents a keyboard key that can be bound to an engine action.
-/// The full set of supported keys is completed by later stories; this story
-/// only needs the movement keys (WASD) used by the default <see cref="GameConfig"/>.
+/// A framework-agnostic keyboard key that can be bound to an engine action
+/// (for this epic, to a movement direction via <see cref="GameConfig"/>).
 /// </summary>
+/// <remarks>
+/// <para>
+/// The engine deliberately does not depend on any GUI framework's input types
+/// (WPF <c>KeyEventArgs</c>, Avalonia <c>KeyEventArgs</c>, Blazor
+/// <c>KeyboardEventArgs</c>) so it can run on any SkiaSharp host, including
+/// WebAssembly. Host applications are responsible for translating their
+/// framework's key event to a <see cref="Key"/> value before passing it to the
+/// engine.
+/// </para>
+/// <para>
+/// The translation adapters themselves are out of scope for this epic and may
+/// be added later as optional extension packages.
+/// </para>
+/// </remarks>
 public enum Key
 {
-    /// <summary>The W key (bound to moving up by default).</summary>
-    W,
-
-    /// <summary>The A key (bound to moving left by default).</summary>
+    /// <summary>The A key.</summary>
     A,
 
-    /// <summary>The S key (bound to moving down by default).</summary>
+    /// <summary>The B key.</summary>
+    B,
+
+    /// <summary>The C key.</summary>
+    C,
+
+    /// <summary>The D key.</summary>
+    D,
+
+    /// <summary>The E key.</summary>
+    E,
+
+    /// <summary>The F key.</summary>
+    F,
+
+    /// <summary>The G key.</summary>
+    G,
+
+    /// <summary>The H key.</summary>
+    H,
+
+    /// <summary>The I key.</summary>
+    I,
+
+    /// <summary>The J key.</summary>
+    J,
+
+    /// <summary>The K key.</summary>
+    K,
+
+    /// <summary>The L key.</summary>
+    L,
+
+    /// <summary>The M key.</summary>
+    M,
+
+    /// <summary>The N key.</summary>
+    N,
+
+    /// <summary>The O key.</summary>
+    O,
+
+    /// <summary>The P key.</summary>
+    P,
+
+    /// <summary>The Q key.</summary>
+    Q,
+
+    /// <summary>The R key.</summary>
+    R,
+
+    /// <summary>The S key.</summary>
     S,
 
-    /// <summary>The D key (bound to moving right by default).</summary>
-    D,
+    /// <summary>The T key.</summary>
+    T,
+
+    /// <summary>The U key.</summary>
+    U,
+
+    /// <summary>The V key.</summary>
+    V,
+
+    /// <summary>The W key.</summary>
+    W,
+
+    /// <summary>The X key.</summary>
+    X,
+
+    /// <summary>The Y key.</summary>
+    Y,
+
+    /// <summary>The Z key.</summary>
+    Z,
+
+    /// <summary>The up arrow key.</summary>
+    Up,
+
+    /// <summary>The down arrow key.</summary>
+    Down,
+
+    /// <summary>The left arrow key.</summary>
+    Left,
+
+    /// <summary>The right arrow key.</summary>
+    Right,
+
+    /// <summary>The space bar.</summary>
+    Space,
 }

--- a/tests/RPGEngine.Tests/Core/GameConfigTests.cs
+++ b/tests/RPGEngine.Tests/Core/GameConfigTests.cs
@@ -1,0 +1,219 @@
+using RPGEngine;
+using Xunit;
+
+namespace RPGEngine.Tests.Core;
+
+/// <summary>
+/// Acceptance tests for <see cref="GameConfig"/> and <see cref="Key"/>
+/// (story 8: GameConfig — movement key mapping with WASD defaults).
+/// </summary>
+public class GameConfigTests
+{
+    // ---------------------------------------------------------------------
+    // Acceptance 1: defaults are W/S/A/D and GetDirection returns
+    // Up/Down/Left/Right respectively.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the default bindings are W/S/A/D and that GetDirection maps them to Up/Down/Left/Right.</summary>
+    [Fact]
+    public void Defaults_AreWAsd_AndGetDirectionReturnsExpectedDirections()
+    {
+        var config = new GameConfig();
+
+        Assert.Equal(Key.W, config.UpKey);
+        Assert.Equal(Key.S, config.DownKey);
+        Assert.Equal(Key.A, config.LeftKey);
+        Assert.Equal(Key.D, config.RightKey);
+
+        Assert.Equal(Direction.Up, config.GetDirection(Key.W));
+        Assert.Equal(Direction.Down, config.GetDirection(Key.S));
+        Assert.Equal(Direction.Left, config.GetDirection(Key.A));
+        Assert.Equal(Direction.Right, config.GetDirection(Key.D));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 2: reassigning a key takes effect immediately; the old key
+    // is no longer mapped.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies that reassigning UpKey to Z makes GetDirection(Z) return Up immediately and the old key W return null.</summary>
+    [Fact]
+    public void ReassigningUpKey_TakesEffectImmediately()
+    {
+        var config = new GameConfig();
+
+        config.UpKey = Key.Z;
+
+        Assert.Equal(Direction.Up, config.GetDirection(Key.Z));
+        Assert.Null(config.GetDirection(Key.W));
+    }
+
+    /// <summary>Verifies that reassigning any direction key takes effect immediately and unbinds the previous key.</summary>
+    [Theory]
+    [InlineData("UpKey", Key.P, Direction.Up, Key.W)]
+    [InlineData("DownKey", Key.P, Direction.Down, Key.S)]
+    [InlineData("LeftKey", Key.P, Direction.Left, Key.A)]
+    [InlineData("RightKey", Key.P, Direction.Right, Key.D)]
+    public void ReassigningAnyDirectionKey_TakesEffectImmediately(
+        string propertyName,
+        Key newKey,
+        Direction expectedDirection,
+        Key previousKey)
+    {
+        var config = new GameConfig();
+
+        switch (propertyName)
+        {
+            case "UpKey":
+                config.UpKey = newKey;
+                break;
+            case "DownKey":
+                config.DownKey = newKey;
+                break;
+            case "LeftKey":
+                config.LeftKey = newKey;
+                break;
+            case "RightKey":
+                config.RightKey = newKey;
+                break;
+        }
+
+        Assert.Equal(expectedDirection, config.GetDirection(newKey));
+        Assert.Null(config.GetDirection(previousKey));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 3: assigning a key already used by another direction throws
+    // ArgumentException and leaves the config unchanged.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies that binding an already-used key throws ArgumentException and leaves the configuration unchanged.</summary>
+    [Theory]
+    [InlineData("UpKey", Key.S, Direction.Down)]    // S is bound to Down
+    [InlineData("UpKey", Key.A, Direction.Left)]    // A is bound to Left
+    [InlineData("DownKey", Key.W, Direction.Up)]    // W is bound to Up
+    [InlineData("DownKey", Key.D, Direction.Right)] // D is bound to Right
+    [InlineData("LeftKey", Key.W, Direction.Up)]    // W is bound to Up
+    [InlineData("LeftKey", Key.S, Direction.Down)]  // S is bound to Down
+    [InlineData("RightKey", Key.S, Direction.Down)] // S is bound to Down
+    [InlineData("RightKey", Key.A, Direction.Left)] // A is bound to Left
+    public void AssigningKeyAlreadyUsedByAnotherDirection_ThrowsAndLeavesConfigUnchanged(
+        string propertyName,
+        Key conflictingKey,
+        Direction originalDirection)
+    {
+        var config = new GameConfig();
+
+        var exception = Record.Exception(() => Set(config, propertyName, conflictingKey));
+
+        Assert.IsType<ArgumentException>(exception);
+
+        // The configuration must be left exactly as it was.
+        Assert.Equal(Key.W, config.UpKey);
+        Assert.Equal(Key.S, config.DownKey);
+        Assert.Equal(Key.A, config.LeftKey);
+        Assert.Equal(Key.D, config.RightKey);
+
+        Assert.Equal(Direction.Up, config.GetDirection(Key.W));
+        Assert.Equal(Direction.Down, config.GetDirection(Key.S));
+        Assert.Equal(Direction.Left, config.GetDirection(Key.A));
+        Assert.Equal(Direction.Right, config.GetDirection(Key.D));
+
+        // The conflicting key keeps its original binding: nothing changed.
+        Assert.Equal(originalDirection, config.GetDirection(conflictingKey));
+    }
+
+    /// <summary>Verifies that setting a property to its current value is a harmless no-op (does not throw).</summary>
+    [Theory]
+    [InlineData("UpKey", Key.W)]
+    [InlineData("DownKey", Key.S)]
+    [InlineData("LeftKey", Key.A)]
+    [InlineData("RightKey", Key.D)]
+    public void AssigningSameKeyToItsOwnProperty_IsANoOp(string propertyName, Key ownKey)
+    {
+        var config = new GameConfig();
+
+        Set(config, propertyName, ownKey); // must not throw
+
+        Assert.Equal(Direction.Up, config.GetDirection(Key.W));
+        Assert.Equal(Direction.Down, config.GetDirection(Key.S));
+        Assert.Equal(Direction.Left, config.GetDirection(Key.A));
+        Assert.Equal(Direction.Right, config.GetDirection(Key.D));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 4: GetDirection on an unmapped key returns null.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies GetDirection returns null for keys that are not mapped to any movement direction.</summary>
+    [Theory]
+    [InlineData(Key.Z)]
+    [InlineData(Key.Up)]
+    [InlineData(Key.Down)]
+    [InlineData(Key.Left)]
+    [InlineData(Key.Right)]
+    [InlineData(Key.Space)]
+    public void GetDirection_OnUnmappedKey_ReturnsNull(Key unmappedKey)
+    {
+        var config = new GameConfig();
+
+        Assert.Null(config.GetDirection(unmappedKey));
+    }
+
+    // ---------------------------------------------------------------------
+    // Additional coverage: the Key enum exposes exactly the documented set
+    // (A–Z, arrow keys, Space) and every movement binding stays unique.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the Key enum contains the full documented set: A–Z, Up, Down, Left, Right and Space.</summary>
+    [Fact]
+    public void KeyEnum_ContainsDocumentedSet()
+    {
+        var expected = new[]
+        {
+            Key.A, Key.B, Key.C, Key.D, Key.E, Key.F, Key.G, Key.H, Key.I, Key.J,
+            Key.K, Key.L, Key.M, Key.N, Key.O, Key.P, Key.Q, Key.R, Key.S, Key.T,
+            Key.U, Key.V, Key.W, Key.X, Key.Y, Key.Z,
+            Key.Up, Key.Down, Key.Left, Key.Right, Key.Space,
+        };
+
+        Assert.Equal(expected, Enum.GetValues<Key>());
+    }
+
+    /// <summary>Verifies that after rebinding, no two directions ever share a key.</summary>
+    [Fact]
+    public void Bindings_AlwaysRemainUnique()
+    {
+        var config = new GameConfig();
+
+        config.UpKey = Key.Up;
+        config.DownKey = Key.Down;
+        config.LeftKey = Key.Left;
+        config.RightKey = Key.Right;
+
+        Assert.Equal(Direction.Up, config.GetDirection(Key.Up));
+        Assert.Equal(Direction.Down, config.GetDirection(Key.Down));
+        Assert.Equal(Direction.Left, config.GetDirection(Key.Left));
+        Assert.Equal(Direction.Right, config.GetDirection(Key.Right));
+        Assert.Null(config.GetDirection(Key.W));
+        Assert.Null(config.GetDirection(Key.S));
+        Assert.Null(config.GetDirection(Key.A));
+        Assert.Null(config.GetDirection(Key.D));
+    }
+
+    private static void Set(GameConfig config, string propertyName, Key key)
+    {
+        switch (propertyName)
+        {
+            case "UpKey":
+                config.UpKey = key;
+                break;
+            case "DownKey":
+                config.DownKey = key;
+                break;
+            case "LeftKey":
+                config.LeftKey = key;
+                break;
+            case "RightKey":
+                config.RightKey = key;
+                break;
+            default:
+                throw new ArgumentException($"Unknown property '{propertyName}'.", nameof(propertyName));
+        }
+    }
+}

--- a/tests/RPGEngine.Tests/GameEngineSmokeTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineSmokeTests.cs
@@ -22,10 +22,10 @@ public class GameEngineSmokeTests
         Assert.Empty(engine.Characters);
 
         Assert.NotNull(engine.Config);
-        Assert.Equal(Key.W, engine.Config.MoveUp);
-        Assert.Equal(Key.S, engine.Config.MoveDown);
-        Assert.Equal(Key.A, engine.Config.MoveLeft);
-        Assert.Equal(Key.D, engine.Config.MoveRight);
+        Assert.Equal(Key.W, engine.Config.UpKey);
+        Assert.Equal(Key.S, engine.Config.DownKey);
+        Assert.Equal(Key.A, engine.Config.LeftKey);
+        Assert.Equal(Key.D, engine.Config.RightKey);
 
         Assert.Null(engine.Map);
     }


### PR DESCRIPTION
Closes #8

Implements [Story 8](https://github.com/elliottv/rpg-engine/issues/8): the `GameConfig` configuration object with WASD-default movement key mapping.

## Changes

### `src/RPGEngine/Key.cs`
- Full framework-agnostic `RPGEngine.Key` enum: `A`–`Z`, arrow keys (`Up`, `Down`, `Left`, `Right`) and `Space` (31 members).
- XML remarks document that the engine does not depend on WPF/Avalonia/Blazor input types (so it runs on any SkiaSharp host including WebAssembly) and that host applications translate their framework key events into `RPGEngine.Key`; the translation adapters are out of scope.

### `src/RPGEngine/GameConfig.cs`
- `sealed class GameConfig` with `UpKey` / `DownKey` / `LeftKey` / `RightKey` (defaults `W`/`S`/`A`/`D`) and `Direction? GetDirection(Key)`.
- **Immediate effect**: values are read at input time (never cached); documented in the class remarks — no event mechanism needed because `Input()` runs per key event.
- **Uniqueness invariant**: assigning a key already bound to another direction throws `ArgumentException` and leaves the config unchanged.
- XML docs on the class and all public members (CS1591 enforced; the project builds with `TreatWarningsAsErrors`).

### `tests/RPGEngine.Tests/Core/GameConfigTests.cs` (new)
- Covers the four acceptance criteria plus extras: defaults & direction mapping, immediate rebinding, `ArgumentException` on conflicting assignment with config left unchanged, unmapped key → `null`, no-op self-assignment, full `Key` enum set, and uniqueness after rebinding.

### `tests/RPGEngine.Tests/GameEngineSmokeTests.cs`
- Updated to the new property names (`UpKey`/`DownKey`/`LeftKey`/`RightKey`).

## Verification
- `dotnet build RPGEngine.sln -c Release` → 0 warnings, 0 errors.
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~GameConfigTests"` → 26/26 passed.
- Full suite: 100/100 passed.