### PR TITLE
Story 5: Character — position, movement, direction and sprite part composition

### DIFF
--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -1,12 +1,167 @@
+using RPGEngine.Sprites;
+using SkiaSharp;
+
 namespace RPGEngine;
 
 /// <summary>
-/// Represents a character present in the game world.
-/// Movement, direction, base speed and sprite sheets are introduced by later
-/// stories of the epic; this story only establishes the type.
+/// A character present in the game world (the player or an NPC). It holds the position,
+/// facing direction, movement speed, the walk-cycle animation state and the list of
+/// spritesheet references used to render it.
 /// </summary>
-public class Character
+/// <remarks>
+/// <para>
+/// Spritesheets are referenced with <see cref="SpriteSheetRef"/>, which pairs a loaded sheet
+/// name with the 1-based character index (1..8) to use within that sheet. Rendering resolves
+/// those references through the <see cref="SpriteSheetManager"/> supplied by the engine at
+/// draw time (see <see cref="Draw"/>); the actual drawing is delegated to an internal
+/// <see cref="CharacterSpriteCompositor"/> (composition over inheritance).
+/// </para>
+/// <para>
+/// A character uses either a single <em>full</em> sheet or one or more <em>part</em> sheets.
+/// Parts are composed in the fixed RPG Maker MZ order regardless of the order of entries in
+/// <see cref="SpriteSheets"/>; mixing full and part sheets, or using more than one full sheet,
+/// throws <see cref="InvalidOperationException"/> at draw time. A <see cref="SpriteSheetRef"/>
+/// whose <see cref="SpriteSheetRef.CharacterIndex"/> is outside 1..8 is rejected when used.
+/// </para>
+/// </remarks>
+public sealed class Character
 {
-    // Deliberately empty: position, direction, base speed and sprite sheets
-    // are added by later stories.
+    /// <summary>The middle column of the 3-frame walk cycle: the standing frame in RPG Maker MZ.</summary>
+    private const int StandingFrame = 1;
+
+    private readonly CharacterSpriteCompositor _compositor = new();
+    private readonly List<SpriteSheetRef> _spriteSheets = [];
+
+    private Position _lastUpdatePosition;
+    private int _animationFrame = StandingFrame;
+
+    // The walk cycle is a bounce: 0 → 1 → 2 → 1 → 0 → ... Starting from the standing frame (1)
+    // the first step goes toward 0, then the bounce alternates direction at each end.
+    private int _frameStep = -1;
+
+    /// <summary>Gets or sets the top-left world position of the character's sprite, in pixels.</summary>
+    public Position Position { get; set; }
+
+    /// <summary>Gets or sets the direction the character is facing.</summary>
+    public Direction Direction { get; set; }
+
+    /// <summary>Gets or sets the movement speed of the character in pixels per second.</summary>
+    public double BaseSpeed { get; set; }
+
+    /// <summary>
+    /// Gets the mutable list of spritesheet references used to render the character. Each entry
+    /// pairs a loaded sheet name with the 1-based character index (1..8) within that sheet.
+    /// The order of the entries is irrelevant for part sheets: they are composed in the fixed
+    /// RPG Maker MZ order (see <see cref="CharacterSpriteCompositor"/>).
+    /// </summary>
+    public IList<SpriteSheetRef> SpriteSheets => _spriteSheets;
+
+    /// <summary>
+    /// Gets the current walk-cycle animation frame (0..2). The middle frame (1) is the standing
+    /// frame. This accessor is internal so tests can verify animation advancement.
+    /// </summary>
+    internal int AnimationFrame => _animationFrame;
+
+    /// <summary>Initializes a new instance of the <see cref="Character"/> class at the origin, facing down.</summary>
+    public Character()
+    {
+        _lastUpdatePosition = Position;
+    }
+
+    /// <summary>
+    /// Moves the character in <paramref name="direction"/> by <c>BaseSpeed * speedFactor * dt</c>
+    /// pixels and sets the facing direction.
+    /// </summary>
+    /// <param name="direction">The direction to face and move towards.</param>
+    /// <param name="speedFactor">A multiplier applied to <see cref="BaseSpeed"/>. When zero the
+    /// character only turns to face <paramref name="direction"/> without moving.</param>
+    /// <param name="dt">The elapsed time in seconds (defaults to 1, so calling
+    /// <c>Move(d, factor)</c> moves <c>BaseSpeed * factor</c> pixels, i.e. per-second semantics).</param>
+    public void Move(Direction direction, double speedFactor = 1, double dt = 1)
+    {
+        Direction = direction;
+
+        if (speedFactor == 0)
+        {
+            return;
+        }
+
+        var delta = direction.Delta() * (BaseSpeed * speedFactor * dt);
+        Position = Position + delta;
+    }
+
+    /// <summary>
+    /// Moves the character in its current facing direction. See
+    /// <see cref="Move(Direction, double, double)"/> for the movement semantics.
+    /// </summary>
+    /// <param name="speedFactor">A multiplier applied to <see cref="BaseSpeed"/>.</param>
+    /// <param name="dt">The elapsed time in seconds.</param>
+    public void Move(double speedFactor = 1, double dt = 1) => Move(Direction, speedFactor, dt);
+
+    /// <summary>
+    /// Advances the walk-cycle animation when the character moved since the previous update,
+    /// otherwise snaps the animation back to the standing frame. Called by the engine's update
+    /// loop once per frame.
+    /// </summary>
+    /// <param name="dt">The elapsed time in seconds. Animation timing tuning is out of scope for
+    /// this story, so <paramref name="dt"/> is accepted for the engine-loop contract but does not
+    /// affect the frame advancement (one frame per update while moving).</param>
+    internal void Update(double dt)
+    {
+        var moved = Position != _lastUpdatePosition;
+        _lastUpdatePosition = Position;
+
+        if (moved)
+        {
+            AdvanceFrame();
+        }
+        else
+        {
+            _animationFrame = StandingFrame;
+            _frameStep = -1;
+        }
+    }
+
+    /// <summary>
+    /// Draws the character at <paramref name="screenPosition"/> (its world position minus the
+    /// camera origin). The spritesheet references are resolved through
+    /// <paramref name="spriteSheetManager"/>, which the engine supplies at draw time.
+    /// </summary>
+    /// <param name="canvas">The canvas to draw onto.</param>
+    /// <param name="screenPosition">The top-left screen position of the 48×48 sprite.</param>
+    /// <param name="dt">The elapsed time in seconds (reserved for future animation timing).</param>
+    /// <param name="spriteSheetManager">The manager that resolves the referenced sheet names.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The <see cref="SpriteSheets"/> list mixes full and part sheets, or contains more than one
+    /// full sheet.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A <see cref="SpriteSheetRef"/> has a <see cref="SpriteSheetRef.CharacterIndex"/> outside 1..8.
+    /// </exception>
+    internal void Draw(SKCanvas canvas, Position screenPosition, double dt, SpriteSheetManager spriteSheetManager)
+    {
+        _compositor.Draw(canvas, screenPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager);
+    }
+
+    private void AdvanceFrame()
+    {
+        if (_frameStep > 0)
+        {
+            _animationFrame++;
+            if (_animationFrame == 2)
+            {
+                // Reached the top of the bounce; the next step goes back down.
+                _frameStep = -1;
+            }
+        }
+        else
+        {
+            _animationFrame--;
+            if (_animationFrame == 0)
+            {
+                // Reached the bottom of the bounce; the next step goes back up.
+                _frameStep = 1;
+            }
+        }
+    }
 }

