### PR TITLE
Story 22: async asset loading from streams (sprites and tilemaps)

### DIFF
--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -155,6 +155,27 @@ using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/charact
 engine.LoadPartSpriteSheet("villager_body", stream, CharacterPartType.Body);
 ```
 
+### `Task LoadSpriteSheetAsync(string name, Stream stream)`
+
+The asynchronous counterpart of `LoadSpriteSheet(string, Stream)` for streams that only support
+asynchronous reads (e.g. certain network/browser streams). The caller remains the owner of the
+stream.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/character_full.png"));
+await engine.LoadSpriteSheetAsync("hero", stream);
+```
+
+### `Task LoadPartSpriteSheetAsync(string name, Stream stream, CharacterPartType partType)`
+
+The asynchronous counterpart of `LoadPartSpriteSheet(string, Stream, CharacterPartType)` for
+streams that only support asynchronous reads. The caller remains the owner of the stream.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/character_part_body.png"));
+await engine.LoadPartSpriteSheetAsync("villager_body", stream, CharacterPartType.Body);
+```
+
 ## Full example ("hello world")
 
 ```csharp

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -42,6 +42,7 @@ documented**. Every page below includes a commented, compilable example; the tes
 | `TileMapLayer` | class | [TileMapLayer.md](TileMapLayer.md) |
 | `TileFlags` | enum (`[Flags]`) | [TileFlags.md](TileFlags.md) |
 | `TiledAssetFetcher` | delegate | [TiledAssetFetcher.md](TiledAssetFetcher.md) |
+| `TiledAssetFetcherAsync` | delegate (async) | [TiledAssetFetcherAsync.md](TiledAssetFetcherAsync.md) |
 
 ## The character index 1..8
 

