### PR TITLE
Story 21: 8-direction (diagonal) movement and speed-scaled walk-cycle animation

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -17,7 +17,7 @@ Player ── Character (Position, Direction, BaseSpeed, SpriteSheets, walk-cycl
 the in-world state lives on `Character`:
 
 - `Character.Position` — top-left world pixel position of the 48×48 sprite.
-- `Character.Direction` — the facing direction (Down/Left/Right/Up).
+- `Character.Direction` — the facing direction (8 directions: Down/Left/Right/Up plus the four diagonals).
 - `Character.BaseSpeed` — movement speed in pixels per second.
 - `Character.SpriteSheets` — the list of `SpriteSheetRef`s (sheet name + 1..8 character index).
 - `Character.Update(dt)` — advances the walk-cycle animation (internal).
@@ -76,8 +76,10 @@ charRow = (i - 1) / 4
 ```
 
 Its cell `(frame, direction)` is at column `charCol * 3 + frame` and row
-`charRow * 4 + (int)direction`, where the direction rows are
-`0 = Down`, `1 = Left`, `2 = Right`, `3 = Up`.
+`charRow * 4 + direction.RowIndex()`, where the direction rows are
+`0 = Down`, `1 = Left`, `2 = Right`, `3 = Up`. Diagonal directions have no dedicated row and
+fall back to their horizontal component's row (`DownLeft`/`UpLeft` → 1, `DownRight`/`UpRight`
+→ 2), so a diagonally-facing character renders with the side-view row.
 
 A `SpriteSheetRef(Name, CharacterIndex)` pairs a loaded sheet name with one of the **8
 characters** in that sheet. The index is enforced (1..8) where the reference is consumed — at
@@ -131,8 +133,15 @@ guard.SpriteSheets.Add(new SpriteSheetRef("guard_head", CharacterIndex: 3));
 
 ## Movement and input
 
-Movement input uses **last-pressed wins** priority: when several bound keys are held, the
-direction of the most recently pressed key is used. Horizontal and vertical movement are never
-combined — the player moves along one axis per frame. When no bound key is held the player
-stops and the animation snaps back to the standing frame. The engine reads `GameConfig` at input
-time and never caches a snapshot.
+Movement input combines every held bound key into a single **8-direction vector**: each key that
+is bound to a movement direction (via `GameConfig.GetDirection`) contributes its unit delta, the
+deltas are summed, normalized and quantized to the nearest of the eight `Direction` values.
+Opposite keys cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal
+(`W`+`D` → up-right) at the same speed as cardinal movement (the diagonal deltas are
+normalized, magnitude 1). When no bound key is held the player stops and the animation snaps back
+to the standing frame. The engine reads `GameConfig` at input time and never caches a snapshot.
+
+The walk-cycle animation is **time-based and speed-scaled**: `Character.Update(dt)` advances the
+walk cycle at a rate proportional to `BaseSpeed` and `AnimationCycleSpeed`, so at
+`BaseSpeed == AnimationCycleSpeed == 96` the cycle (`0 → 1 → 2 → 1`) completes exactly
+once per second.

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -2,8 +2,8 @@
 
 Namespace: `RPGEngine` — a character present in the game world (the player or an NPC).
 
-`Character` holds the position, facing direction, movement speed, the walk-cycle animation state
-and the list of spritesheet references used to render it.
+`Character` holds the position, facing direction (8 directions, cardinal + diagonal), movement
+speed, the walk-cycle animation state and the list of spritesheet references used to render it.
 
 ## Remarks
 
@@ -39,6 +39,22 @@ Gets or sets the movement speed of the character in pixels per second.
 
 ```csharp
 var character = new Character { BaseSpeed = 96 };
+```
+
+### `double AnimationCycleSpeed`
+
+Gets or sets the movement speed (px/s) at which the walk cycle completes exactly one full cycle
+per second. Defaults to 96 (matching the player's default `BaseSpeed`).
+
+The walk cycle is the bounce `0 → 1 → 2 → 1`, i.e. 4 frame steps. The time per frame is
+`secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)`, so at
+`BaseSpeed == AnimationCycleSpeed == 96` one frame lasts 0.25 s (4 frames/s = 1 cycle/s).
+Doubling the movement speed doubles the cycle rate; halving it halves it. Raising this property
+(the reference speed) slows the animation relative to movement speed.
+
+```csharp
+var character = new Character { BaseSpeed = 96, AnimationCycleSpeed = 96 };
+// One full walk cycle (0 → 1 → 2 → 1) completes every second.
 ```
 
 ### `IList<SpriteSheetRef> SpriteSheets`

--- a/docs/api/Direction.md
+++ b/docs/api/Direction.md
@@ -1,10 +1,12 @@
 # Direction
 
-Namespace: `RPGEngine` — the four facing directions used throughout the engine.
+Namespace: `RPGEngine` — the eight facing directions used throughout the engine.
 
-The numeric values match the RPG Maker MZ character sheet row order
-(`0 = down`, `1 = left`, `2 = right`, `3 = up`). This is the single source of truth used by
-sprite cropping and rendering; see `DirectionExtensions.RowIndex`.
+The cardinal values match the RPG Maker MZ character sheet row order
+(`0 = down`, `1 = left`, `2 = right`, `3 = up`); the diagonal values follow them and have no
+dedicated sprite-sheet row — a diagonally-facing character renders with the side-view row of its
+horizontal component (see `DirectionExtensions.RowIndex`). This is the single source of truth
+used by sprite cropping and rendering.
 
 ## Values
 
@@ -14,10 +16,15 @@ sprite cropping and rendering; see `DirectionExtensions.RowIndex`.
 | `Left` | 1 | 1 | Facing left. |
 | `Right` | 2 | 2 | Facing right. |
 | `Up` | 3 | 3 | Facing up. |
+| `DownLeft` | 4 | 1 (side view) | Facing down-left. |
+| `DownRight` | 5 | 2 (side view) | Facing down-right. |
+| `UpLeft` | 6 | 1 (side view) | Facing up-left. |
+| `UpRight` | 7 | 2 (side view) | Facing up-right. |
 
 ## Example
 
 ```csharp
-var direction = Direction.Down;
-Console.WriteLine((int)direction); // 0 — row 0 of an RPG Maker MZ sheet
+var direction = Direction.UpRight;
+Console.WriteLine((int)direction); // 7
+Console.WriteLine(direction.RowIndex()); // 2 — falls back to the Right (side-view) row
 ```

--- a/docs/api/DirectionExtensions.md
+++ b/docs/api/DirectionExtensions.md
@@ -8,47 +8,67 @@ opposites, sprite-sheet row indices and axis classification.
 ### `Vector2 Delta(this Direction d)`
 
 Returns the screen-space unit delta for the direction. Screen coordinates grow Y downward, so
-`Down` is `(0, +1)` and `Up` is `(0, -1)`. Throws `ArgumentOutOfRangeException` for an undefined
-direction.
+`Down` is `(0, +1)` and `Up` is `(0, -1)`. Diagonal deltas are **normalized** (magnitude 1, not
+√2), so diagonal movement is exactly as fast as cardinal movement. Throws
+`ArgumentOutOfRangeException` for an undefined direction.
 
 ```csharp
-Console.WriteLine(Direction.Up.Delta());    // (0, -1)
-Console.WriteLine(Direction.Right.Delta()); // (1, 0)
+Console.WriteLine(Direction.Up.Delta());       // (0, -1)
+Console.WriteLine(Direction.Right.Delta());    // (1, 0)
+Console.WriteLine(Direction.UpRight.Delta());  // (0.7071, -0.7071) — normalized diagonal
 ```
 
 ### `Direction Opposite(this Direction d)`
 
-Returns the opposite direction (`Down` ↔ `Up`, `Left` ↔ `Right`). Throws
-`ArgumentOutOfRangeException` for an undefined direction.
+Returns the opposite direction (`Down` ↔ `Up`, `Left` ↔ `Right`, `DownLeft` ↔ `UpRight`,
+`DownRight` ↔ `UpLeft`). Throws `ArgumentOutOfRangeException` for an undefined direction.
 
 ```csharp