--- a/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
+++ b/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
@@ -1,0 +1,211 @@
+using SkiaSharp;
+
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// Draws a <see cref="Character"/>'s sprite by resolving its spritesheet references and either
+/// drawing a single <em>full</em> sheet or composing <em>part</em> sheets in the fixed RPG Maker
+/// MZ order. Kept internal and separate from <c>Character</c> so the composition algorithm is
+/// unit-testable through <c>InternalsVisibleTo</c> without being part of the public API.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The part composition reproduces the epic's PIXI.js example with 48×48 cells. For the current
+/// animation frame and direction the 48×48 cell of each part is drawn bottom → top in exactly
+/// this order (missing parts are skipped):
+/// </para>
+/// <list type="number">
+/// <item><see cref="CharacterPartType.Hair2"/> (when hair is shown) — behind everything.</item>
+/// <item><see cref="CharacterPartType.Face"/>.</item>
+/// <item><see cref="CharacterPartType.Body"/>.</item>
+/// <item><see cref="CharacterPartType.Hair1"/> (when hair is shown).</item>
+/// <item><see cref="CharacterPartType.FaceHair"/>.</item>
+/// <item><see cref="CharacterPartType.Armour"/>.</item>
+/// <item><see cref="CharacterPartType.Hair2"/> again, only when facing up (the per-direction
+/// adjustment: rear hair is drawn over the body).</item>
+/// <item><see cref="CharacterPartType.Head"/>.</item>
+/// </list>
+/// <para>
+/// Hair (hair1 and hair2) is shown unless a <see cref="CharacterPartType.Head"/> sheet is present
+/// whose name contains the <c>$</c> character (the <c>$</c>-prefix rule from the epic).
+/// </para>
+/// </remarks>
+internal sealed class CharacterSpriteCompositor
+{
+    private const int MinCharacterIndex = 1;
+    private const int MaxCharacterIndex = 8;
+
+    /// <summary>
+    /// Draws the character described by <paramref name="spriteSheetRefs"/> at
+    /// <paramref name="screenPosition"/>.
+    /// </summary>
+    /// <param name="canvas">The canvas to draw onto.</param>
+    /// <param name="screenPosition">The top-left screen position of the 48×48 sprite.</param>
+    /// <param name="spriteSheetRefs">The spritesheet references to use (sheet name + character index).</param>
+    /// <param name="direction">The direction the character faces.</param>
+    /// <param name="frame">The animation frame (0..2).</param>
+    /// <param name="manager">Resolves sheet names to <see cref="SpriteSheet"/> instances.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A reference has a <see cref="SpriteSheetRef.CharacterIndex"/> outside 1..8.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">A referenced sheet name is not loaded in <paramref name="manager"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The list mixes full and part sheets, or contains more than one full sheet.
+    /// </exception>
+    public void Draw(
+        SKCanvas canvas,
+        Position screenPosition,
+        IReadOnlyList<SpriteSheetRef> spriteSheetRefs,
+        Direction direction,
+        int frame,
+        SpriteSheetManager manager)
+    {
+        if (spriteSheetRefs.Count == 0)
+        {
+            return;
+        }
+
+        var resolved = Resolve(spriteSheetRefs, manager);
+
+        var fullCount = resolved.Count(r => r.Sheet.Type == SpriteSheetType.Full);
+        var partCount = resolved.Count - fullCount;
+
+        if (fullCount == 1 && partCount == 0)
+        {
+            // A single full sheet: draw its cell directly, no composition.
+            DrawCell(canvas, screenPosition, resolved[0], direction, frame);
+            return;
+        }
+
+        if (fullCount >= 1)
+        {
+            // Either mixed full+part or more than one full sheet — both are misconfiguration.
+            throw new InvalidOperationException(
+                "A character must use either exactly one full spritesheet or one or more part " +
+                $"sheets; the configured list contains {fullCount} full and {partCount} part sheet(s).");
+        }
+
+        ComposeParts(canvas, screenPosition, resolved, direction, frame);
+    }
+
+    /// <summary>
+    /// Resolves every reference to a sheet, rejecting character indices outside 1..8 before any
+    /// drawing happens (so an invalid configuration never partially renders).
+    /// </summary>
+    private static List<ResolvedRef> Resolve(IReadOnlyList<SpriteSheetRef> refs, SpriteSheetManager manager)
+    {
+        var resolved = new List<ResolvedRef>(refs.Count);
+        foreach (var reference in refs)
+        {
+            if (reference.CharacterIndex < MinCharacterIndex || reference.CharacterIndex > MaxCharacterIndex)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(SpriteSheetRef.CharacterIndex),
+                    reference.CharacterIndex,
+                    $"Character index must be between {MinCharacterIndex} and {MaxCharacterIndex} " +
+                    $"(RPG Maker MZ sheets contain 8 characters), but was {reference.CharacterIndex}.");
+            }
+
+            resolved.Add(new ResolvedRef(reference, manager.Get(reference.Name)));
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Draws the parts in the fixed bottom → top composition order. The order is independent of
+    /// the order of the entries in <c>SpriteSheets</c>: each part type is looked up on demand.
+    /// </summary>
+    private static void ComposeParts(
+        SKCanvas canvas,
+        Position screenPosition,
+        IReadOnlyList<ResolvedRef> parts,
+        Direction direction,
+        int frame)
+    {
+        var head = FindPart(parts, CharacterPartType.Head);
+        var showHair = head is null || !head.Value.Sheet.Name.Contains('$');
+
+        // 1. hair2 behind everything (when hair is shown).
+        if (showHair)
+        {
+            DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Hair2), direction, frame);
+        }
+
+        // 2. face
+        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Face), direction, frame);
+
+        // 3. body
+        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Body), direction, frame);
+
+        // 4. hair1 (when hair is shown)
+        if (showHair)
+        {
+            DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Hair1), direction, frame);
+        }
+
+        // 5. face_hair
+        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.FaceHair), direction, frame);
+
+        // 6. armour
+        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Armour), direction, frame);
+
+        // 7. hair2 again, only when facing up (rear hair drawn over the body).
+        if (showHair && direction == Direction.Up)
+        {
+            DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Hair2), direction, frame);
+        }
+
+        // 8. head (if present)
+        DrawPart(canvas, screenPosition, head, direction, frame);
+    }
+
+    /// <summary>
+    /// Draws a single part, doing nothing when the part is not present in the list.
+    /// </summary>
+    private static void DrawPart(
+        SKCanvas canvas,
+        Position screenPosition,
+        ResolvedRef? part,
+        Direction direction,
+        int frame)
+    {
+        if (part is null)
+        {
+            return;
+        }
+
+        DrawCell(canvas, screenPosition, part.Value, direction, frame);
+    }
+
+    /// <summary>Draws the 48×48 cell selected by the part's own character index.</summary>
+    private static void DrawCell(
+        SKCanvas canvas,
+        Position screenPosition,
+        ResolvedRef part,
+        Direction direction,
+        int frame)
+    {
+        // GetSprite validates the index/frame again defensively and returns an independent
+        // 48×48 image that the caller owns.
+        using var sprite = part.Sheet.GetSprite(part.Ref.CharacterIndex, direction, frame);
+        canvas.DrawImage(sprite, new SKPoint((float)screenPosition.X, (float)screenPosition.Y));
+    }
+
+    /// <summary>Returns the first resolved part of the given type, or <see langword="null"/> when absent.</summary>
+    private static ResolvedRef? FindPart(IReadOnlyList<ResolvedRef> parts, CharacterPartType type)
+    {
+        foreach (var part in parts)
+        {
+            if (part.Sheet.PartType == type)
+            {
+                return part;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>A resolved spritesheet reference: the original reference plus its sheet.</summary>
+    private readonly record struct ResolvedRef(SpriteSheetRef Ref, SpriteSheet Sheet);
+}

--- a/src/RPGEngine/Vector2.cs
+++ b/src/RPGEngine/Vector2.cs
@@ -16,4 +16,14 @@ public readonly record struct Vector2(double X, double Y)
 
     /// <summary>Returns the negation of <paramref name="v"/>.</summary>
     public static Vector2 operator -(Vector2 v) => new(-v.X, -v.Y);
+
+    /// <summary>
+    /// Returns the component-wise product of <paramref name="v"/> and the scalar
+    /// <paramref name="scalar"/>. Used by movement logic to scale a direction delta by a
+    /// distance (<c>direction.Delta() * (BaseSpeed * factor * dt)</c>).
+    /// </summary>
+    public static Vector2 operator *(Vector2 v, double scalar) => new(v.X * scalar, v.Y * scalar);
+
+    /// <summary>Returns the component-wise product of the scalar <paramref name="scalar"/> and <paramref name="v"/>.</summary>
+    public static Vector2 operator *(double scalar, Vector2 v) => new(v.X * scalar, v.Y * scalar);
 }

--- a/tests/RPGEngine.Tests/CharacterTestHelper.cs
+++ b/tests/RPGEngine.Tests/CharacterTestHelper.cs
@@ -1,0 +1,107 @@
+using SkiaSharp;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Generates RPG Maker MZ spritesheet fixtures for the <see cref="CharacterTests"/>.
+/// Each sheet is identified by a <em>seed</em> so that different sheets (different character
+/// parts) get globally distinct cell colors; within a sheet, every 48×48 cell is uniquely
+/// colored by (row, column). This lets pixel-level composition tests tell which part ended up
+/// on top.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The color scheme guarantees global uniqueness across (seed, row, col): the red channel
+/// encodes the seed (seeds 0..6 map to distinct red values), the green channel encodes the
+/// column and the blue channel encodes the row-major cell index.
+/// </para>
+/// <para>
+/// A sheet can also be generated fully transparent (the <c>transparent</c> flag of
+/// <see cref="CreateSheetPng(int,bool)"/>). Transparent sheets are used for the head part in the
+/// <c>$</c>-rule tests: they let the hair layer show through at the checked pixel while the
+/// head is still present in the list (and its <c>$</c> rule still applies), so the test can
+/// observe whether hair was drawn or skipped.
+/// </para>
+/// </remarks>
+internal static class CharacterTestHelper
+{
+    public const int SheetWidth = 576;
+    public const int SheetHeight = 384;
+    public const int CellSize = 48;
+    public const int Columns = 12;
+    public const int Rows = 8;
+
+    /// <summary>
+    /// Returns the unique opaque color used for the cell at (row, col) of the sheet identified
+    /// by <paramref name="seed"/>.
+    /// </summary>
+    public static SKColor CellColor(int seed, int row, int col)
+    {
+        // R encodes the seed, G the column, B the row-major cell index. Distinct (seed, row, col)
+        // triples always map to distinct colors for the seeds used by the tests.
+        var r = (byte)((seed * 37) % 256);
+        var g = (byte)col;
+        var b = (byte)((row * Columns) + col);
+        return new SKColor(r, g, b, alpha: 255);
+    }
+
+    /// <summary>
+    /// Encodes a 576×384 sheet as PNG. When <paramref name="transparent"/> is
+    /// <see langword="true"/> every cell is fully transparent; otherwise each 48×48 cell is
+    /// filled with the unique color from <see cref="CellColor(int, int, int)"/>.
+    /// </summary>
+    public static byte[] CreateSheetPng(int seed, bool transparent = false)
+    {
+        using var bitmap = new SKBitmap(SheetWidth, SheetHeight);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+
+            if (!transparent)
+            {
+                for (var row = 0; row < Rows; row++)
+                {
+                    for (var col = 0; col < Columns; col++)
+                    {
+                        using var paint = new SKPaint { Color = CellColor(seed, row, col), IsAntialias = false };
+                        canvas.DrawRect(
+                            new SKRect(col * CellSize, row * CellSize, (col + 1) * CellSize, (row + 1) * CellSize),
+                            paint);
+                    }
+                }
+            }
+        }
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    /// <summary>Returns a read-only stream containing a 576×384 sheet encoded as PNG.</summary>
+    public static MemoryStream CreateSheetStream(int seed, bool transparent = false)
+        => new(CreateSheetPng(seed, transparent), writable: false);
+
+    /// <summary>
+    /// Computes the sheet cell (row, col) that <c>SpriteSheet.GetSprite</c> crops for the given
+    /// 1-based character index, direction and animation frame (mirrors the sheet's slicing
+    /// contract so tests can predict the exact color).
+    /// </summary>
+    public static (int Row, int Col) CellFor(int characterIndex, Direction direction, int frame)
+    {
+        var charCol = (characterIndex - 1) % 4;
+        var charRow = (characterIndex - 1) / 4;
+        var col = (charCol * 3) + frame;
+        var row = (charRow * 4) + (int)direction;
+        return (row, col);
+    }
+
+    /// <summary>
+    /// Returns the expected opaque color of the cell that a part or full sheet with the given
+    /// <paramref name="seed"/> would produce for (characterIndex, direction, frame).
+    /// </summary>
+    public static SKColor SpriteColor(int seed, int characterIndex, Direction direction, int frame)
+    {
+        var (row, col) = CellFor(characterIndex, direction, frame);
+        return CellColor(seed, row, col);
+    }
+}

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -1,0 +1,377 @@
+using RPGEngine.Sprites;
+using SkiaSharp;
+using Xunit;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Acceptance tests for <see cref="Character"/>: movement, direction, walk-cycle animation and
+/// the RPG Maker MZ sprite part composition (story 5: Character — position, movement, direction
+/// and sprite part composition).
+/// </summary>
+/// <remarks>
+/// The composition tests render a character into an offscreen <see cref="SKBitmap"/> using the
+/// seeded sheets from <see cref="CharacterTestHelper"/> and assert the pixel color of the
+/// top-most part at a known overlapping coordinate. All generated sheets are fully opaque 48×48
+/// cells (the head used for the <c>$</c>-rule tests is deliberately fully transparent so the
+/// hair layer behind it can be observed), so the whole sprite is uniformly the color of the
+/// last-drawn part; checking the centre and both corners guards against accidental offsets.
+/// </remarks>
+public class CharacterTests
+{
+    private const int StandingFrame = 1; // the frame a fresh/stopped character renders at
+
+    // ---------------------------------------------------------------------
+    // Acceptance 1: Move with speedFactor == 0 changes only Direction.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies that Move with speedFactor 0 only turns the character and does not move it.</summary>
+    [Fact]
+    public void Move_WithZeroSpeedFactor_ChangesOnlyDirection()
+    {
+        var character = new Character
+        {
+            Position = new Position(10, 20),
+            Direction = Direction.Down,
+        };
+
+        character.Move(Direction.Right, speedFactor: 0);
+
+        Assert.Equal(Direction.Right, character.Direction);
+        Assert.Equal(new Position(10, 20), character.Position);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 2: Move(direction, factor, dt) moves exactly
+    // BaseSpeed * factor * dt pixels in the right axis/direction and sets Direction.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Move(direction, factor, dt) moves exactly BaseSpeed × factor × dt pixels along the correct axis and direction, and sets Direction.</summary>
+    [Theory]
+    [InlineData(Direction.Down, 0.0, 100.0)]
+    [InlineData(Direction.Up, 0.0, -100.0)]
+    [InlineData(Direction.Left, -100.0, 0.0)]
+    [InlineData(Direction.Right, 100.0, 0.0)]
+    public void Move_WithDirectionFactorAndDt_MovesExactly(
+        Direction direction,
+        double expectedX,
+        double expectedY)
+    {
+        var character = new Character { BaseSpeed = 100, Position = new Position(0, 0) };
+
+        // BaseSpeed * factor * dt = 100 * 2 * 0.5 = 100 pixels.
+        character.Move(direction, speedFactor: 2, dt: 0.5);
+
+        Assert.Equal(expectedX, character.Position.X);
+        Assert.Equal(expectedY, character.Position.Y);
+        Assert.Equal(direction, character.Direction);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 3: the direction-less Move reuses the previous Direction.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies that Move(speedFactor, dt) without a direction reuses the character's previous Direction.</summary>
+    [Fact]
+    public void Move_WithoutDirection_ReusesPreviousDirection()
+    {
+        var character = new Character { BaseSpeed = 100, Direction = Direction.Up };
+
+        character.Move(speedFactor: 1, dt: 1);
+
+        Assert.Equal(new Position(0, -100), character.Position);
+        Assert.Equal(Direction.Up, character.Direction);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 4: Update advances frames only while moving.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies the walk-cycle animation advances 0 → 1 → 2 → 1 → 0 only while the character
+    /// moves, and snaps back to the standing frame (1) once it stops.
+    /// </summary>
+    [Fact]
+    public void Update_AdvancesWalkCycleOnlyWhileMoving()
+    {
+        var character = new Character { BaseSpeed = 1 };
+
+        // A fresh character stands on the middle (standing) frame and stays there when idle.
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+        character.Update(dt: 1);
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+
+        // Walk cycle while moving: 0 → 1 → 2 → 1 → 0.
+        MoveAndUpdate(character, Direction.Down);
+        Assert.Equal(0, character.AnimationFrame);
+
+        MoveAndUpdate(character, Direction.Down);
+        Assert.Equal(1, character.AnimationFrame);
+
+        MoveAndUpdate(character, Direction.Down);
+        Assert.Equal(2, character.AnimationFrame);
+
+        MoveAndUpdate(character, Direction.Down);
+        Assert.Equal(1, character.AnimationFrame);
+
+        MoveAndUpdate(character, Direction.Down);
+        Assert.Equal(0, character.AnimationFrame);
+
+        // Once the character stops moving, Update snaps back to the standing frame.
+        character.Update(dt: 1);
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5a: a single full sheet renders the expected cell for the
+    // configured CharacterIndex.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a character configured with a single full sheet renders the exact cell of its CharacterIndex.</summary>
+    [Fact]
+    public void Draw_SingleFullSheet_WithCharacterIndex_RendersExpectedCell()
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false));
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        character.Move(Direction.Down, speedFactor: 0); // face down without moving
+
+        using var bitmap = Render(character, manager);
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.Down, StandingFrame);
+        AssertPixel(bitmap, expected);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5b: parts without head compose in the fixed order, with the
+    // per-direction hair2 adjustment (hair2 on top when facing Up, body visible
+    // when facing Down). The entries are added out of composition order to also
+    // prove the list order is irrelevant.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies part composition without a head: body on top facing down, hair2 drawn on top facing up (the per-direction adjustment), regardless of list order.</summary>
+    [Fact]
+    public void Draw_PartsWithoutHead_Hair2OnTopWhenUp_BodyOnTopWhenDown()
+    {
+        var manager = CreateManager(
+            (Name: "body", PartType: CharacterPartType.Body, Seed: 1, Transparent: false),
+            (Name: "face", PartType: CharacterPartType.Face, Seed: 2, Transparent: false),
+            (Name: "hair2", PartType: CharacterPartType.Hair2, Seed: 3, Transparent: false));
+
+        var character = new Character();
+        // Deliberately not in composition order: hair2, face, body is the draw order.
+        character.SpriteSheets.Add(new SpriteSheetRef("body", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("face", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("hair2", 1));
+
+        // Facing down: fixed order hair2 → face → body, so body is on top.
+        character.Move(Direction.Down, speedFactor: 0);
+        using (var down = Render(character, manager))
+        {
+            var expectedDown = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+            AssertPixel(down, expectedDown);
+        }
+
+        // Facing up: the second hair2 crop is drawn in front (the per-direction adjustment).
+        character.Move(Direction.Up, speedFactor: 0);
+        using (var up = Render(character, manager))
+        {
+            var expectedUp = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 1, Direction.Up, StandingFrame);
+            AssertPixel(up, expectedUp);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5c/5d: the "$" prefix rule. A head sheet whose name contains
+    // '$' hides the hair layers; one whose name does not shows them. The head
+    // fixture is fully transparent so the hair behind it is observable.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a head sheet whose name contains '$' hides the hair layers (hair2 is not drawn).</summary>
+    [Fact]
+    public void Draw_HeadNameWithDollar_HidesHair()
+    {
+        var manager = CreateManager(
+            (Name: "body", PartType: CharacterPartType.Body, Seed: 1, Transparent: false),
+            (Name: "hair2", PartType: CharacterPartType.Hair2, Seed: 3, Transparent: false),
+            (Name: "head$", PartType: CharacterPartType.Head, Seed: 4, Transparent: true));
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("body", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("hair2", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("head$", 1));
+
+        // Facing up: even though hair2 would be drawn in front (per-direction adjustment),
+        // showHair is false so hair2 is skipped and the body shows through the transparent head.
+        character.Move(Direction.Up, speedFactor: 0);
+        using var bitmap = Render(character, manager);
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Up, StandingFrame); // body
+        AssertPixel(bitmap, expected);
+    }
+
+    /// <summary>Verifies a head sheet whose name does not contain '$' keeps the hair layers shown.</summary>
+    [Fact]
+    public void Draw_HeadNameWithoutDollar_ShowsHair()
+    {
+        var manager = CreateManager(
+            (Name: "body", PartType: CharacterPartType.Body, Seed: 1, Transparent: false),
+            (Name: "hair2", PartType: CharacterPartType.Hair2, Seed: 3, Transparent: false),
+            (Name: "head", PartType: CharacterPartType.Head, Seed: 4, Transparent: true));
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("body", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("hair2", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("head", 1));
+
+        // Facing up: showHair is true, so hair2 is drawn behind the body and again in front
+        // (the per-direction adjustment); the transparent head lets it show through.
+        character.Move(Direction.Up, speedFactor: 0);
+        using var bitmap = Render(character, manager);
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 1, Direction.Up, StandingFrame); // hair2
+        AssertPixel(bitmap, expected);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5e: two entries referencing the same sheet with different
+    // CharacterIndex values render different sprites.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the CharacterIndex selects which character within a shared sheet is rendered.</summary>
+    [Fact]
+    public void Draw_SameSheet_DifferentCharacterIndex_RendersDifferentSprites()
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false));
+
+        var first = new Character();
+        first.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        first.Move(Direction.Down, speedFactor: 0);
+
+        var second = new Character();
+        second.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 2));
+        second.Move(Direction.Down, speedFactor: 0);
+
+        using var firstBitmap = Render(first, manager);
+        using var secondBitmap = Render(second, manager);
+
+        var expectedFirst = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.Down, StandingFrame);
+        var expectedSecond = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 2, Direction.Down, StandingFrame);
+
+        AssertPixel(firstBitmap, expectedFirst);
+        AssertPixel(secondBitmap, expectedSecond);
+        Assert.NotEqual(expectedFirst, expectedSecond);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 6: mixed full+part list throws InvalidOperationException at
+    // draw time.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a character mixing a full and a part sheet throws InvalidOperationException at draw time.</summary>
+    [Fact]
+    public void Draw_MixedFullAndPartSheets_ThrowsInvalidOperationException()
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false),
+            (Name: "body", PartType: CharacterPartType.Body, Seed: 1, Transparent: false));
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("hero", 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("body", 1));
+
+        using var bitmap = new SKBitmap(CharacterTestHelper.CellSize, CharacterTestHelper.CellSize);
+        using var canvas = new SKCanvas(bitmap);
+        Assert.Throws<InvalidOperationException>(
+            () => character.Draw(canvas, new Position(0, 0), dt: 1, manager));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 7: a SpriteSheetRef with CharacterIndex outside 1..8 is
+    // rejected when used.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a SpriteSheetRef whose CharacterIndex is outside 1..8 throws ArgumentOutOfRangeException when drawn.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(9)]
+    public void Draw_InvalidCharacterIndex_ThrowsArgumentOutOfRangeException(int characterIndex)
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false));
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("hero", characterIndex));
+
+        using var bitmap = new SKBitmap(CharacterTestHelper.CellSize, CharacterTestHelper.CellSize);
+        using var canvas = new SKCanvas(bitmap);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => character.Draw(canvas, new Position(0, 0), dt: 1, manager));
+    }
+
+    // ---------------------------------------------------------------------
+    // Additional coverage: a character with no sprite sheets draws nothing.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a character with an empty SpriteSheets list draws nothing (no exception, transparent output).</summary>
+    [Fact]
+    public void Draw_NoSpriteSheets_DrawsNothing()
+    {
+        var manager = new SpriteSheetManager();
+        var character = new Character();
+
+        using var bitmap = Render(character, manager);
+
+        // Nothing was drawn: every pixel stays fully transparent.
+        Assert.Equal(0, bitmap.GetPixel(24, 24).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(47, 47).Alpha);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// <summary>Moves the character one step and updates it, advancing the walk cycle.</summary>
+    private static void MoveAndUpdate(Character character, Direction direction)
+    {
+        character.Move(direction, speedFactor: 1, dt: 1);
+        character.Update(dt: 1);
+    }
+
+    /// <summary>Loads the sheets described by the given tuples and returns a fresh manager.</summary>
+    /// <remarks>
+    /// Each tuple is (Name, PartType, Seed, Transparent); <c>PartType</c> is null for a full sheet.
+    /// </remarks>
+    private static SpriteSheetManager CreateManager(
+        params (string Name, CharacterPartType? PartType, int Seed, bool Transparent)[] sheets)
+    {
+        var manager = new SpriteSheetManager();
+        foreach (var (name, partType, seed, transparent) in sheets)
+        {
+            using var stream = CharacterTestHelper.CreateSheetStream(seed, transparent);
+            if (partType is null)
+            {
+                manager.Load(name, stream);
+            }
+            else
+            {
+                manager.LoadPart(name, stream, partType.Value);
+            }
+        }
+
+        return manager;
+    }
+
+    /// <summary>Renders the character into a fresh 48×48 bitmap at the origin.</summary>
+    private static SKBitmap Render(Character character, SpriteSheetManager manager)
+    {
+        var bitmap = new SKBitmap(CharacterTestHelper.CellSize, CharacterTestHelper.CellSize);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            character.Draw(canvas, new Position(0, 0), dt: 1, manager);
+        }
+
+        return bitmap;
+    }
+
+    /// <summary>Asserts the centre and both corners of the sprite have the expected color.</summary>
+    private static void AssertPixel(SKBitmap bitmap, SKColor expected)
+    {
+        Assert.Equal(expected, bitmap.GetPixel(24, 24));
+        Assert.Equal(expected, bitmap.GetPixel(0, 0));
+        Assert.Equal(expected, bitmap.GetPixel(47, 47));
+    }
+}