--- a/docs/api/SpriteSheetManager.md
+++ b/docs/api/SpriteSheetManager.md
@@ -48,6 +48,32 @@ var body = manager.LoadPart("body", "assets/characters/character_part_body.png",
 Loads the part spritesheet of layer `partType` from a stream. The caller remains the owner of
 the stream.
 
+### `Task<SpriteSheet> LoadAsync(string name, Stream stream)`
+
+The asynchronous counterpart of `Load(string, Stream)` for streams that only support
+asynchronous reads (e.g. certain network/browser streams). The name is validated and its
+availability checked before the stream is touched, so a bad name fails without reading it; the
+stream is then copied into memory asynchronously and decoded from that seekable buffer. The
+caller remains the owner of the stream.
+
+```csharp
+// e.g. an HttpClient shared by the host application.
+using var http = new HttpClient();
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/character_full.png"));
+var sheet = await manager.LoadAsync("hero", stream);
+```
+
+### `Task<SpriteSheet> LoadPartAsync(string name, Stream stream, CharacterPartType partType)`
+
+The asynchronous counterpart of `LoadPart(string, Stream, CharacterPartType)` for streams that
+only support asynchronous reads. Same validation/availability-first behaviour and ownership
+rules as `LoadAsync`.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/character_part_body.png"));
+var body = await manager.LoadPartAsync("body", stream, CharacterPartType.Body);
+```
+
 ### `SpriteSheet Get(string name)`
 
 Returns the sheet registered under `name`. Throws `KeyNotFoundException` when no such sheet is

--- a/docs/api/TileMap.md
+++ b/docs/api/TileMap.md
@@ -45,6 +45,31 @@ var map = TileMap.Load(
     uri => httpClient.GetByteArrayAsync(uri).GetAwaiter().GetResult());
 ```
 
+### `static Task<TileMap> LoadAsync(Stream stream, Uri baseUri, TiledAssetFetcherAsync fetcher)`
+
+The asynchronous counterpart of `Load(Stream, Uri, TiledAssetFetcher)` for streams and asset
+fetchers that only support asynchronous I/O (e.g. certain network/browser streams). No
+synchronous read is performed on the caller's stream: the TMX content is read with
+`StreamReader.ReadToEndAsync()` and every external asset is fetched with `await fetcher(...)`.
+
+DotTiled 1.0.0 only exposes synchronous external-tileset resolvers, so the async path
+pre-fetches the external asset graph (the map's external `.tsx` tilesets and the images they
+reference, plus any embedded `<tileset><image>` images) asynchronously into an in-memory cache
+and then reuses the existing synchronous parsing/decoding against that cache, so no blocking
+I/O remains. This is a pragmatic bridge until DotTiled exposes asynchronous resolvers; the
+TMX/TSX format remains the source of truth.
+
+```csharp
+// e.g. an HttpClient shared by the host application.
+using var http = new HttpClient();
+
+using var stream = File.OpenRead("assets/map.tmx");
+var map = await TileMap.LoadAsync(
+    stream,
+    new Uri("https://example.com/assets/map.tmx"),
+    uri => http.GetByteArrayAsync(uri));
+```
+
 ### `uint GetTileId(string layerName, int x, int y)`
 
 Returns the global tile ID of the tile at `(x, y)` in the layer named `layerName`, with all flip

--- a/docs/api/TileSet.md
+++ b/docs/api/TileSet.md
@@ -45,6 +45,25 @@ var tileset = TileSet.Load(
     uri => httpClient.GetByteArrayAsync(uri).GetAwaiter().GetResult());
 ```
 
+### `static Task<TileSet> LoadAsync(Stream stream, Uri baseUri, TiledAssetFetcherAsync fetcher)`
+
+The asynchronous counterpart of `Load(Stream, Uri, TiledAssetFetcher)` for streams and asset
+fetchers that only support asynchronous I/O (e.g. certain network/browser streams). The TSX
+content is read with `StreamReader.ReadToEndAsync()` and the image is fetched with
+`await fetcher(...)`, so no synchronous read is performed on the caller's stream. The caller
+remains the owner of the stream.
+
+```csharp
+// e.g. an HttpClient shared by the host application.
+using var http = new HttpClient();
+
+using var stream = File.OpenRead("assets/tiles.tsx");
+var tileset = await TileSet.LoadAsync(
+    stream,
+    new Uri("https://example.com/assets/tiles.tsx"),
+    uri => http.GetByteArrayAsync(uri));
+```
+
 ### `SKImage GetTileImage(int localTileId)`
 
 Returns the image of the tile with the given 0-based `localTileId`, cropped from the tileset

--- a/docs/api/TiledAssetFetcherAsync.md
+++ b/docs/api/TiledAssetFetcherAsync.md
@@ -1,0 +1,31 @@
+# TiledAssetFetcherAsync
+
+Namespace: `RPGEngine.Tiled` — a delegate that **asynchronously** fetches the raw bytes of a
+Tiled asset (a map, tileset or image) located at a URI.
+
+```csharp
+public delegate Task<byte[]> TiledAssetFetcherAsync(Uri uri);
+```
+
+## Remarks
+
+This is the asynchronous counterpart of `TiledAssetFetcher`. The engine uses it in the async
+loaders (`TileSet.LoadAsync`, `TileMap.LoadAsync`) whenever an asset is not available on the
+local file system and must be fetched with asynchronous I/O (e.g. certain network/browser
+streams). Unlike `TiledAssetFetcher`, implementations never block: they return a
+`Task<byte[]>` that completes with the asset's bytes.
+
+## Example
+
+```csharp
+// e.g. an HttpClient shared by the host application.
+using var http = new HttpClient();
+
+TiledAssetFetcherAsync fetcher = uri => http.GetByteArrayAsync(uri);
+
+using var mapStream = File.OpenRead("assets/map.tmx");
+var map = await TileMap.LoadAsync(
+    mapStream,
+    new Uri("https://example.com/assets/map.tmx"),
+    fetcher);
+```

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -192,7 +192,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public void LoadSpriteSheet(string name, string path) => _spriteSheetManager.Load(name, path);
@@ -207,7 +207,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -226,7 +226,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -248,12 +248,52 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
     public void LoadPartSpriteSheet(string name, Stream stream, CharacterPartType partType)
         => _spriteSheetManager.LoadPart(name, stream, partType);
+
+    /// <summary>
+    /// Asynchronously loads a full character spritesheet from <paramref name="stream"/> and
+    /// registers it under <paramref name="name"/> so characters can reference it by name. This
+    /// is the asynchronous counterpart of <see cref="LoadSpriteSheet(string, Stream)"/> for
+    /// streams that only support asynchronous reads (e.g. certain network/browser streams).
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet.</param>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>A task that completes when the sheet is loaded and registered.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
+    public Task LoadSpriteSheetAsync(string name, Stream stream)
+        => _spriteSheetManager.LoadAsync(name, stream);
+
+    /// <summary>
+    /// Asynchronously loads a <em>part</em> character spritesheet of layer
+    /// <paramref name="partType"/> from <paramref name="stream"/> and registers it under
+    /// <paramref name="name"/> so characters can reference it by name. This is the asynchronous
+    /// counterpart of <see cref="LoadPartSpriteSheet(string, Stream, CharacterPartType)"/> for
+    /// streams that only support asynchronous reads (e.g. certain network/browser streams).
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet.</param>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <param name="partType">The character layer the sheet provides.</param>
+    /// <returns>A task that completes when the sheet is loaded and registered.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
+    public Task LoadPartSpriteSheetAsync(string name, Stream stream, CharacterPartType partType)
+        => _spriteSheetManager.LoadPartAsync(name, stream, partType);
 
     /// <summary>
     /// Computes the camera origin: the world pixel position that maps to the canvas' top-left

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -192,7 +192,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public void LoadSpriteSheet(string name, string path) => _spriteSheetManager.Load(name, path);
@@ -207,7 +207,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -226,7 +226,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -248,7 +248,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -267,7 +267,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -288,7 +288,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>

--- a/src/RPGEngine/Sprites/SpriteSheetManager.cs
+++ b/src/RPGEngine/Sprites/SpriteSheetManager.cs
@@ -36,7 +36,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public SpriteSheet Load(string name, string path)
@@ -60,7 +60,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -90,7 +90,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -126,7 +126,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public SpriteSheet LoadPart(string name, string path, CharacterPartType partType)
@@ -151,7 +151,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -180,7 +180,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>

--- a/src/RPGEngine/Sprites/SpriteSheetManager.cs
+++ b/src/RPGEngine/Sprites/SpriteSheetManager.cs
@@ -36,7 +36,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public SpriteSheet Load(string name, string path)
@@ -60,7 +60,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -79,6 +79,43 @@ public sealed class SpriteSheetManager
     }
 
     /// <summary>
+    /// Asynchronously loads the <em>full</em> character spritesheet from <paramref name="stream"/>
+    /// and registers it under <paramref name="name"/>. This is the asynchronous counterpart of
+    /// <see cref="Load(string, Stream)"/> for streams that only support asynchronous reads
+    /// (e.g. certain network/browser streams).
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet (trimmed).</param>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>A task that resolves to the loaded <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    /// <remarks>
+    /// The name is validated and its availability checked <em>before</em> the stream is touched,
+    /// so a bad name fails without reading <paramref name="stream"/>. The stream is then copied
+    /// into an in-memory buffer asynchronously and decoded from that seekable buffer with the
+    /// same <see cref="Decode"/> helper as the synchronous overloads, so no synchronous read is
+    /// performed on the caller's stream. The caller remains the owner of <paramref name="stream"/>;
+    /// it is not disposed here.
+    /// </remarks>
+    public async Task<SpriteSheet> LoadAsync(string name, Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var trimmedName = ValidateName(name);
+        EnsureNameAvailable(trimmedName);
+
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer).ConfigureAwait(false);
+        buffer.Position = 0;
+
+        return Register(trimmedName, SpriteSheetType.Full, null, Decode(buffer, trimmedName, "<stream>"));
+    }
+
+    /// <summary>
     /// Loads the <em>part</em> spritesheet of layer <paramref name="partType"/> at
     /// <paramref name="path"/> and registers it under <paramref name="name"/>.
     /// </summary>
@@ -89,7 +126,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public SpriteSheet LoadPart(string name, string path, CharacterPartType partType)
@@ -114,7 +151,7 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -128,6 +165,43 @@ public sealed class SpriteSheetManager
         EnsureNameAvailable(trimmedName);
 
         return Register(trimmedName, SpriteSheetType.Part, partType, Decode(stream, trimmedName, "<stream>"));
+    }
+
+    /// <summary>
+    /// Asynchronously loads the <em>part</em> spritesheet of layer <paramref name="partType"/>
+    /// from <paramref name="stream"/> and registers it under <paramref name="name"/>. This is
+    /// the asynchronous counterpart of <see cref="LoadPart(string, Stream, CharacterPartType)"/>
+    /// for streams that only support asynchronous reads (e.g. certain network/browser streams).
+    /// </summary>
+    /// <param name="name">The unique name used to reference the sheet (trimmed).</param>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <param name="partType">The character layer the sheet provides.</param>
+    /// <returns>A task that resolves to the loaded <see cref="SpriteSheet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>&#215;<see cref="SpriteSheet.SheetHeight"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
+    /// <remarks>
+    /// The name is validated and its availability checked <em>before</em> the stream is touched,
+    /// so a bad name fails without reading <paramref name="stream"/>. The stream is then copied
+    /// into an in-memory buffer asynchronously and decoded from that seekable buffer with the
+    /// same <see cref="Decode"/> helper as the synchronous overloads. The caller remains the
+    /// owner of <paramref name="stream"/>; it is not disposed here.
+    /// </remarks>
+    public async Task<SpriteSheet> LoadPartAsync(string name, Stream stream, CharacterPartType partType)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var trimmedName = ValidateName(name);
+        EnsureNameAvailable(trimmedName);
+
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer).ConfigureAwait(false);
+        buffer.Position = 0;
+
+        return Register(trimmedName, SpriteSheetType.Part, partType, Decode(buffer, trimmedName, "<stream>"));
     }
 
     /// <summary>

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using DotTiled;
 using DotTiled.Serialization;
 using SkiaSharp;
@@ -59,14 +60,14 @@ public sealed class TileMap
     /// <summary>Gets the height of a single tile in pixels.</summary>
     public int TileHeight { get; }
 
-    /// <summary>Gets the total width of the map in pixels (<see cref="Width"/> × <see cref="TileWidth"/>).</summary>
+    /// <summary>Gets the total width of the map in pixels (<see cref="Width"/> &#215; <see cref="TileWidth"/>).</summary>
     public int PixelWidth => Width * TileWidth;
 
-    /// <summary>Gets the total height of the map in pixels (<see cref="Height"/> × <see cref="TileHeight"/>).</summary>
+    /// <summary>Gets the total height of the map in pixels (<see cref="Height"/> &#215; <see cref="TileHeight"/>).</summary>
     public int PixelHeight => Height * TileHeight;
 
     /// <summary>
-    /// Gets the tile layers of the map, in the order they appear in the file (bottom → top).
+    /// Gets the tile layers of the map, in the order they appear in the file (bottom &#8594; top).
     /// Only tile layers are represented; object, image and group layers are ignored for now.
     /// </summary>
     public IReadOnlyList<TileMapLayer> Layers { get; }
@@ -120,6 +121,53 @@ public sealed class TileMap
         var map = ParseMapContent(content, baseUri, fetcher);
 
         return BuildMap(map, dotTiledTileset => CreateUriTileSet(dotTiledTileset, baseUri, fetcher));
+    }
+
+    /// <summary>
+    /// Asynchronously loads the Tiled map content from <paramref name="stream"/>, parsing the
+    /// referenced external tilesets and decoding their images.
+    /// </summary>
+    /// <param name="stream">A stream containing the Tiled <c>.tmx</c> map content.</param>
+    /// <param name="baseUri">
+    /// The URI the map was fetched from (e.g. <c>https://example.com/maps/map.tmx</c>).
+    /// Relative references declared by the map and its tilesets are resolved against it.
+    /// </param>
+    /// <param name="fetcher">Asynchronously fetches the raw bytes of a resolved asset URI.</param>
+    /// <returns>A task that resolves to the loaded <see cref="TileMap"/>.</returns>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">A referenced tileset has no image or an image could not be decoded.</exception>
+    /// <remarks>
+    /// <para>
+    /// This is the asynchronous counterpart of <see cref="Load(Stream, Uri, TiledAssetFetcher)"/>
+    /// for streams and asset fetchers that only support asynchronous I/O (e.g. certain
+    /// network/browser streams). No synchronous read is performed on the caller's stream: the
+    /// TMX content is read with <c>StreamReader.ReadToEndAsync()</c> and every external asset is
+    /// fetched with <c>await fetcher(...)</c>.
+    /// </para>
+    /// <para>
+    /// DotTiled 1.0.0 only exposes synchronous external-tileset resolvers (the parser takes
+    /// <c>Func&lt;string, Tileset&gt;</c>), so the external TSX and its image cannot be awaited
+    /// from inside the parser. The async path therefore <em>pre-fetches the external asset
+    /// graph asynchronously</em> and then reuses the existing synchronous DotTiled
+    /// parsing/decoding against an in-memory cache: the map's external <c>.tsx</c> tilesets and
+    /// the images they reference (plus any embedded <c>&lt;tileset&gt;&lt;image&gt;</c> images)
+    /// are fetched and stored in a <see cref="Dictionary{TKey,TValue}"/> cache keyed by resolved
+    /// URI, and the synchronous helpers then resolve only from that memory cache, so no blocking
+    /// I/O remains. This is a pragmatic bridge until DotTiled exposes asynchronous resolvers; the
+    /// TMX/TSX format remains the source of truth.
+    /// </para>
+    /// </remarks>
+    public static async Task<TileMap> LoadAsync(Stream stream, Uri baseUri, TiledAssetFetcherAsync fetcher)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(baseUri);
+        ArgumentNullException.ThrowIfNull(fetcher);
+
+        var content = await ReadAllTextAsync(stream).ConfigureAwait(false);
+        var cache = await PrefetchAssetsAsync(content, baseUri, fetcher).ConfigureAwait(false);
+
+        var map = ParseMapContent(content, baseUri, uri => cache[uri]);
+        return BuildMap(map, dotTiledTileset => CreateUriTileSet(dotTiledTileset, baseUri, uri => cache[uri]));
     }
 
     /// <summary>
@@ -381,6 +429,64 @@ public sealed class TileMap
     {
         using var reader = new StreamReader(stream, leaveOpen: true);
         return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Pre-fetches the external asset graph referenced by <paramref name="mapContent"/> into an
+    /// in-memory cache keyed by resolved URI, so the synchronous DotTiled parse that follows can
+    /// resolve every asset (external TSX and image) without performing blocking I/O.
+    /// </summary>
+    /// <param name="mapContent">The raw TMX content of the map.</param>
+    /// <param name="baseUri">The URI the map was fetched from; relative references are resolved against it.</param>
+    /// <param name="fetcher">Asynchronously fetches the raw bytes of a resolved asset URI.</param>
+    /// <returns>A task that resolves to a cache of resolved asset URIs to their raw bytes.</returns>
+    private static async Task<Dictionary<Uri, byte[]>> PrefetchAssetsAsync(
+        string mapContent,
+        Uri baseUri,
+        TiledAssetFetcherAsync fetcher)
+    {
+        var cache = new Dictionary<Uri, byte[]>();
+
+        var document = XDocument.Parse(mapContent, LoadOptions.PreserveWhitespace);
+        foreach (var tilesetElement in document.Root?.Elements("tileset") ?? Enumerable.Empty<XElement>())
+        {
+            var sourceAttribute = tilesetElement.Attribute("source");
+            if (sourceAttribute is not null && !string.IsNullOrWhiteSpace(sourceAttribute.Value))
+            {
+                // External tileset: fetch the TSX, then parse it to find the image it declares
+                // (relative to the TSX URI) and fetch that too.
+                var tilesetUri = new Uri(baseUri, sourceAttribute.Value);
+                var tsxBytes = await fetcher(tilesetUri).ConfigureAwait(false);
+                cache[tilesetUri] = tsxBytes;
+
+                var tsxContent = TextFromBytes(tsxBytes);
+                var tsxDocument = XDocument.Parse(tsxContent, LoadOptions.PreserveWhitespace);
+                var imageSource = tsxDocument.Root?.Element("image")?.Attribute("source")?.Value;
+                if (!string.IsNullOrWhiteSpace(imageSource))
+                {
+                    var imageUri = new Uri(tilesetUri, imageSource);
+                    cache[imageUri] = await fetcher(imageUri).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                // Embedded <tileset> with an image: the image source is relative to the map URI.
+                var imageSource = tilesetElement.Element("image")?.Attribute("source")?.Value;
+                if (!string.IsNullOrWhiteSpace(imageSource))
+                {
+                    var imageUri = new Uri(baseUri, imageSource);
+                    cache[imageUri] = await fetcher(imageUri).ConfigureAwait(false);
+                }
+            }
+        }
+
+        return cache;
+    }
+
+    private static async Task<string> ReadAllTextAsync(Stream stream)
+    {
+        using var reader = new StreamReader(stream, leaveOpen: true);
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
     }
 
     private static string TextFromBytes(byte[] bytes)

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -60,14 +60,14 @@ public sealed class TileMap
     /// <summary>Gets the height of a single tile in pixels.</summary>
     public int TileHeight { get; }
 
-    /// <summary>Gets the total width of the map in pixels (<see cref="Width"/> &#215; <see cref="TileWidth"/>).</summary>
+    /// <summary>Gets the total width of the map in pixels (<see cref="Width"/> × <see cref="TileWidth"/>).</summary>
     public int PixelWidth => Width * TileWidth;
 
-    /// <summary>Gets the total height of the map in pixels (<see cref="Height"/> &#215; <see cref="TileHeight"/>).</summary>
+    /// <summary>Gets the total height of the map in pixels (<see cref="Height"/> × <see cref="TileHeight"/>).</summary>
     public int PixelHeight => Height * TileHeight;
 
     /// <summary>
-    /// Gets the tile layers of the map, in the order they appear in the file (bottom &#8594; top).
+    /// Gets the tile layers of the map, in the order they appear in the file (bottom → top).
     /// Only tile layers are represented; object, image and group layers are ignored for now.
     /// </summary>
     public IReadOnlyList<TileMapLayer> Layers { get; }

--- a/src/RPGEngine/Tiled/TileSet.cs
+++ b/src/RPGEngine/Tiled/TileSet.cs
@@ -141,8 +141,49 @@ public sealed class TileSet
     }
 
     /// <summary>
+    /// Asynchronously loads a Tiled tileset (<c>.tsx</c>) from <paramref name="stream"/> and
+    /// decodes its image. The image <c>source</c> declared by the tileset is resolved relative to
+    /// <paramref name="baseUri"/> and fetched through <paramref name="fetcher"/>.
+    /// </summary>
+    /// <param name="stream">A stream containing the Tiled <c>.tsx</c> tileset content.</param>
+    /// <param name="baseUri">
+    /// The URI the tileset was fetched from (e.g. <c>https://example.com/tiles/tiles.tsx</c>).
+    /// Relative image sources declared by the tileset are resolved against it.
+    /// </param>
+    /// <param name="fetcher">Asynchronously fetches the raw bytes of a resolved asset URI.</param>
+    /// <returns>A task that resolves to the loaded <see cref="TileSet"/>.</returns>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">The tileset has no image or the image could not be decoded.</exception>
+    /// <remarks>
+    /// This is the asynchronous counterpart of <see cref="Load(Stream, Uri, TiledAssetFetcher)"/>
+    /// for streams and asset fetchers that only support asynchronous I/O (e.g. certain
+    /// network/browser streams). The TSX content is read with <c>StreamReader.ReadToEndAsync()</c>
+    /// and the image is fetched with <c>await fetcher(...)</c>, so no synchronous read is
+    /// performed on the caller's stream. The caller remains the owner of <paramref name="stream"/>.
+    /// </remarks>
+    public static async Task<TileSet> LoadAsync(Stream stream, Uri baseUri, TiledAssetFetcherAsync fetcher)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(baseUri);
+        ArgumentNullException.ThrowIfNull(fetcher);
+
+        var content = await ReadAllTextAsync(stream).ConfigureAwait(false);
+        var dotTiledTileset = ParseTilesetContent(content);
+
+        return await FromDotTiledAsync(dotTiledTileset, dotTiledTileset.FirstGID.GetValueOr(0u), async source =>
+        {
+            var imageUri = new Uri(baseUri, source);
+            var bytes = await fetcher(imageUri).ConfigureAwait(false);
+            using var imageStream = new MemoryStream(bytes, writable: false);
+            return SKBitmap.Decode(imageStream)
+                ?? throw new InvalidOperationException(
+                    $"Unable to decode tileset image '{imageUri}' for '{dotTiledTileset.Name}'.");
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Returns the image of the tile with the given 0-based <paramref name="localTileId"/>,
-    /// cropped from the tileset image at <see cref="TileWidth"/>×<see cref="TileHeight"/>.
+    /// cropped from the tileset image at <see cref="TileWidth"/>&#215;<see cref="TileHeight"/>.
     /// </summary>
     /// <param name="localTileId">The 0-based local tile ID within this tileset.</param>
     /// <returns>An independent raster image containing the requested tile.</returns>
@@ -239,6 +280,62 @@ public sealed class TileSet
             tileset.Margin);
     }
 
+    /// <summary>
+    /// Asynchronously creates a <see cref="TileSet"/> from a DotTiled <see cref="Tileset"/>,
+    /// decoding its image with <paramref name="imageDecoderAsync"/>. Shares the validation of
+    /// <see cref="FromDotTiled"/>: a tileset with no image, an empty image source, or an image
+    /// that cannot be decoded throws the same exceptions.
+    /// </summary>
+    /// <param name="tileset">The parsed DotTiled tileset.</param>
+    /// <param name="firstGid">The first global tile ID of the tileset within its map.</param>
+    /// <param name="imageDecoderAsync">
+    /// Asynchronously decodes the image of the tileset given its raw <c>source</c> string as
+    /// declared by the tileset. The caller resolves the source (e.g. relative to a URI) and
+    /// returns the decoded bitmap; the resolution base is owned by the caller.
+    /// </param>
+    /// <returns>A task that resolves to a fully decoded <see cref="TileSet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="tileset"/> or <paramref name="imageDecoderAsync"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The tileset has no image, or the image could not be decoded.
+    /// </exception>
+    internal static async Task<TileSet> FromDotTiledAsync(
+        Tileset tileset,
+        uint firstGid,
+        Func<string, Task<SKBitmap>> imageDecoderAsync)
+    {
+        ArgumentNullException.ThrowIfNull(tileset);
+        ArgumentNullException.ThrowIfNull(imageDecoderAsync);
+
+        if (!tileset.Image.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"Tileset '{tileset.Name}' has no image; image-collection tilesets are not supported.");
+        }
+
+        var source = tileset.Image.Value.Source.GetValueOr(string.Empty);
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            throw new InvalidOperationException($"Tileset '{tileset.Name}' does not declare an image source.");
+        }
+
+        var sourceImage = await imageDecoderAsync(source).ConfigureAwait(false);
+        if (sourceImage is null)
+        {
+            throw new InvalidOperationException($"Unable to decode the image for tileset '{tileset.Name}'.");
+        }
+
+        return new TileSet(
+            tileset.Name,
+            firstGid,
+            tileset.TileWidth,
+            tileset.TileHeight,
+            sourceImage,
+            tileset.TileCount,
+            tileset.Columns,
+            tileset.Spacing,
+            tileset.Margin);
+    }
+
     private static Tileset ParseTilesetContent(string content)
     {
         using var reader = new TilesetReader(
@@ -255,5 +352,11 @@ public sealed class TileSet
     {
         using var reader = new StreamReader(stream, leaveOpen: true);
         return reader.ReadToEnd();
+    }
+
+    private static async Task<string> ReadAllTextAsync(Stream stream)
+    {
+        using var reader = new StreamReader(stream, leaveOpen: true);
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
     }
 }

--- a/src/RPGEngine/Tiled/TileSet.cs
+++ b/src/RPGEngine/Tiled/TileSet.cs
@@ -183,7 +183,7 @@ public sealed class TileSet
 
     /// <summary>
     /// Returns the image of the tile with the given 0-based <paramref name="localTileId"/>,
-    /// cropped from the tileset image at <see cref="TileWidth"/>&#215;<see cref="TileHeight"/>.
+    /// cropped from the tileset image at <see cref="TileWidth"/>×<see cref="TileHeight"/>.
     /// </summary>
     /// <param name="localTileId">The 0-based local tile ID within this tileset.</param>
     /// <returns>An independent raster image containing the requested tile.</returns>

--- a/src/RPGEngine/Tiled/TiledAssetFetcherAsync.cs
+++ b/src/RPGEngine/Tiled/TiledAssetFetcherAsync.cs
@@ -1,0 +1,22 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// Asynchronously fetches the raw bytes of a Tiled asset (a map, tileset or image) located at
+/// <paramref name="uri"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the asynchronous counterpart of <see cref="TiledAssetFetcher"/>. The engine uses it
+/// whenever it needs an asset that is not available on the local file system and must be fetched
+/// with asynchronous I/O (e.g. certain network/browser streams that only support async reads).
+/// Unlike <see cref="TiledAssetFetcher"/>, implementations never block: they return a
+/// <see cref="Task{TResult}"/> that completes with the asset's bytes.
+/// </para>
+/// <para>
+/// Implementations are expected to fetch <paramref name="uri"/> and return its content, for
+/// example by calling <c>httpClient.GetByteArrayAsync(uri)</c>.
+/// </para>
+/// </remarks>
+/// <param name="uri">The absolute URI of the asset to fetch.</param>
+/// <returns>A task that resolves to the raw bytes of the asset.</returns>
+public delegate Task<byte[]> TiledAssetFetcherAsync(Uri uri);

--- a/tests/RPGEngine.Tests/AsyncOnlyStream.cs
+++ b/tests/RPGEngine.Tests/AsyncOnlyStream.cs
@@ -1,0 +1,65 @@
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// A read-only wrapper stream that only supports asynchronous reads: the synchronous
+/// <see cref="Read(byte[], int, int)"/>, <see cref="Position"/> and <see cref="Seek"/> members
+/// throw, <see cref="CanSeek"/> is <see langword="false"/>, and <see cref="ReadAsync(Memory{byte}, CancellationToken)"/>
+/// delegates to the wrapped stream. This mirrors network/browser streams that only expose async
+/// reads and proves that the async asset loaders never perform a blocking synchronous read of
+/// the caller's stream.
+/// </summary>
+internal sealed class AsyncOnlyStream : Stream
+{
+    private readonly Stream _inner;
+
+    public AsyncOnlyStream(Stream inner)
+    {
+        _inner = inner;
+    }
+
+    public override bool CanRead => _inner.CanRead;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException(
+        "Length is not available on an async-only stream.");
+
+    public override long Position
+    {
+        get => throw new NotSupportedException("Position is not supported on an async-only stream.");
+        set => throw new NotSupportedException("Position is not supported on an async-only stream.");
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => throw new NotSupportedException("Synchronous reads are not supported on an async-only stream.");
+
+    public override int Read(Span<byte> buffer)
+        => throw new NotSupportedException("Synchronous reads are not supported on an async-only stream.");
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.ReadAsync(buffer, cancellationToken);
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override long Seek(long offset, SeekOrigin origin)
+        => throw new NotSupportedException("Seeking is not supported on an async-only stream.");
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -370,4 +370,77 @@ public class DocsExamplesTests
 
         Assert.Equal(16, map.Width);
     }
+
+    // ---------------------------------------------------------------------
+    // Async loading (story 22): the async stream-based loaders work with
+    // read-async-only streams and async asset fetchers.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the async spritesheet loading example: SpriteSheetManager.LoadAsync and GameEngine.LoadSpriteSheetAsync from an async-only stream.</summary>
+    [Fact]
+    public async Task AsyncSheetLoading_LoadsAndRegisters()
+    {
+        using var fixtures = FixtureAssets.MaterializeToTempDirectory();
+
+        // SpriteSheetManager.LoadAsync: a stream that only supports asynchronous reads, as a
+        // browser host would provide.
+        using (var stream = new AsyncOnlyStream(FixtureAssets.DecodePngStream(FixtureAssets.FullSheet)))
+        {
+            var manager = new SpriteSheetManager();
+            var sheet = await manager.LoadAsync("hero", stream);
+
+            Assert.Equal("hero", sheet.Name);
+            Assert.Equal(SpriteSheetType.Full, sheet.Type);
+        }
+
+        // GameEngine.LoadSpriteSheetAsync: the engine-level delegating overload.
+        var engine = new GameEngine();
+        using (var stream = new AsyncOnlyStream(FixtureAssets.DecodePngStream(FixtureAssets.FullSheet)))
+        {
+            await engine.LoadSpriteSheetAsync("hero", stream);
+        }
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+
+        using var bitmap = new SKBitmap(48, 48);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.Render(canvas, FrameDt);
+        }
+
+        Assert.NotEqual(0, bitmap.GetPixel(24, 24).Alpha);
+    }
+
+    /// <summary>Verifies the async map loading example: TileMap.LoadAsync with a TiledAssetFetcherAsync resolving external assets over HTTP.</summary>
+    [Fact]
+    public async Task AsyncMapLoading_WithAsyncFetcher()
+    {
+        using var fixtures = FixtureAssets.MaterializeToTempDirectory();
+
+        var mapBytes = File.ReadAllBytes(fixtures.PathOf(FixtureAssets.MapFile));
+        using var stream = new AsyncOnlyStream(new MemoryStream(mapBytes, writable: false));
+
+        // A TiledAssetFetcherAsync mirrors what HttpClient.GetByteArrayAsync would do.
+        TiledAssetFetcherAsync fetcher = async uri =>
+        {
+            await Task.Delay(1);
+            var name = Path.GetFileName(uri.AbsolutePath);
+            if (name == FixtureAssets.TilesetFile)
+            {
+                return System.Text.Encoding.UTF8.GetBytes(File.ReadAllText(fixtures.PathOf(FixtureAssets.TilesetFile)));
+            }
+
+            if (name == FixtureAssets.TilesImage)
+            {
+                return File.ReadAllBytes(fixtures.PathOf(FixtureAssets.TilesImage));
+            }
+
+            throw new FileNotFoundException($"Unknown asset '{uri}'.");
+        };
+
+        var map = await TileMap.LoadAsync(stream, new Uri("file:///fixtures/map.tmx"), fetcher);
+
+        Assert.Equal(16, map.Width);
+        Assert.Equal(12, map.Height);
+        Assert.Equal(2, map.Layers.Count);
+    }
 }

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -246,6 +246,61 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Async loading (story 22): the engine's LoadSpriteSheetAsync /
+    // LoadPartSpriteSheetAsync delegate to the sprite sheet manager and must
+    // work with streams that only support asynchronous reads.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies LoadSpriteSheetAsync registers a sheet so a SpriteSheetRef renders non-empty pixels.</summary>
+    [Fact]
+    public async Task LoadSpriteSheetAsync_AndSpriteSheetRef_RendersNonEmpty()
+    {
+        var engine = new GameEngine();
+        using (var stream = new AsyncOnlyStream(CharacterTestHelper.CreateSheetStream(0)))
+        {
+            await engine.LoadSpriteSheetAsync("hero", stream);
+        }
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+
+        using var bitmap = Render(engine, CellSize, CellSize);
+        Assert.NotEqual(0, bitmap.GetPixel(24, 24).Alpha);
+    }
+
+    /// <summary>Verifies LoadPartSpriteSheetAsync registers part sheets that compose into a complete character.</summary>
+    [Fact]
+    public async Task LoadPartSpriteSheetAsync_ComposesParts()
+    {
+        var engine = new GameEngine();
+
+        // body (opaque) + hair2 (opaque) + head (fully transparent, name without '$'). The
+        // transparent head lets the hair2 layer show through when facing up, proving the parts
+        // were actually composed instead of a single sheet being drawn alone.
+        using (var bodyStream = new AsyncOnlyStream(CharacterTestHelper.CreateSheetStream(1)))
+        {
+            await engine.LoadPartSpriteSheetAsync("body", bodyStream, CharacterPartType.Body);
+        }
+        using (var hairStream = new AsyncOnlyStream(CharacterTestHelper.CreateSheetStream(3)))
+        {
+            await engine.LoadPartSpriteSheetAsync("hair2", hairStream, CharacterPartType.Hair2);
+        }
+        using (var headStream = new AsyncOnlyStream(CharacterTestHelper.CreateSheetStream(4, transparent: true)))
+        {
+            await engine.LoadPartSpriteSheetAsync("head", headStream, CharacterPartType.Head);
+        }
+
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("body", CharacterIndex: 1));
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hair2", CharacterIndex: 1));
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("head", CharacterIndex: 1));
+
+        // Facing up: the per-direction adjustment draws hair2 over the body; the transparent
+        // head keeps it visible, so the rendered centre pixel is the hair2 colour.
+        engine.Player.Character.Move(Direction.Up, speedFactor: 0);
+
+        using var bitmap = Render(engine, CellSize, CellSize);
+        var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 1, Direction.Up, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(CellSize / 2, CellSize / 2));
+    }
+
+    // ---------------------------------------------------------------------
     // Additional coverage (story 21): 8-direction vector-combined movement.
     // The movement model is no longer last-pressed-wins: holding W+D moves
     // diagonally, opposite keys cancel, and releasing one key of a held

--- a/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
+++ b/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
@@ -226,6 +226,76 @@ public class SpriteSheetTests
     }
 
     // ---------------------------------------------------------------------
+    // Async loading (story 22): LoadAsync / LoadPartAsync must never perform a
+    // synchronous read of the caller's stream, so they are exercised against a
+    // non-seekable, read-async-only stream.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies LoadAsync loads a full sheet from a non-seekable, read-async-only stream (proves no synchronous read of the caller's stream).</summary>
+    [Fact]
+    public async Task LoadAsync_SucceedsFromAsyncOnlyStream()
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new AsyncOnlyStream(SpriteSheetTestHelper.CreateSheetStream());
+
+        var sheet = await manager.LoadAsync("hero", stream);
+
+        Assert.Equal("hero", sheet.Name);
+        Assert.Equal(SpriteSheetType.Full, sheet.Type);
+        Assert.Null(sheet.PartType);
+
+        using var sprite = sheet.GetSprite(1, Direction.Down, 0);
+        AssertCell(sprite, row: 0, col: 0);
+    }
+
+    /// <summary>Verifies LoadPartAsync round-trips every character part type.</summary>
+    [Theory]
+    [InlineData(CharacterPartType.Body)]
+    [InlineData(CharacterPartType.Armour)]
+    [InlineData(CharacterPartType.Face)]
+    [InlineData(CharacterPartType.FaceHair)]
+    [InlineData(CharacterPartType.Hair1)]
+    [InlineData(CharacterPartType.Hair2)]
+    [InlineData(CharacterPartType.Head)]
+    public async Task LoadPartAsync_RoundTripsPartType(CharacterPartType partType)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new AsyncOnlyStream(SpriteSheetTestHelper.CreateSheetStream());
+
+        var sheet = await manager.LoadPartAsync("part", stream, partType);
+
+        Assert.Equal(SpriteSheetType.Part, sheet.Type);
+        Assert.Equal(partType, sheet.PartType);
+    }
+
+    /// <summary>Verifies the async path keeps the duplicate-name failure mode (InvalidOperationException) and fails without touching the stream.</summary>
+    [Fact]
+    public async Task LoadAsync_DuplicateName_ThrowsInvalidOperationException()
+    {
+        var manager = new SpriteSheetManager();
+        using (var stream = new AsyncOnlyStream(SpriteSheetTestHelper.CreateSheetStream()))
+        {
+            await manager.LoadAsync("hero", stream);
+        }
+
+        using var duplicate = new AsyncOnlyStream(SpriteSheetTestHelper.CreateSheetStream());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => manager.LoadAsync("hero", duplicate));
+    }
+
+    /// <summary>Verifies the async path keeps the invalid-dimensions failure mode (ArgumentException).</summary>
+    [Theory]
+    [InlineData(144, 192)] // the single-character '$' sheet variant (out of scope)
+    [InlineData(100, 100)]
+    public async Task LoadAsync_ThrowsArgumentException_ForInvalidDimensions(int width, int height)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new AsyncOnlyStream(new MemoryStream(
+            SpriteSheetTestHelper.CreateSheetPng(width, height),
+            writable: false));
+
+        await Assert.ThrowsAsync<ArgumentException>(() => manager.LoadAsync("bad", stream));
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 

--- a/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
+++ b/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
@@ -298,6 +298,114 @@ public class TileMapTests
     }
 
     // ---------------------------------------------------------------------
+    // Async loading (story 22): TileSet.LoadAsync / TileMap.LoadAsync must
+    // never perform a synchronous read of the caller's stream, so they are
+    // exercised against a non-seekable, read-async-only stream and an async
+    // fetcher that is genuinely awaited.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies TileSet.LoadAsync parses a TSX from a non-seekable stream and resolves the image through the async fetcher (the fetched image is used).</summary>
+    [Fact]
+    public async Task TileSet_LoadAsyncFromStreamWithFetcher_ResolvesImageUri()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var baseUri = new Uri("https://example.com/maps/tiles.tsx");
+        using var stream = new AsyncOnlyStream(new MemoryStream(File.ReadAllBytes(fixture.TilesetPath), writable: false));
+
+        var tileSet = await TileSet.LoadAsync(stream, baseUri, CreateAsyncFetcher(fixture));
+
+        Assert.Equal("test_tiles", tileSet.Name);
+        Assert.Equal(48, tileSet.TileWidth);
+        Assert.Equal(48, tileSet.TileHeight);
+
+        // The image was fetched asynchronously from https://example.com/maps/tiles.png and the
+        // fetched bytes are the ones actually decoded: the cropped tile is the fixture's solid
+        // red, so its centre pixel is opaque.
+        using var tileImage = tileSet.GetTileImage(0);
+        Assert.Equal(48, tileImage.Width);
+        Assert.Equal(48, tileImage.Height);
+
+        using var bitmap = new SKBitmap(tileImage.Width, tileImage.Height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawImage(tileImage, new SKPoint(0, 0));
+        }
+
+        Assert.NotEqual(0, bitmap.GetPixel(24, 24).Alpha);
+    }
+
+    /// <summary>Verifies TileSet.LoadAsync propagates an exception thrown by the async fetcher for a missing asset.</summary>
+    [Fact]
+    public async Task TileSet_LoadAsync_PropagatesFetcherException_ForMissingAsset()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var baseUri = new Uri("https://example.com/maps/tiles.tsx");
+        using var stream = new AsyncOnlyStream(new MemoryStream(File.ReadAllBytes(fixture.TilesetPath), writable: false));
+
+        // A fetcher that throws for the image (the only asset a standalone tileset fetches).
+        TiledAssetFetcherAsync fetcher = async uri => uri.Segments[^1] == "tiles.png"
+            ? throw new KeyNotFoundException($"Asset not found: {uri}")
+            : await CreateAsyncFetcher(fixture)(uri);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => TileSet.LoadAsync(stream, baseUri, fetcher));
+    }
+
+    /// <summary>Verifies TileMap.LoadAsync loads a TMX from a non-seekable stream, resolving the external TSX and its image exclusively through the async fetcher.</summary>
+    [Fact]
+    public async Task TileMap_LoadAsyncFromStreamWithFetcher_LoadsExternalTileset()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var baseUri = new Uri("https://example.com/maps/map.tmx");
+        using var stream = new AsyncOnlyStream(new MemoryStream(File.ReadAllBytes(fixture.MapPath), writable: false));
+
+        var map = await TileMap.LoadAsync(stream, baseUri, CreateAsyncFetcher(fixture));
+
+        Assert.Equal(2, map.Width);
+        Assert.Equal(2, map.Height);
+        Assert.Equal(48, map.TileWidth);
+        Assert.Equal(48, map.TileHeight);
+
+        Assert.Equal(1u, map.GetTileId("ground", 0, 0));
+        Assert.Equal(TileFlags.FlippedHorizontally, map.GetTileFlags("ground", 0, 1));
+    }
+
+    /// <summary>Verifies a map loaded through the async fetcher renders its tiles correctly.</summary>
+    [Fact]
+    public async Task TileMap_LoadAsyncFromStreamWithFetcher_Renders()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var baseUri = new Uri("https://example.com/maps/map.tmx");
+        using var stream = new AsyncOnlyStream(new MemoryStream(File.ReadAllBytes(fixture.MapPath), writable: false));
+
+        var map = await TileMap.LoadAsync(stream, baseUri, CreateAsyncFetcher(fixture));
+
+        using var bitmap = RenderMap(map);
+
+        // Tile at (0,0) is solid red and opaque.
+        Assert.NotEqual(0, bitmap.GetPixel(24, 24).Alpha);
+        // Empty cell at (1,0) stays transparent.
+        Assert.Equal(0, bitmap.GetPixel(72, 24).Alpha);
+    }
+
+    /// <summary>Verifies the async fetcher is genuinely awaited and that a fetcher throwing for a missing asset propagates the exception.</summary>
+    [Fact]
+    public async Task TileMap_LoadAsync_PropagatesFetcherException_ForMissingAsset()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var baseUri = new Uri("https://example.com/maps/map.tmx");
+        using var stream = new AsyncOnlyStream(new MemoryStream(File.ReadAllBytes(fixture.MapPath), writable: false));
+
+        // The fetcher only serves the map and TSX but throws for the PNG image. The original
+        // exception type must propagate unwrapped, which proves the loader awaited the returned
+        // task instead of blocking on it.
+        TiledAssetFetcherAsync fetcher = async uri => uri.Segments[^1] == "tiles.png"
+            ? throw new KeyNotFoundException($"Asset not found: {uri}")
+            : await CreateAsyncFetcher(fixture)(uri);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => TileMap.LoadAsync(stream, baseUri, fetcher));
+    }
+
+    // ---------------------------------------------------------------------
     // TileSet.GetTileImage: crops the tile from the decoded tileset image.
     // ---------------------------------------------------------------------
     /// <summary>Verifies TileSet.GetTileImage returns a cropped tile image from the decoded tileset image.</summary>
@@ -371,6 +479,29 @@ public class TileMapTests
         return uri => assets.TryGetValue(uri.Segments[^1], out var bytes)
             ? bytes
             : throw new KeyNotFoundException($"Unexpected asset URI: {uri}");
+    }
+
+    /// <summary>
+    /// Builds an async fetcher that serves the fixture's map, tileset and image bytes under a
+    /// fake HTTP base URI, with a short await before returning so the async path is genuinely
+    /// exercised (the loader must await the returned task).
+    /// </summary>
+    private static TiledAssetFetcherAsync CreateAsyncFetcher(TiledTestFixture fixture)
+    {
+        var assets = new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["map.tmx"] = File.ReadAllBytes(fixture.MapPath),
+            ["tiles.tsx"] = File.ReadAllBytes(fixture.TilesetPath),
+            ["tiles.png"] = File.ReadAllBytes(fixture.ImagePath),
+        };
+
+        return async uri =>
+        {
+            await Task.Delay(1); // prove the fetcher is genuinely awaited (a real async hop).
+            return assets.TryGetValue(uri.Segments[^1], out var bytes)
+                ? bytes
+                : throw new KeyNotFoundException($"Unexpected asset URI: {uri}");
+        };
     }
 
     private static SKBitmap RenderMap(TileMap map)


### PR DESCRIPTION
## Summary

Implements [#22](https://github.com/elliottv/rpg-engine/issues/22) — Closes #22.

Truly async, non-blocking counterparts for the stream-based asset loaders so they work with streams that only support asynchronous reads (e.g. certain network/browser streams). The async versions never perform a blocking synchronous read of the caller's stream; all I/O (stream reads and asset fetches) is awaited.

### Source changes

- **`SpriteSheetManager`** (`RPGEngine.Sprites`): `LoadAsync(string, Stream)` and `LoadPartAsync(string, Stream, CharacterPartType)` — validate/trim the name and check availability **first** (same exceptions as the sync overloads), then copy the stream into memory asynchronously (`CopyToAsync`) and decode from the seekable buffer with the existing `Decode` helper. The caller keeps ownership of the stream.
- **`GameEngine`** (`RPGEngine`): thin delegating `LoadSpriteSheetAsync` / `LoadPartSpriteSheetAsync` overloads (docs + exceptions mirror the sync versions).
- **`TiledAssetFetcherAsync`** (new delegate, `RPGEngine.Tiled`): `Task<byte[]> TiledAssetFetcherAsync(Uri)`, documented on the type.
- **`TileSet`**: `LoadAsync(Stream, Uri, TiledAssetFetcherAsync)` — awaits the TSX content read (`StreamReader.ReadToEndAsync` with `leaveOpen: true`), parses with the existing `ParseTilesetContent`, and decodes the image by `await fetcher(imageUri)` + `SKBitmap.Decode`. Added internal `FromDotTiledAsync` sharing the sync validation (no image / empty source / undecodable → same exceptions).
- **`TileMap`**: `LoadAsync(Stream, Uri, TiledAssetFetcherAsync)` — awaits the TMX content read, then **pre-fetches the external asset graph asynchronously** (external TSX + their images + embedded `<tileset><image>` images) into a `Dictionary<Uri, byte[]>` cache and reuses the existing synchronous DotTiled parsing/decoding against that memory cache, so no blocking I/O remains. The pre-fetch design is documented in the method remarks (pragmatic bridge until DotTiled exposes async resolvers).

### Tests

- New `AsyncOnlyStream` helper whose sync `Read`/`Position`/`Seek` throw and `CanSeek == false`, proving no synchronous read of the caller's stream.
- `SpriteSheetTests`: `LoadAsync` from an async-only stream; `LoadPartAsync` round-trips `PartType`; async paths keep duplicate-name → `InvalidOperationException` and invalid-dimensions → `ArgumentException`.
- `GameEngineTests`: `LoadSpriteSheetAsync` + `SpriteSheetRef` renders non-empty pixels; `LoadPartSpriteSheetAsync` composes part sheets.
- `TileMapTests`: `TileSet.LoadAsync` / `TileMap.LoadAsync` from async-only streams with a genuinely awaited async fetcher (assert dims, layer GIDs, rendering, and exception propagation); sync loaders unchanged (non-regression).
- `DocsExamplesTests`: async sheet + async map loading examples.

### Docs

Added `docs/api/TiledAssetFetcherAsync.md` and documented the new async methods on the existing API pages.

### Verification

```
dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~SpriteSheetTests|FullyQualifiedName~GameEngineTests|FullyQualifiedName~TileMapTests|FullyQualifiedName~DocsExamplesTests"
Passed! - Failed: 0, Passed: 86, Total: 86
```

Full suite: **223 passed, 0 failed, 0 warnings** (build with `TreatWarningsAsErrors`).