### PR TITLE
Story 9: Player — character wrapper moved by input

### DIFF
--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -1,18 +1,106 @@
+using RPGEngine.Sprites;
+
 namespace RPGEngine;
 
 /// <summary>
-/// Represents the player controlled by the user. It is composed of a
-/// <see cref="Character"/> which represents the player in the game world,
-/// and it will be moved when the engine receives input events (later story).
+/// Represents the player character controlled by the user.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The player is <em>composed</em> of a <see cref="Character"/> (composition, no inheritance)
+/// which carries all of the in-world state: position, facing direction, movement speed and the
+/// list of spritesheet references. <see cref="Player"/> is a thin wrapper that forwards state
+/// access and movement to that character, so configuring <see cref="SpriteSheets"/> or moving
+/// the player is exactly equivalent to configuring/moving the underlying <see cref="Character"/>.
+/// </para>
+/// <para>
+/// The player does not listen to input itself. The engine (<see cref="GameEngine"/>) owns the
+/// pressed-keys state and, in its update loop, calls <c>Move(direction, 1, dt)</c> with the
+/// direction derived from <see cref="GameConfig"/>. This keeps <see cref="Player"/> a thin,
+/// easily testable wrapper.
+/// </para>
+/// </remarks>
 public sealed class Player
 {
-    /// <summary>Gets the <see cref="Character"/> that represents the player in the game world.</summary>
-    public Character Character { get; }
+    /// <summary>
+    /// The default movement speed, in pixels per second, of a player created by the parameterless
+    /// constructor: 96 px/s, i.e. one 48px tile every half second. This is a gameplay tuning
+    /// constant and is expected to be adjusted later.
+    /// </summary>
+    public const double DefaultBaseSpeed = 96;
 
-    /// <summary>Initializes a new instance of the <see cref="Player"/> class.</summary>
+    /// <summary>Gets or sets the <see cref="Character"/> that represents the player in the game world.</summary>
+    /// <remarks>
+    /// All other members of <see cref="Player"/> forward to this character, so replacing it
+    /// replaces the player's position, direction, speed and spritesheets as well.
+    /// </remarks>
+    public Character Character { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Player"/> class with its own
+    /// <see cref="Character"/> using the default <see cref="DefaultBaseSpeed"/>.
+    /// </summary>
     public Player()
     {
-        Character = new Character();
+        Character = new Character { BaseSpeed = DefaultBaseSpeed };
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Player"/> class wrapping the provided
+    /// <see cref="Character"/>.
+    /// </summary>
+    /// <param name="character">The character that represents the player in the game world.</param>
+    public Player(Character character)
+    {
+        Character = character;
+    }
+
+    /// <summary>
+    /// Gets or sets the top-left world position of the player's sprite, in pixels. Forwards to
+    /// <see cref="Character.Position"/>.
+    /// </summary>
+    public Position Position
+    {
+        get => Character.Position;
+        set => Character.Position = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the direction the player is facing. Forwards to
+    /// <see cref="Character.Direction"/>.
+    /// </summary>
+    public Direction Direction
+    {
+        get => Character.Direction;
+        set => Character.Direction = value;
+    }
+
+    /// <summary>
+    /// Gets the mutable list of spritesheet references used to render the player. Each entry
+    /// pairs a loaded sheet name with the 1-based character index (1..8) within that sheet.
+    /// Forwards to <see cref="Character.SpriteSheets"/>: the returned list is the same instance,
+    /// so entries added through the player are immediately visible on the underlying character
+    /// (e.g. <c>player.SpriteSheets.Add(new SpriteSheetRef("hero_body", 3))</c>).
+    /// </summary>
+    public IList<SpriteSheetRef> SpriteSheets => Character.SpriteSheets;
+
+    /// <summary>
+    /// Moves the player in <paramref name="direction"/> by <c>BaseSpeed * speedFactor * dt</c>
+    /// pixels and sets the facing direction. Forwards to
+    /// <see cref="Character.Move(Direction, double, double)"/>.
+    /// </summary>
+    /// <param name="direction">The direction to face and move towards.</param>
+    /// <param name="speedFactor">A multiplier applied to the character's <see cref="Character.BaseSpeed"/>.</param>
+    /// <param name="dt">The elapsed time in seconds.</param>
+    public void Move(Direction direction, double speedFactor = 1, double dt = 1)
+        => Character.Move(direction, speedFactor, dt);
+
+    /// <summary>
+    /// Moves the player in its current facing direction. Forwards to
+    /// <see cref="Character.Move(double, double)"/>.
+    /// </summary>
+    /// <param name="speedFactor">A multiplier applied to the character's <see cref="Character.BaseSpeed"/>.</param>
+    /// <param name="dt">The elapsed time in seconds.</param>
+    public void Move(double speedFactor = 1, double dt = 1)
+        => Character.Move(speedFactor, dt);
 }

--- a/tests/RPGEngine.Tests/PlayerTests.cs
+++ b/tests/RPGEngine.Tests/PlayerTests.cs
@@ -1,0 +1,171 @@
+using RPGEngine.Sprites;
+using Xunit;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Acceptance tests for <see cref="Player"/> (story 9): the player is a thin wrapper that
+/// composes a <see cref="Character"/> and forwards state access and movement to it. It does
+/// not listen to input itself; the engine drives it via <c>Move(direction, 1, dt)</c>.
+/// </summary>
+public class PlayerTests
+{
+    // ---------------------------------------------------------------------
+    // Acceptance 1: the parameterless constructor creates its own Character
+    // (with the default BaseSpeed), and Character is settable.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the parameterless constructor creates a non-null Character with the default BaseSpeed.</summary>
+    [Fact]
+    public void ParameterlessConstructor_CreatesOwnCharacterWithDefaultSpeed()
+    {
+        var player = new Player();
+
+        Assert.NotNull(player.Character);
+        Assert.Equal(Player.DefaultBaseSpeed, player.Character.BaseSpeed);
+    }
+
+    /// <summary>Verifies Player.Character can be replaced with another Character instance.</summary>
+    [Fact]
+    public void Character_IsSettable()
+    {
+        var player = new Player();
+        var character = new Character();
+
+        player.Character = character;
+
+        Assert.Same(character, player.Character);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 2: Position/Direction read/write forward to Character.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies writing Player.Position updates the underlying Character and reading it returns the character's value.</summary>
+    [Fact]
+    public void Position_ReadWriteForwardsToCharacter()
+    {
+        var player = new Player();
+        var character = player.Character;
+
+        player.Position = new Position(12, 34);
+
+        Assert.Equal(new Position(12, 34), character.Position);
+        Assert.Equal(character.Position, player.Position);
+    }
+
+    /// <summary>Verifies writing Player.Direction updates the underlying Character and reading it returns the character's value.</summary>
+    [Fact]
+    public void Direction_ReadWriteForwardsToCharacter()
+    {
+        var player = new Player();
+        var character = player.Character;
+
+        player.Direction = Direction.Left;
+
+        Assert.Equal(Direction.Left, character.Direction);
+        Assert.Equal(character.Direction, player.Direction);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 3: SpriteSheets is the same list instance as
+    // Character.SpriteSheets, so adding a SpriteSheetRef (with a character
+    // index 1..8) via the player is visible on the character.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Player.SpriteSheets returns the exact same list instance as Character.SpriteSheets.</summary>
+    [Fact]
+    public void SpriteSheets_IsSameInstanceAsCharacterSpriteSheets()
+    {
+        var player = new Player();
+
+        Assert.Same(player.Character.SpriteSheets, player.SpriteSheets);
+    }
+
+    /// <summary>Verifies a SpriteSheetRef added through Player.SpriteSheets is visible on the underlying Character.</summary>
+    [Fact]
+    public void SpriteSheets_AddViaPlayer_IsVisibleOnCharacter()
+    {
+        var player = new Player();
+
+        player.SpriteSheets.Add(new SpriteSheetRef("hero_body", CharacterIndex: 3));
+
+        Assert.Contains(new SpriteSheetRef("hero_body", 3), player.Character.SpriteSheets);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 4: Move(direction, factor, dt) moves the underlying Character
+    // by BaseSpeed * factor * dt and updates its Direction.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Move(direction, factor, dt) moves the underlying Character exactly BaseSpeed × factor × dt pixels along the right axis and updates its Direction.</summary>
+    [Theory]
+    [InlineData(Direction.Down, 0.0, 100.0)]
+    [InlineData(Direction.Up, 0.0, -100.0)]
+    [InlineData(Direction.Left, -100.0, 0.0)]
+    [InlineData(Direction.Right, 100.0, 0.0)]
+    public void Move_WithDirectionFactorAndDt_MovesUnderlyingCharacter(
+        Direction direction,
+        double expectedX,
+        double expectedY)
+    {
+        var player = new Player { Position = new Position(0, 0) };
+        player.Character.BaseSpeed = 100;
+
+        // BaseSpeed * factor * dt = 100 * 2 * 0.5 = 100 pixels.
+        player.Move(direction, speedFactor: 2, dt: 0.5);
+
+        Assert.Equal(expectedX, player.Position.X);
+        Assert.Equal(expectedY, player.Position.Y);
+        Assert.Equal(direction, player.Direction);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5: Move(factor, dt) without a direction uses the Character's
+    // previous direction.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Move(speedFactor, dt) without a direction reuses the underlying Character's previous Direction.</summary>
+    [Fact]
+    public void Move_WithoutDirection_ReusesPreviousDirection()
+    {
+        var player = new Player { Direction = Direction.Up };
+        player.Character.BaseSpeed = 100;
+
+        player.Move(speedFactor: 1, dt: 1);
+
+        Assert.Equal(new Position(0, -100), player.Position);
+        Assert.Equal(Direction.Up, player.Direction);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 6: driving the player the way the engine will — derive a
+    // direction from Config and call Move(direction, 1, dt) each frame at
+    // dt = 1/60 — tracks the expected path.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a player driven like the engine (Config-derived direction, Move each frame at dt = 1/60) tracks the expected path.</summary>
+    [Fact]
+    public void DrivenLikeTheEngine_TracksExpectedPath()
+    {
+        var engine = new GameEngine();
+        var player = engine.Player;
+        var config = engine.Config;
+
+        const double dt = 1.0 / 60;
+        var right = config.GetDirection(Key.D)!.Value;
+        var down = config.GetDirection(Key.S)!.Value;
+
+        // Move right for one second (60 frames at 1/60 s) → 96 px to the right.
+        for (var frame = 0; frame < 60; frame++)
+        {
+            player.Move(right, speedFactor: 1, dt);
+        }
+
+        Assert.Equal(96, player.Position.X, precision: 6);
+        Assert.Equal(0, player.Position.Y, precision: 6);
+
+        // Then move down for half a second (30 frames) → 48 px down.
+        for (var frame = 0; frame < 30; frame++)
+        {
+            player.Move(down, speedFactor: 1, dt);
+        }
+
+        Assert.Equal(96, player.Position.X, precision: 6);
+        Assert.Equal(48, player.Position.Y, precision: 6);
+    }
+}


### PR DESCRIPTION
Closes #9

## Summary

Implements `Player` as a thin, testable wrapper that **composes** a `Character` (composition, no inheritance) and is moved by the engine when it receives input events.

### `Player` (RPGEngine)
- `Character` get/set — the underlying composed character.
- `Position` / `Direction` — convenience pass-throughs forwarding to `Character`.
- `SpriteSheets` — returns the **same** `IList<SpriteSheetRef>` instance as `Character.SpriteSheets` (sheet name + 1-based character index 1..8), so `player.SpriteSheets.Add(new SpriteSheetRef("hero_body", 3))` is equivalent to configuring `player.Character.SpriteSheets`.
- `Move(direction, speedFactor = 1, dt = 1)` and `Move(speedFactor = 1, dt = 1)` — forward to `Character.Move`.
- Constructors:
  - `Player()` — creates its own `Character` with a documented default `BaseSpeed` of **96 px/s** (one 48 px tile per half second), exposed as `Player.DefaultBaseSpeed`, so `GameEngine.Player` works out of the box.
  - `Player(Character character)` — wraps an existing character.
- Movement contract: `Player` does not listen to input itself; the engine owns the pressed-keys state and drives the player via `Move(direction, 1, dt)` in `Update(dt)`.

### `PlayerTests` (tests/RPGEngine.Tests)
12 tests covering all 6 acceptance criteria:
1. Parameterless ctor creates a non-null `Character` (with the default `BaseSpeed`); `Character` is settable.
2. `Position` / `Direction` read/write forward to the `Character`.
3. `SpriteSheets` is the same list instance as `Character.SpriteSheets`; adding a `SpriteSheetRef` (character index 3) via the player is visible on the character.
4. `Move(d, factor, dt)` moves the underlying `Character` exactly `BaseSpeed × factor × dt` and updates its `Direction`.
5. `Move(factor, dt)` without a direction reuses the character's previous direction.
6. A player driven like the engine (Config-derived direction, `Move(direction, 1, 1/60)` each frame) tracks the expected path.

Verified locally: `dotnet build RPGEngine.sln -c Release` → 0 warnings / 0 errors; `dotnet test RPGEngine.sln -c Release` → 128 passed (116 existing + 12 new).

Run: `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~PlayerTests"`