-Console.WriteLine(Direction.Up.Opposite()); // Down
+Console.WriteLine(Direction.Up.Opposite());     // Down
+Console.WriteLine(Direction.UpRight.Opposite()); // DownLeft
 ```
 
 ### `int RowIndex(this Direction d)`
 
 Returns the RPG Maker MZ character sheet row for this direction (`0 = down`, `1 = left`,
-`2 = right`, `3 = up`). It always equals the enum value; it is exposed explicitly to guard the
-sprite-row contract.
+`2 = right`, `3 = up`). Cardinal directions return their enum value; diagonal directions
+deliberately fall back to their **horizontal** component's row (`DownLeft`/`UpLeft` → 1,
+`DownRight`/`UpRight` → 2) so a diagonally-facing character renders with the side-view row,
+which reads better than the front or back rows for an oblique facing.
 
 ```csharp
-Console.WriteLine(Direction.Up.RowIndex()); // 3
+Console.WriteLine(Direction.Up.RowIndex());     // 3
+Console.WriteLine(Direction.UpRight.RowIndex()); // 2 — the Right (side-view) row
 ```
 
 ### `bool IsHorizontal(this Direction d)`
 
-Returns whether the direction is horizontal (`Left` or `Right`).
+Returns whether the direction is horizontal (`Left` or `Right`). Diagonals are neither
+horizontal nor vertical.
 
 ```csharp
 Console.WriteLine(Direction.Left.IsHorizontal());  // True
 Console.WriteLine(Direction.Up.IsHorizontal());    // False
+Console.WriteLine(Direction.UpRight.IsHorizontal()); // False
 ```
 
 ### `bool IsVertical(this Direction d)`
 
-Returns whether the direction is vertical (`Down` or `Up`).
+Returns whether the direction is vertical (`Down` or `Up`). Diagonals are neither horizontal nor
+vertical.
 
 ```csharp
 Console.WriteLine(Direction.Left.IsVertical());  // False
 Console.WriteLine(Direction.Up.IsVertical());    // True
+Console.WriteLine(Direction.UpRight.IsVertical()); // False
+```
+
+### `bool IsDiagonal(this Direction d)`
+
+Returns whether the direction is one of the four diagonal directions (`DownLeft`, `DownRight`,
+`UpLeft` or `UpRight`).
+
+```csharp
+Console.WriteLine(Direction.UpRight.IsDiagonal()); // True
+Console.WriteLine(Direction.Up.IsDiagonal());      // False
 ```

--- a/docs/api/GameConfig.md
+++ b/docs/api/GameConfig.md
@@ -64,6 +64,23 @@ Direction? up = config.GetDirection(Key.W);   // Direction.Up
 Direction? none = config.GetDirection(Key.Q); // null
 ```
 
+### `Direction? GetMovementDirection(IEnumerable<Key> pressedKeys)`
+
+Returns the movement direction to use for the given set of currently pressed keys, or `null`
+when no movement should happen (no bound key, or the bound directions cancel out, e.g. Up+Down
+or Left+Right held together).
+
+Every pressed key bound to a movement direction contributes its unit delta; the deltas are
+summed, normalized and quantized to the **nearest of the eight `Direction` values** by dot
+product against each direction's unit delta. This is what makes diagonal movement work: `W`+`D`
+resolves to `UpRight`, while `W`+`A`+`D` resolves to `Up` because A and D cancel.
+
+```csharp
+var config = new GameConfig();
+Direction? diagonal = config.GetMovementDirection([Key.W, Key.D]); // UpRight
+Direction? cancelled = config.GetMovementDirection([Key.W, Key.S]); // null
+```
+
 ## Example: rebinding and uniqueness
 
 ```csharp

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -16,7 +16,9 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   SkiaSharp GL view or a WebAssembly `SKSurface` created from a `GRContext`), the drawing is
   hardware accelerated. The engine has **zero platform-specific dependencies**.
 - The camera is internal: `Render` follows the player and clamps the viewport inside the map.
-- Movement input uses *last-pressed wins* priority (see [Architecture](../Architecture.md)).
+- Movement input combines every held bound key into a single 8-direction vector: opposite keys
+  cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
+  at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
 - Tile sets are not loaded through the engine: a `TileMap` owns the tilesets its layers
   reference. Standalone tilesets are loaded directly through the `TileSet.Load` factories.
 
@@ -77,9 +79,10 @@ engine.Config.UpKey = Key.Up; // rebind movement up to the up-arrow key
 ### `void Input(Key key, bool isPressed)`
 
 Reports a key event to the engine. `true` presses the key; `false` releases it. The engine keeps
-a set of currently pressed keys and derives the movement direction in `Update` via `GameConfig`.
-Host applications translate their framework's key events to a `Key` value before calling this
-method.
+a set of currently pressed keys and derives the movement direction in `Update` via
+`GameConfig.GetMovementDirection`, which combines all held bound keys into one of the eight
+directions. Host applications translate their framework's key events to a `Key` value before
+calling this method.
 
 ```csharp
 engine.Input(Key.D, isPressed: true);   // key-down

--- a/docs/api/SpriteSheet.md
+++ b/docs/api/SpriteSheet.md
@@ -58,7 +58,9 @@ Returns the 48×48 sprite at `(direction, frame)` for the character `characterIn
 `ArgumentOutOfRangeException` when `characterIndex` is outside 1..8 or `frame` is outside 0..2.
 
 Character `i` is located at `charCol = (i - 1) % 4`, `charRow = (i - 1) / 4`; its cell
-`(frame, direction)` is at column `charCol * 3 + frame` and row `charRow * 4 + (int)direction`.
+`(frame, direction)` is at column `charCol * 3 + frame` and row `charRow * 4 + direction.RowIndex()`.
+Row selection uses `DirectionExtensions.RowIndex`, so diagonal directions (which have no dedicated
+sheet row) fall back to the side-view row of their horizontal component.
 
 ```csharp
 using var sprite = sheet.GetSprite(characterIndex: 1, Direction.Down, frame: 1);

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -29,11 +29,18 @@ public sealed class Character
     /// <summary>The middle column of the 3-frame walk cycle: the standing frame in RPG Maker MZ.</summary>
     private const int StandingFrame = 1;
 
+    /// <summary>The number of frame steps in one complete walk cycle: <c>0 &#8594; 1 &#8594; 2 &#8594; 1</c>.</summary>
+    private const int FramesPerCycle = 4;
+
     private readonly CharacterSpriteCompositor _compositor = new();
     private readonly List<SpriteSheetRef> _spriteSheets = [];
 
     private Position _lastUpdatePosition;
     private int _animationFrame = StandingFrame;
+
+    // Accumulated animation time in seconds, used to advance the walk cycle at a rate scaled by
+    // BaseSpeed and AnimationCycleSpeed (see Update). The remainder below a whole frame is kept.
+    private double _animationAccumulator;
 
     // The walk cycle is a bounce: 0 → 1 → 2 → 1 → 0 → ... Starting from the standing frame (1)
     // the first step goes toward 0, then the bounce alternates direction at each end.
@@ -49,6 +56,20 @@ public sealed class Character
     public double BaseSpeed { get; set; }
 
     /// <summary>