### PR DESCRIPTION
Closes #5

Implements `Character`, the entity used for the player and NPCs: position, direction, speed, movement logic, walk-cycle animation and the list of spritesheet references (sheet name + character index 1..8) used to render it — including the RPG Maker MZ part composition algorithm.

## What was added

### `Character` (RPGEngine, sealed)
- `Position`, `Direction`, `BaseSpeed`, and a mutable `IList<SpriteSheetRef> SpriteSheets`.
- `Move(direction, speedFactor = 1, dt = 1)`:
  - `speedFactor == 0` → only sets `Direction` (look-only), no movement.
  - otherwise moves `Position += direction.Delta() * (BaseSpeed * speedFactor * dt)` and sets `Direction`.
- `Move(speedFactor = 1, dt = 1)` reuses the previous `Direction`.
- `Update(dt)` advances the walk-cycle frame `0 → 1 → 2 → 1 → 0 …` only while the character moved since the last update, otherwise snaps to the standing frame (middle column = 1). Frame state is exposed through an internal `AnimationFrame` test-only accessor.
- `Draw(canvas, screenPosition, dt, spriteSheetManager)` resolves sheet refs through the `SpriteSheetManager` supplied by the engine at draw time and delegates to an internal `CharacterSpriteCompositor`.

### `CharacterSpriteCompositor` (RPGEngine.Sprites, internal)
- Single **full** sheet → draws that sheet's cell for `(CharacterIndex, direction, frame)` directly.
- **Part** sheets → composed bottom→top in the fixed order: `hair2` (if shown) → `face` → `body` → `hair1` (if shown) → `face_hair` → `armour` → `hair2` again when `Direction == Up` (per-direction adjustment) → `head`. Order is independent of list order.
- `showHair = headSheet is null || !headSheet.Name.Contains('$')` (the `$`-prefix rule).
- Rejects a `SpriteSheetRef` with `CharacterIndex` outside 1..8 (`ArgumentOutOfRangeException`) and mixed full+part lists (`InvalidOperationException`) **before** drawing.

### `Vector2`
- Added scalar multiplication operators so movement can scale a direction delta by a distance.

### Tests — `CharacterTests` (16 tests) + `CharacterTestHelper`
Covers all 7 acceptance criteria: look-only move, exact movement distance per direction, direction-less move reuse, frame advancement only while moving, pixel-level composition (single full sheet by CharacterIndex; parts without head with hair2 on top facing Up / body visible facing Down; head name with `$` hides hair; head name without `$` shows hair; same sheet with different CharacterIndex renders different sprites), mixed full+part throws, and invalid CharacterIndex rejection.

Verified locally: `dotnet build RPGEngine.sln -c Release` → 0 warnings / 0 errors; `dotnet test` → all 116 tests pass, including `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~CharacterTests"` (16/16).

## Notes
- `Character.Draw` is internal and takes the `SpriteSheetManager` as an explicit parameter (the spec's code sketch omits it, but the spec text states the renderer "resolves them through the SpriteSheetManager supplied by the engine at draw time"); GameEngine will pass its manager when the Render story lands.