+    /// Gets or sets the movement speed (px/s) at which the walk cycle completes exactly one full
+    /// cycle per second. Defaults to 96, matching <see cref="Player.DefaultBaseSpeed"/>.
+    /// </summary>
+    /// <remarks>
+    /// The walk cycle is the bounce <c>0 &#8594; 1 &#8594; 2 &#8594; 1</c>, i.e.
+    /// <see cref="FramesPerCycle"/> frame steps. The time per frame is
+    /// <c>secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)</c>, so at
+    /// <c>BaseSpeed == AnimationCycleSpeed == 96</c> one frame lasts 0.25 s (4 frames/s =
+    /// 1 cycle/s). Doubling the movement speed doubles the cycle rate; halving it halves it.
+    /// Raising this property (the reference speed) slows the animation relative to movement speed.
+    /// </remarks>
+    public double AnimationCycleSpeed { get; set; } = 96;
+
+    /// <summary>
     /// Gets the mutable list of spritesheet references used to render the character. Each entry
     /// pairs a loaded sheet name with the 1-based character index (1..8) within that sheet.
     /// The order of the entries is irrelevant for part sheets: they are composed in the fixed
@@ -58,7 +79,8 @@ public sealed class Character
 
     /// <summary>
     /// Gets the current walk-cycle animation frame (0..2). The middle frame (1) is the standing
-    /// frame. This accessor is internal so tests can verify animation advancement.
+    /// frame. The frame advances on a time/speed basis (see <see cref="Update(double)"/>). This
+    /// accessor is internal so tests can verify animation advancement.
     /// </summary>
     internal int AnimationFrame => _animationFrame;
 
@@ -99,26 +121,42 @@ public sealed class Character
     public void Move(double speedFactor = 1, double dt = 1) => Move(Direction, speedFactor, dt);
 
     /// <summary>
-    /// Advances the walk-cycle animation when the character moved since the previous update,
-    /// otherwise snaps the animation back to the standing frame. Called by the engine's update
-    /// loop once per frame.
+    /// Advances the walk-cycle animation based on elapsed time and movement speed. If the
+    /// character moved since the previous update, the animation accumulator is advanced by
+    /// <paramref name="dt"/> and the number of whole frames due (scaled by
+    /// <see cref="BaseSpeed"/> and <see cref="AnimationCycleSpeed"/>) are stepped, keeping the
+    /// remainder for the next update. If the character did not move, the animation snaps back to
+    /// the standing frame and the accumulator is reset. Called by the engine's update loop once
+    /// per frame.
     /// </summary>
-    /// <param name="dt">The elapsed time in seconds. Animation timing tuning is out of scope for
-    /// this story, so <paramref name="dt"/> is accepted for the engine-loop contract but does not
-    /// affect the frame advancement (one frame per update while moving).</param>
+    /// <param name="dt">The elapsed time in seconds.</param>
     internal void Update(double dt)
     {
         var moved = Position != _lastUpdatePosition;
         _lastUpdatePosition = Position;
 
-        if (moved)
+        if (!moved || BaseSpeed <= 0)
         {
-            AdvanceFrame();
-        }
-        else
-        {
+            // Standing still (or the defensive case of a zero/negative movement speed, which
+            // cannot actually happen): show the standing frame and drop any partially accumulated
+            // animation time so the cycle restarts cleanly on the next move.
             _animationFrame = StandingFrame;
             _frameStep = -1;
+            _animationAccumulator = 0;
+            return;
+        }
+
+        _animationAccumulator += dt;
+
+        // secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle). At
+        // BaseSpeed == AnimationCycleSpeed == 96 this is 0.25 s/frame, i.e. 4 frames/s = 1 cycle/s.
+        var secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle);
+        var framesToAdvance = (int)Math.Floor(_animationAccumulator / secondsPerFrame);
+        _animationAccumulator -= framesToAdvance * secondsPerFrame;
+
+        for (var i = 0; i < framesToAdvance; i++)
+        {
+            AdvanceFrame();
         }
     }
 

--- a/src/RPGEngine/Direction.cs
+++ b/src/RPGEngine/Direction.cs
@@ -1,13 +1,15 @@
 namespace RPGEngine;
 
 /// <summary>
-/// The four facing directions used throughout the engine.
+/// The eight facing directions used throughout the engine.
 /// </summary>
 /// <remarks>
-/// The numeric values match the RPG Maker MZ character sheet row order
-/// (<c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>). This is the single
-/// source of truth used by sprite cropping and rendering; see
-/// <see cref="DirectionExtensions.RowIndex"/>.
+/// The cardinal values match the RPG Maker MZ character sheet row order
+/// (<c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>) and the diagonal values
+/// follow them (<c>4..7</c>). Diagonals have no dedicated sprite-sheet row: a diagonally-facing
+/// character renders with the side-view row of its horizontal component (see
+/// <see cref="DirectionExtensions.RowIndex"/>). This enum is the single source of truth used by
+/// sprite cropping and rendering.
 /// </remarks>
 public enum Direction
 {
@@ -22,4 +24,16 @@ public enum Direction
 
     /// <summary>Facing up (row 3 of an RPG Maker MZ character sheet).</summary>
     Up = 3,
+
+    /// <summary>Facing down-left (renders with the Left/row-1 sprite).</summary>
+    DownLeft = 4,
+
+    /// <summary>Facing down-right (renders with the Right/row-2 sprite).</summary>
+    DownRight = 5,
+
+    /// <summary>Facing up-left (renders with the Left/row-1 sprite).</summary>
+    UpLeft = 6,
+
+    /// <summary>Facing up-right (renders with the Right/row-2 sprite).</summary>
+    UpRight = 7,
 }

--- a/src/RPGEngine/DirectionExtensions.cs
+++ b/src/RPGEngine/DirectionExtensions.cs
@@ -9,7 +9,8 @@ public static class DirectionExtensions
     /// <summary>
     /// Returns the screen-space unit delta for the direction. Screen coordinates grow Y
     /// downward, so <see cref="Direction.Down"/> is <c>(0, +1)</c> and
-    /// <see cref="Direction.Up"/> is <c>(0, -1)</c>.
+    /// <see cref="Direction.Up"/> is <c>(0, -1)</c>. Diagonal deltas are normalized (magnitude 1,
+    /// not &#8730;2), so diagonal movement is exactly as fast as cardinal movement.
     /// </summary>
     /// <param name="d">The direction.</param>
     /// <returns>The unit vector the direction points to.</returns>
@@ -20,10 +21,20 @@ public static class DirectionExtensions
         Direction.Left => new Vector2(-1, 0),
         Direction.Right => new Vector2(1, 0),
         Direction.Up => new Vector2(0, -1),
+        Direction.DownLeft => new Vector2(-RootHalf, RootHalf),
+        Direction.DownRight => new Vector2(RootHalf, RootHalf),
+        Direction.UpLeft => new Vector2(-RootHalf, -RootHalf),
+        Direction.UpRight => new Vector2(RootHalf, -RootHalf),
         _ => throw new ArgumentOutOfRangeException(nameof(d), d, "Unknown direction."),
     };
 
-    /// <summary>Returns the direction opposite to this one (<see cref="Direction.Down"/> ↔ <see cref="Direction.Up"/>, <see cref="Direction.Left"/> ↔ <see cref="Direction.Right"/>).</summary>
+    /// <summary>
+    /// Returns the direction opposite to this one: <see cref="Direction.Down"/> &#8596;
+    /// <see cref="Direction.Up"/>, <see cref="Direction.Left"/> &#8596;
+    /// <see cref="Direction.Right"/>, <see cref="Direction.DownLeft"/> &#8596;
+    /// <see cref="Direction.UpRight"/> and <see cref="Direction.DownRight"/> &#8596;
+    /// <see cref="Direction.UpLeft"/>.
+    /// </summary>
     /// <param name="d">The direction.</param>
     /// <returns>The opposite direction.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="d"/> is not a defined <see cref="Direction"/>.</exception>
@@ -33,25 +44,61 @@ public static class DirectionExtensions
         Direction.Left => Direction.Right,
         Direction.Right => Direction.Left,
         Direction.Up => Direction.Down,
+        Direction.DownLeft => Direction.UpRight,
+        Direction.DownRight => Direction.UpLeft,
+        Direction.UpLeft => Direction.DownRight,
+        Direction.UpRight => Direction.DownLeft,
         _ => throw new ArgumentOutOfRangeException(nameof(d), d, "Unknown direction."),
     };
 
     /// <summary>
     /// Returns the RPG Maker MZ character sheet row for this direction
-    /// (<c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>). It always equals the
-    /// enum value; it is exposed explicitly to guard the sprite-row contract.
+    /// (<c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>).
     /// </summary>
+    /// <remarks>
+    /// Cardinal directions return their enum value (<c>0..3</c>). Diagonal directions have no
+    /// dedicated sheet row, so they deliberately fall back to their <em>horizontal</em>
+    /// component's row: <see cref="Direction.DownLeft"/> and <see cref="Direction.UpLeft"/> map to
+    /// row 1 (the Left row) and <see cref="Direction.DownRight"/> and
+    /// <see cref="Direction.UpRight"/> map to row 2 (the Right row). A diagonally-facing
+    /// character therefore renders with the side-view row, which reads better than the front or
+    /// back rows for an oblique facing.
+    /// </remarks>
     /// <param name="d">The direction.</param>
     /// <returns>The 0-based sprite-sheet row (0..3).</returns>
-    public static int RowIndex(this Direction d) => (int)d;
+    public static int RowIndex(this Direction d) => d switch
+    {
+        Direction.DownLeft or Direction.UpLeft => 1,
+        Direction.DownRight or Direction.UpRight => 2,
+        _ => (int)d,
+    };
 
-    /// <summary>Returns whether the direction is horizontal (<see cref="Direction.Left"/> or <see cref="Direction.Right"/>).</summary>
+    /// <summary>
+    /// Returns whether the direction is horizontal (<see cref="Direction.Left"/> or
+    /// <see cref="Direction.Right"/>). Diagonals are neither horizontal nor vertical.
+    /// </summary>
     /// <param name="d">The direction.</param>
     /// <returns><see langword="true"/> when the direction is horizontal; otherwise <see langword="false"/>.</returns>
     public static bool IsHorizontal(this Direction d) => d is Direction.Left or Direction.Right;
 
-    /// <summary>Returns whether the direction is vertical (<see cref="Direction.Down"/> or <see cref="Direction.Up"/>).</summary>
+    /// <summary>
+    /// Returns whether the direction is vertical (<see cref="Direction.Down"/> or
+    /// <see cref="Direction.Up"/>). Diagonals are neither horizontal nor vertical.
+    /// </summary>
     /// <param name="d">The direction.</param>
     /// <returns><see langword="true"/> when the direction is vertical; otherwise <see langword="false"/>.</returns>
     public static bool IsVertical(this Direction d) => d is Direction.Down or Direction.Up;
+
+    /// <summary>
+    /// Returns whether the direction is one of the four diagonal directions
+    /// (<see cref="Direction.DownLeft"/>, <see cref="Direction.DownRight"/>,
+    /// <see cref="Direction.UpLeft"/> or <see cref="Direction.UpRight"/>).
+    /// </summary>
+    /// <param name="d">The direction.</param>
+    /// <returns><see langword="true"/> when the direction is diagonal; otherwise <see langword="false"/>.</returns>
+    public static bool IsDiagonal(this Direction d)
+        => d is Direction.DownLeft or Direction.DownRight or Direction.UpLeft or Direction.UpRight;
+
+    /// <summary>The magnitude of a normalized diagonal component: &#8730;&#189; &#8776; 0.7071067811865476.</summary>
+    private const double RootHalf = 0.7071067811865476;
 }

--- a/src/RPGEngine/GameConfig.cs
+++ b/src/RPGEngine/GameConfig.cs
@@ -112,6 +112,68 @@ public sealed class GameConfig
         null;
 
     /// <summary>
+    /// Returns the movement direction to use for the given set of currently pressed keys, or
+    /// <see langword="null"/> when no movement should happen.
+    /// </summary>
+    /// <param name="pressedKeys">The keys currently held down (e.g. the engine's pressed-keys set).</param>
+    /// <returns>
+    /// The movement direction, or <see langword="null"/> when no key is bound to a movement
+    /// direction or the bound directions cancel out (e.g. Up+Down or Left+Right held together).
+    /// </returns>
+    /// <remarks>
+    /// Every pressed key bound to a movement direction (via <see cref="GetDirection(Key)"/>)
+    /// contributes its unit delta; the deltas are summed, normalized and quantized to the nearest
+    /// of the eight <see cref="Direction"/> values by dot product against each direction's unit
+    /// delta. This is what makes diagonal movement work: <c>W</c>+<c>D</c> resolves to
+    /// <see cref="Direction.UpRight"/>, while <c>W</c>+<c>A</c>+<c>D</c> resolves to
+    /// <see cref="Direction.Up"/> because A and D cancel. The configuration is read at input time
+    /// and never cached, so rebinding takes effect immediately.
+    /// </remarks>
+    public Direction? GetMovementDirection(IEnumerable<Key> pressedKeys)
+    {
+        ArgumentNullException.ThrowIfNull(pressedKeys);
+
+        var sum = new Vector2(0, 0);
+        var hasBoundKey = false;
+
+        foreach (var key in pressedKeys)
+        {
+            var direction = GetDirection(key);
+            if (direction.HasValue)
+            {
+                sum += direction.Value.Delta();
+                hasBoundKey = true;
+            }
+        }
+
+        if (!hasBoundKey || (sum.X == 0 && sum.Y == 0))
+        {
+            return null;
+        }
+
+        // Normalize the combined vector, then pick the direction whose unit delta is closest
+        // (largest dot product). For key input the sum always lands exactly on one of the eight
+        // directions, but the dot product makes the quantization robust for arbitrary vectors.
+        var length = Math.Sqrt((sum.X * sum.X) + (sum.Y * sum.Y));
+        var normalized = new Vector2(sum.X / length, sum.Y / length);
+
+        Direction? best = null;
+        var bestDot = double.NegativeInfinity;
+        foreach (var direction in Enum.GetValues<Direction>())
+        {
+            var delta = direction.Delta();
+            var dot = (normalized.X * delta.X) + (normalized.Y * delta.Y);
+            if (dot > bestDot)
+            {
+                bestDot = dot;
+                best = direction;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
     /// Throws <see cref="ArgumentException"/> when <paramref name="key"/> is
     /// already bound to a movement direction other than
     /// <paramref name="direction"/>.

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -30,12 +30,11 @@ namespace RPGEngine;
 /// without breaking this class's API.
 /// </para>
 /// <para>
-/// Movement input uses <em>last-pressed wins</em> priority: when several bound keys are held, the
-/// direction of the most recently pressed key is used (so pressing a new direction takes over
-/// even while another key is still held, and releasing it reverts to the previous still-held
-/// key). Horizontal and vertical movement are never combined — the player moves along one axis
-/// per frame. When no bound key is held the player stops and its animation snaps back to the
-/// standing frame.
+/// Movement input combines every held bound key into a single 8-direction vector: each key that
+/// is bound to a movement direction contributes its unit delta, opposite keys cancel
+/// (<c>W</c>+<c>S</c> or <c>A</c>+<c>D</c>), and the resulting direction can be diagonal
+/// (<c>W</c>+<c>D</c> resolves to up-right). When no bound key is held the player stops and its
+/// animation snaps back to the standing frame.
 /// </para>
 /// <para>
 /// Tile sets are not loaded through the engine: a <see cref="TileMap"/> owns the tilesets that
@@ -48,7 +47,6 @@ public sealed class GameEngine
     private readonly SpriteSheetManager _spriteSheetManager = new();
     private readonly List<Character> _characters = [];
     private readonly HashSet<Key> _pressedKeys = [];
-    private readonly List<Key> _pressedKeyOrder = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameEngine"/> class with default state: a
@@ -102,15 +100,11 @@ public sealed class GameEngine
     {
         if (isPressed)
         {
-            if (_pressedKeys.Add(key))
-            {
-                // Remember the press order so Update can resolve "last-pressed wins".
-                _pressedKeyOrder.Add(key);
-            }
+            _pressedKeys.Add(key);
         }
-        else if (_pressedKeys.Remove(key))
+        else
         {
-            _pressedKeyOrder.Remove(key);
+            _pressedKeys.Remove(key);
         }
     }
 
@@ -122,7 +116,7 @@ public sealed class GameEngine
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
     public void Update(double dt)
     {
-        var direction = GetActiveDirection();
+        var direction = Config.GetMovementDirection(_pressedKeys);
         if (direction.HasValue)
         {
             Player.Move(direction.Value, speedFactor: 1, dt);
@@ -288,25 +282,6 @@ public sealed class GameEngine
         var desiredY = Player.Position.Y - (canvasHeight / 2.0);
 
         return new Position(Math.Clamp(desiredX, 0, maxX), Math.Clamp(desiredY, 0, maxY));
-    }
-
-    /// <summary>
-    /// Returns the movement direction to use this frame, or <see langword="null"/> when no bound
-    /// key is currently pressed. Uses last-pressed-wins priority: the most recently pressed key
-    /// (that is still held and is bound to a movement direction) wins.
-    /// </summary>
-    private Direction? GetActiveDirection()
-    {
-        for (var i = _pressedKeyOrder.Count - 1; i >= 0; i--)
-        {
-            var direction = Config.GetDirection(_pressedKeyOrder[i]);
-            if (direction.HasValue)
-            {
-                return direction;
-            }
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/src/RPGEngine/Sprites/SpriteSheet.cs
+++ b/src/RPGEngine/Sprites/SpriteSheet.cs
@@ -81,7 +81,9 @@ public sealed class SpriteSheet
     /// the character <paramref name="characterIndex"/> (1-based) within the sheet.
     /// </summary>
     /// <param name="characterIndex">The 1-based index (1..8) of the character in the sheet.</param>
-    /// <param name="direction">The direction (down/left/right/up) the sprite faces.</param>
+    /// <param name="direction">The direction the sprite faces. Cardinal directions map to
+    /// their own sheet row; diagonal directions map to the side-view row of their horizontal
+    /// component (see <see cref="DirectionExtensions.RowIndex"/>).</param>
     /// <param name="frame">The animation frame (0..2).</param>
     /// <returns>
     /// An <see cref="SKImage"/> cropped from the decoded source. The caller owns and disposes it.
@@ -92,7 +94,7 @@ public sealed class SpriteSheet
     /// <remarks>
     /// Character <c>i</c> is located at <c>charCol = (i - 1) % 4</c>, <c>charRow = (i - 1) / 4</c>;
     /// its cell <c>(frame, direction)</c> is at column <c>charCol * 3 + frame</c> and row
-    /// <c>charRow * 4 + (int)direction</c>.
+    /// <c>charRow * 4 + direction.RowIndex()</c>.
     /// <para>
     /// The returned image is an independent 48×48 raster crop of the decoded source, produced
     /// with nearest-neighbour sampling (a 1:1 pixel copy, never a re-encode). We deliberately
@@ -122,7 +124,7 @@ public sealed class SpriteSheet
         var charCol = (characterIndex - 1) % CharactersPerRow;
         var charRow = (characterIndex - 1) / CharactersPerRow;
         var col = (charCol * FramesPerCharacter) + frame;
-        var row = (charRow * DirectionsPerCharacter) + (int)direction;
+        var row = (charRow * DirectionsPerCharacter) + direction.RowIndex();
 
         var source = new SKRectI(
             col * CellSize,

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -81,39 +81,104 @@ public class CharacterTests
     }
 
     // ---------------------------------------------------------------------
+    // Acceptance 2b (story 21): diagonal movement moves the normalized distance
+    // (magnitude 1, not √2) and sets the diagonal Direction.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Move(DownRight, 1, 1) at BaseSpeed 100 moves exactly (100·√½, 100·√½) and sets Direction to DownRight.</summary>
+    [Fact]
+    public void Move_Diagonal_MovesNormalizedDistance_AndSetsDirection()
+    {
+        var character = new Character { BaseSpeed = 100, Position = new Position(0, 0) };
+
+        character.Move(Direction.DownRight, speedFactor: 1, dt: 1);
+
+        // DownRight = (+√½, +√½); 100 px of travel split evenly across the two axes.
+        var component = 100 * Math.Sqrt(0.5);
+        Assert.Equal(component, character.Position.X, precision: 9);
+        Assert.Equal(component, character.Position.Y, precision: 9);
+        Assert.Equal(Direction.DownRight, character.Direction);
+    }
+
+    // ---------------------------------------------------------------------
     // Acceptance 4: Update advances frames only while moving.
     // ---------------------------------------------------------------------
     /// <summary>
-    /// Verifies the walk-cycle animation advances 0 → 1 → 2 → 1 → 0 only while the character
-    /// moves, and snaps back to the standing frame (1) once it stops.
+    /// Verifies the walk-cycle animation is time-based and speed-scaled: at
+    /// BaseSpeed == AnimationCycleSpeed == 96 the cycle completes one full 4-frame cycle
+    /// (<c>0 → 1 → 2 → 1</c>) per second. A single one-second <see cref="Character.Update(double)"/>
+    /// after moving advances exactly 4 frames and lands back on the standing frame.
     /// </summary>
     [Fact]
-    public void Update_AdvancesWalkCycleOnlyWhileMoving()
+    public void Update_AtBaseSpeed96_MoveOnceThenOneSecondUpdate_CompletesOneCycle()
     {
-        var character = new Character { BaseSpeed = 1 };
+        var character = new Character { BaseSpeed = 96 };
 
         // A fresh character stands on the middle (standing) frame and stays there when idle.
         Assert.Equal(StandingFrame, character.AnimationFrame);
         character.Update(dt: 1);
         Assert.Equal(StandingFrame, character.AnimationFrame);
 
-        // Walk cycle while moving: 0 → 1 → 2 → 1 → 0.
-        MoveAndUpdate(character, Direction.Down);
+        // Move once, then update for one full second: 4 frames (0.25 s each) advance through
+        // 0 → 1 → 2 → 1 and land back on the standing frame.
+        character.Move(Direction.Down, speedFactor: 1, dt: 1);
+        character.Update(dt: 1);
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+    }
+
+    /// <summary>
+    /// Verifies the walk-cycle advances frames per second proportionally to BaseSpeed: the frame
+    /// sequence over one second is revealed by moving + updating at the exact per-frame duration.
+    /// </summary>
+    [Theory]
+    [InlineData(96, new[] { 0, 1, 2, 1 })]                 // 0.25 s/frame → 4 frames/s → 1 cycle/s
+    [InlineData(192, new[] { 0, 1, 2, 1, 0, 1, 2, 1 })]    // 0.125 s/frame → 8 frames/s → 2 cycles/s
+    [InlineData(48, new[] { 0, 1 })]                       // 0.5 s/frame → 2 frames/s → 1/2 cycle/s
+    public void Update_WalkCycle_AdvancesFramesPerSecondScaledByBaseSpeed(double baseSpeed, int[] expectedFrames)
+    {
+        var character = new Character { BaseSpeed = baseSpeed };
+        var secondsPerFrame = 1.0 / expectedFrames.Length;
+
+        var actualFrames = new int[expectedFrames.Length];
+        for (var i = 0; i < expectedFrames.Length; i++)
+        {
+            MoveAndUpdate(character, Direction.Down, secondsPerFrame);
+            actualFrames[i] = character.AnimationFrame;
+        }
+
+        Assert.Equal(expectedFrames, actualFrames);
+    }
+
+    /// <summary>Verifies the animation snaps back to the standing frame as soon as the character stops moving.</summary>
+    [Fact]
+    public void Update_WhenNotMoving_SnapsToStandingFrame()
+    {
+        var character = new Character { BaseSpeed = 96 };
+
+        // Advance the cycle while moving.
+        MoveAndUpdate(character, Direction.Down, dt: 0.25);
         Assert.Equal(0, character.AnimationFrame);
 
-        MoveAndUpdate(character, Direction.Down);
-        Assert.Equal(1, character.AnimationFrame);
+        // Stop moving: the next update sees no movement and snaps back to the standing frame.
+        character.Update(dt: 1);
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+    }
 
-        MoveAndUpdate(character, Direction.Down);
-        Assert.Equal(2, character.AnimationFrame);
+    /// <summary>Verifies AnimationCycleSpeed is configurable: doubling it halves the cycle rate relative to BaseSpeed.</summary>
+    [Fact]
+    public void Update_AnimationCycleSpeed_IsConfigurable()
+    {
+        // secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)
+        //                 = 192 / (96 * 4) = 0.5 s/frame → only 2 frames per second.
+        var character = new Character { BaseSpeed = 96, AnimationCycleSpeed = 192 };
 
-        MoveAndUpdate(character, Direction.Down);
-        Assert.Equal(1, character.AnimationFrame);
-
-        MoveAndUpdate(character, Direction.Down);
+        MoveAndUpdate(character, Direction.Down, dt: 0.5);
         Assert.Equal(0, character.AnimationFrame);
 
-        // Once the character stops moving, Update snaps back to the standing frame.
+        MoveAndUpdate(character, Direction.Down, dt: 0.5);
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+
+        // A single one-second update also completes the (2-frame) half-speed cycle.
+        character.Move(Direction.Down, speedFactor: 1, dt: 1);
         character.Update(dt: 1);
         Assert.Equal(StandingFrame, character.AnimationFrame);
     }
@@ -323,11 +388,15 @@ public class CharacterTests
     // Helpers
     // ---------------------------------------------------------------------
 
-    /// <summary>Moves the character one step and updates it, advancing the walk cycle.</summary>
+    /// <summary>Moves the character one step (dt = 1) and updates it, advancing the walk cycle.</summary>
     private static void MoveAndUpdate(Character character, Direction direction)
+        => MoveAndUpdate(character, direction, dt: 1);
+
+    /// <summary>Moves the character for the given <paramref name="dt"/> and updates it, advancing the walk cycle.</summary>
+    private static void MoveAndUpdate(Character character, Direction direction, double dt)
     {
-        character.Move(direction, speedFactor: 1, dt: 1);
-        character.Update(dt: 1);
+        character.Move(direction, speedFactor: 1, dt: dt);
+        character.Update(dt: dt);
     }
 
     /// <summary>Loads the sheets described by the given tuples and returns a fresh manager.</summary>

--- a/tests/RPGEngine.Tests/Core/DirectionTests.cs
+++ b/tests/RPGEngine.Tests/Core/DirectionTests.cs
@@ -5,22 +5,43 @@ namespace RPGEngine.Tests.Core;
 
 /// <summary>
 /// Acceptance tests for <see cref="Direction"/> and <see cref="DirectionExtensions"/>
-/// (story 4: core primitives — Direction and Position).
+/// (stories 4 and 21: core primitives — Direction and Position, plus 8-direction support).
 /// </summary>
 public class DirectionTests
 {
-    /// <summary>Verifies <see cref="DirectionExtensions.Delta"/> returns the correct screen-space unit vector for every direction.</summary>
+    /// <summary>
+    /// Verifies <see cref="DirectionExtensions.Delta"/> returns the correct screen-space unit
+    /// vector for every direction. Cardinal values are exact; diagonal values are normalized
+    /// (each component is ±√½) so their magnitude is 1 and diagonal movement is exactly as fast
+    /// as cardinal movement.
+    /// </summary>
     [Theory]
-    [InlineData(Direction.Down, 0, 1)]
-    [InlineData(Direction.Left, -1, 0)]
-    [InlineData(Direction.Right, 1, 0)]
-    [InlineData(Direction.Up, 0, -1)]
-    public void Delta_IsCorrect_ForAllDirections(Direction direction, double expectedX, double expectedY)
+    [InlineData(Direction.Down, 0, 1, false)]
+    [InlineData(Direction.Left, -1, 0, false)]
+    [InlineData(Direction.Right, 1, 0, false)]
+    [InlineData(Direction.Up, 0, -1, false)]
+    [InlineData(Direction.DownLeft, -1, 1, true)]
+    [InlineData(Direction.DownRight, 1, 1, true)]
+    [InlineData(Direction.UpLeft, -1, -1, true)]
+    [InlineData(Direction.UpRight, 1, -1, true)]
+    public void Delta_IsCorrect_ForAllDirections(Direction direction, int signX, int signY, bool isDiagonal)
     {
         var delta = direction.Delta();
 
-        Assert.Equal(expectedX, delta.X);
-        Assert.Equal(expectedY, delta.Y);
+        if (isDiagonal)
+        {
+            var component = Math.Sqrt(0.5);
+            Assert.Equal(signX * component, delta.X, precision: 9);
+            Assert.Equal(signY * component, delta.Y, precision: 9);
+        }
+        else
+        {
+            Assert.Equal(signX, delta.X);
+            Assert.Equal(signY, delta.Y);
+        }
+
+        // Every delta is a unit vector, so diagonal movement is no faster than cardinal movement.
+        Assert.Equal(1, Magnitude(delta), precision: 9);
     }
 
     /// <summary>Verifies <see cref="DirectionExtensions.Opposite"/> returns the opposite direction for every direction.</summary>
@@ -29,41 +50,80 @@ public class DirectionTests
     [InlineData(Direction.Left, Direction.Right)]
     [InlineData(Direction.Right, Direction.Left)]
     [InlineData(Direction.Up, Direction.Down)]
+    [InlineData(Direction.DownLeft, Direction.UpRight)]
+    [InlineData(Direction.DownRight, Direction.UpLeft)]
+    [InlineData(Direction.UpLeft, Direction.DownRight)]
+    [InlineData(Direction.UpRight, Direction.DownLeft)]
     public void Opposite_IsCorrect_ForAllDirections(Direction direction, Direction expected)
     {
         Assert.Equal(expected, direction.Opposite());
     }
 
-    /// <summary>Verifies <see cref="DirectionExtensions.RowIndex"/> equals the RPG Maker MZ sprite-sheet row (0/1/2/3) for Down/Left/Right/Up.</summary>
+    /// <summary>
+    /// Verifies <see cref="DirectionExtensions.RowIndex"/> equals the RPG Maker MZ sprite-sheet
+    /// row (0/1/2/3) for Down/Left/Right/Up and falls back to the horizontal component's row for
+    /// diagonals (DownLeft/UpLeft → 1, DownRight/UpRight → 2) so a diagonally-facing character
+    /// renders with the side-view row.
+    /// </summary>
     [Theory]
     [InlineData(Direction.Down, 0)]
     [InlineData(Direction.Left, 1)]
     [InlineData(Direction.Right, 2)]
     [InlineData(Direction.Up, 3)]
+    [InlineData(Direction.DownLeft, 1)]
+    [InlineData(Direction.DownRight, 2)]
+    [InlineData(Direction.UpLeft, 1)]
+    [InlineData(Direction.UpRight, 2)]
     public void RowIndex_EqualsSpriteSheetRow_ForAllDirections(Direction direction, int expectedRow)
     {
         Assert.Equal(expectedRow, direction.RowIndex());
     }
 
-    /// <summary>Verifies <see cref="DirectionExtensions.IsHorizontal"/> distinguishes horizontal from vertical directions.</summary>
+    /// <summary>Verifies <see cref="DirectionExtensions.IsHorizontal"/> distinguishes horizontal from vertical and diagonal directions.</summary>
     [Theory]
     [InlineData(Direction.Down, false)]
     [InlineData(Direction.Left, true)]
     [InlineData(Direction.Right, true)]
     [InlineData(Direction.Up, false)]
+    [InlineData(Direction.DownLeft, false)]
+    [InlineData(Direction.DownRight, false)]
+    [InlineData(Direction.UpLeft, false)]
+    [InlineData(Direction.UpRight, false)]
     public void IsHorizontal_IsCorrect_ForAllDirections(Direction direction, bool expected)
     {
         Assert.Equal(expected, direction.IsHorizontal());
     }
 
-    /// <summary>Verifies <see cref="DirectionExtensions.IsVertical"/> distinguishes vertical from horizontal directions.</summary>
+    /// <summary>Verifies <see cref="DirectionExtensions.IsVertical"/> distinguishes vertical from horizontal and diagonal directions.</summary>
     [Theory]
     [InlineData(Direction.Down, true)]
     [InlineData(Direction.Left, false)]
     [InlineData(Direction.Right, false)]
     [InlineData(Direction.Up, true)]
+    [InlineData(Direction.DownLeft, false)]
+    [InlineData(Direction.DownRight, false)]
+    [InlineData(Direction.UpLeft, false)]
+    [InlineData(Direction.UpRight, false)]
     public void IsVertical_IsCorrect_ForAllDirections(Direction direction, bool expected)
     {
         Assert.Equal(expected, direction.IsVertical());
     }
+
+    /// <summary>Verifies <see cref="DirectionExtensions.IsDiagonal"/> is true for the four diagonals and false for the cardinals.</summary>
+    [Theory]
+    [InlineData(Direction.Down, false)]
+    [InlineData(Direction.Left, false)]
+    [InlineData(Direction.Right, false)]
+    [InlineData(Direction.Up, false)]
+    [InlineData(Direction.DownLeft, true)]
+    [InlineData(Direction.DownRight, true)]
+    [InlineData(Direction.UpLeft, true)]
+    [InlineData(Direction.UpRight, true)]
+    public void IsDiagonal_IsCorrect_ForAllDirections(Direction direction, bool expected)
+    {
+        Assert.Equal(expected, direction.IsDiagonal());
+    }
+
+    /// <summary>Returns the Euclidean magnitude of <paramref name="v"/>.</summary>
+    private static double Magnitude(Vector2 v) => Math.Sqrt((v.X * v.X) + (v.Y * v.Y));
 }

--- a/tests/RPGEngine.Tests/Core/GameConfigTests.cs
+++ b/tests/RPGEngine.Tests/Core/GameConfigTests.cs
@@ -196,6 +196,86 @@ public class GameConfigTests
         Assert.Null(config.GetDirection(Key.D));
     }
 
+    // ---------------------------------------------------------------------
+    // Acceptance 5 (story 21): GetMovementDirection combines the held bound
+    // keys into a single 8-direction vector.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a single bound key resolves to its cardinal direction (W → Up).</summary>
+    [Fact]
+    public void GetMovementDirection_SingleKey_ReturnsItsCardinalDirection()
+    {
+        var config = new GameConfig();
+
+        Assert.Equal(Direction.Up, config.GetMovementDirection([Key.W]));
+    }
+
+    /// <summary>Verifies two perpendicular keys combine into a diagonal (W+D → UpRight).</summary>
+    [Fact]
+    public void GetMovementDirection_TwoPerpendicularKeys_ReturnsDiagonal()
+    {
+        var config = new GameConfig();
+
+        Assert.Equal(Direction.UpRight, config.GetMovementDirection([Key.W, Key.D]));
+    }
+
+    /// <summary>Verifies opposite keys cancel out and produce no movement (W+S → null).</summary>
+    [Fact]
+    public void GetMovementDirection_OppositeKeys_CancelToNull()
+    {
+        var config = new GameConfig();
+
+        Assert.Null(config.GetMovementDirection([Key.W, Key.S]));
+        Assert.Null(config.GetMovementDirection([Key.A, Key.D]));
+    }
+
+    /// <summary>Verifies a cancelling horizontal pair leaves the vertical direction (W+A+D → Up).</summary>
+    [Fact]
+    public void GetMovementDirection_ThreeKeysWithCancellingHorizontalPair_ReturnsVertical()
+    {
+        var config = new GameConfig();
+
+        Assert.Equal(Direction.Up, config.GetMovementDirection([Key.W, Key.A, Key.D]));
+    }
+
+    /// <summary>Verifies an empty pressed set produces no movement.</summary>
+    [Fact]
+    public void GetMovementDirection_EmptySet_ReturnsNull()
+    {
+        var config = new GameConfig();
+
+        Assert.Null(config.GetMovementDirection(Array.Empty<Key>()));
+    }
+
+    /// <summary>Verifies keys not bound to any movement direction are ignored.</summary>
+    [Fact]
+    public void GetMovementDirection_UnmappedKeysAreIgnored()
+    {
+        var config = new GameConfig();
+
+        Assert.Null(config.GetMovementDirection([Key.Space]));
+        Assert.Equal(Direction.Up, config.GetMovementDirection([Key.W, Key.Space]));
+    }
+
+    /// <summary>Verifies diagonal resolution respects rebinding (Z+D → UpRight after UpKey = Z).</summary>
+    [Fact]
+    public void GetMovementDirection_RespectsRebinding()
+    {
+        var config = new GameConfig();
+        config.UpKey = Key.Z;
+
+        Assert.Equal(Direction.Up, config.GetMovementDirection([Key.Z]));
+        Assert.Equal(Direction.UpRight, config.GetMovementDirection([Key.Z, Key.D]));
+    }
+
+    /// <summary>Verifies GetMovementDirection rejects a null pressed-keys argument.</summary>
+    [Fact]
+    public void GetMovementDirection_NullArgument_ThrowsArgumentNullException()
+    {
+        var config = new GameConfig();
+
+        Assert.Throws<ArgumentNullException>(() => config.GetMovementDirection(null!));
+    }
+
     private static void Set(GameConfig config, string propertyName, Key key)
     {
         switch (propertyName)

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -202,7 +202,7 @@ public class DocsExamplesTests
         Assert.Equal(5, distance, precision: 10);
     }
 
-    /// <summary>Verifies the Direction extension examples (deltas, opposites, rows).</summary>
+    /// <summary>Verifies the Direction extension examples (deltas, opposites, rows, diagonals).</summary>
     [Fact]
     public void Direction_DeltasOppositesAndRows()
     {
@@ -211,6 +211,17 @@ public class DocsExamplesTests
         Assert.Equal(3, Direction.Up.RowIndex()); // RPG Maker MZ row 3
         Assert.True(Direction.Left.IsHorizontal());
         Assert.False(Direction.Left.IsVertical());
+
+        // Diagonal support: normalized delta, diagonal opposite, side-view row fallback and the
+        // IsDiagonal classification.
+        var upRight = Direction.UpRight.Delta();
+        Assert.Equal(Math.Sqrt(0.5), upRight.X, precision: 9);
+        Assert.Equal(-Math.Sqrt(0.5), upRight.Y, precision: 9);
+        Assert.Equal(Direction.DownLeft, Direction.UpRight.Opposite());
+        Assert.Equal(2, Direction.UpRight.RowIndex()); // falls back to the Right (side-view) row
+        Assert.True(Direction.UpRight.IsDiagonal());
+        Assert.False(Direction.UpRight.IsHorizontal());
+        Assert.False(Direction.UpRight.IsVertical());
     }
 
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -246,24 +246,69 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
-    // Additional coverage: the documented last-pressed-wins priority.
+    // Additional coverage (story 21): 8-direction vector-combined movement.
+    // The movement model is no longer last-pressed-wins: holding W+D moves
+    // diagonally, opposite keys cancel, and releasing one key of a held
+    // diagonal pair reverts to the remaining cardinal direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies that when two movement keys are held the most recently pressed one wins, and releasing it reverts to the other.</summary>
+    /// <summary>Verifies holding W+D for one second at 96 px/s moves diagonally up-right (~±67.88 px per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
     [Fact]
-    public void Update_LastPressedKeyWins()
+    public void Update_HoldingDiagonalPair_MovesDiagonallyAndRevertsOnRelease()
+    {
+        var engine = new GameEngine();
+        engine.Player.Character.BaseSpeed = 96;
+        engine.Player.Position = new Position(200, 200);
+
+        engine.Input(Key.W, true);
+        engine.Input(Key.D, true);
+        for (var frame = 0; frame < 60; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // UpRight = (+√½, -√½); one second at 96 px/s → (±96·√½) ≈ (±67.88) per axis.
+        var component = 96 * Math.Sqrt(0.5);
+        Assert.Equal(200 + component, engine.Player.Position.X, precision: 6);
+        Assert.Equal(200 - component, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(Direction.UpRight, engine.Player.Direction);
+
+        // Releasing D reverts to the remaining cardinal direction (straight up).
+        var xAfterDiagonal = engine.Player.Position.X;
+        engine.Input(Key.D, false);
+        engine.Update(FrameDt);
+        Assert.True(engine.Player.Position.Y < 200 - component);
+        Assert.Equal(xAfterDiagonal, engine.Player.Position.X, precision: 6);
+        Assert.Equal(Direction.Up, engine.Player.Direction);
+    }
+
+    /// <summary>Verifies holding opposite keys (W+S) produces no movement.</summary>
+    [Fact]
+    public void Update_OppositeKeysCancel_ProducesNoMovement()
     {
         var engine = new GameEngine();
         engine.Player.Position = new Position(100, 100);
 
-        engine.Input(Key.W, true); // up
-        engine.Input(Key.D, true); // right — most recently pressed
+        engine.Input(Key.W, true);
+        engine.Input(Key.S, true);
         engine.Update(FrameDt);
-        Assert.True(engine.Player.Position.X > 100);
-        Assert.Equal(100, engine.Player.Position.Y, precision: 6);
 
-        // Releasing right reverts to up (still held).
-        engine.Input(Key.D, false);
+        Assert.Equal(new Position(100, 100), engine.Player.Position);
+    }
+
+    /// <summary>Verifies diagonal resolution respects config rebinding (Z+D → UpRight after UpKey = Z).</summary>
+    [Fact]
+    public void Update_DiagonalResolution_RespectsConfigRebinding()
+    {
+        var engine = new GameEngine();
+        engine.Config.UpKey = Key.Z;
+        engine.Player.Position = new Position(100, 100);
+
+        engine.Input(Key.Z, true);
+        engine.Input(Key.D, true);
         engine.Update(FrameDt);
+
+        Assert.Equal(Direction.UpRight, engine.Player.Direction);
+        Assert.True(engine.Player.Position.X > 100);
         Assert.True(engine.Player.Position.Y < 100);
     }
 


### PR DESCRIPTION
Implements [#21](https://github.com/elliottv/rpg-engine/issues/21) — two movement-related adjustments from epic #20:

1. **8-direction (diagonal) movement** — the player/NPCs can move along the four diagonal axes at the same speed as cardinal movement (normalized deltas, magnitude 1, not √2).
2. **Speed-scaled walk-cycle animation** — the walk cycle is now time-based and scales with `BaseSpeed`/`AnimationCycleSpeed`; at `BaseSpeed == AnimationCycleSpeed == 96` it completes one full 4-frame cycle (`0 → 1 → 2 → 1`) per second.

### What changed

- **`Direction`**: added `DownLeft = 4`, `DownRight = 5`, `UpLeft = 6`, `UpRight = 7` after the cardinal RPG Maker MZ rows (0..3 unchanged).
- **`DirectionExtensions`**: diagonals return normalized unit deltas; `Opposite()` covers the diagonal pairs; `RowIndex()` falls back to the horizontal component's row (side view) for diagonals; `IsHorizontal`/`IsVertical` are `false` for diagonals; new `IsDiagonal()`.
- **`SpriteSheet.GetSprite`**: row selection uses `direction.RowIndex()` so a diagonal `Direction` maps to a valid sheet row.
- **`Character`**: new `AnimationCycleSpeed` property (default 96); `Update(dt)` is time-based — while moving it accumulates `dt` and advances `⌊accumulator / secondsPerFrame⌋` frames (`secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * 4)`), keeping the remainder; when not moving it snaps to the standing frame and resets the accumulator (defensive `BaseSpeed <= 0` also stays on the standing frame).
- **`GameConfig`**: new `GetMovementDirection(IEnumerable<Key>)` — sums each bound key's unit delta, returns `null` for an empty/cancelling set, otherwise normalizes and quantizes to the nearest of the 8 directions by dot product (`W`+`D` → `UpRight`, `W`+`A`+`D` → `Up`).
- **`GameEngine`**: `Update(dt)` resolves movement via `Config.GetMovementDirection(_pressedKeys)`; removed the last-pressed-wins machinery (`_pressedKeyOrder`, `GetActiveDirection()`); remarks updated.

### Tests

- Extended `DirectionTests` (deltas/opposites/rows/axis classification for all 8 directions + `IsDiagonal`).
- Added `GameConfigTests.GetMovementDirection` coverage (single key, diagonal pair, cancellation, empty set, unmapped keys, rebinding).
- `CharacterTests`: diagonal `Move` distance, time-based walk-cycle scaling (96→4 frames/s, 192→8, 48→2), standing-frame snap on stop, `AnimationCycleSpeed` configurability.
- `GameEngineTests`: replaced the obsolete `Update_LastPressedKeyWins` with vector-combined diagonal tests (W+D for 1 s ≈ (+67.88, −67.88) with `Direction = UpRight`, releasing D reverts to straight up; W+S produces no movement; rebinding respected).
- Extended `DocsExamplesTests.Direction_DeltasOppositesAndRows` with diagonal assertions.

Docs (`docs/Architecture.md`, `docs/api/*.md`) updated to describe 8-direction vector-combined movement and the time-based animation.

Validation: `dotnet test tests/RPGEngine.Tests` → 203 passed; the acceptance filter (`DirectionTests|GameConfigTests|CharacterTests|GameEngineTests|DocsExamplesTests`) → 130 passed.