### PR TITLE
Story 23: spritesheets of arbitrary cell size (12×8 grid)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -16,7 +16,8 @@ Player ── Character (Position, Direction, BaseSpeed, SpriteSheets, walk-cycl
 `Player` is a thin wrapper that forwards state access and movement to its `Character`. All of
 the in-world state lives on `Character`:
 
-- `Character.Position` — top-left world pixel position of the 48×48 sprite.
+- `Character.Position` — top-left world pixel position of the sprite (its size is the
+  configured sheet's derived cell size).
 - `Character.Direction` — the facing direction (8 directions: Down/Left/Right/Up plus the four diagonals).
 - `Character.BaseSpeed` — movement speed in pixels per second.
 - `Character.SpriteSheets` — the list of `SpriteSheetRef`s (sheet name + 1..8 character index).
@@ -58,13 +59,13 @@ in this epic.
 (they are created when the map is loaded — there is no global tileset registry). Standalone
 tilesets are loaded through `TileSet.Load` factories when needed.
 
-## Spritesheet layout (576×384, 8 characters)
+## Spritesheet layout (normative 12×8 grid, 8 characters)
 
 Both **full** sheets and **part** sheets use the same normative RPG Maker MZ layout:
 
-- Image size: **576 × 384** pixels.
-- Cell size: **48 × 48** pixels.
-- Grid: **12 columns × 8 rows** of cells.
+- Grid: **12 columns × 8 rows** of cells (the grid is normative; the image size is not).
+- Cell size: **derived from the image** (`width / 12` × `height / 8`). The standard 576 × 384
+  sheet yields 48 × 48 cells; a 936 × 864 sheet yields 78 × 108 cells.
 - Characters: **8** (a 4 × 2 grid), each occupying a 3-cell × 4-row block
   (3 animation frames × 4 directions).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ using (var canvas = new SKCanvas(bitmap))
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering. |
 | [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input, asset loading, camera. |
 | [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state and sprite references. |
-| [api/SpriteSheet.md](api/SpriteSheet.md) | The 576×384 sheet layout and the **1..8 character index** semantics. |
+| [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading and rendering. |
 | [api/GameConfig.md](api/GameConfig.md) / [api/Key.md](api/Key.md) | Movement key bindings and host key translation. |
 | [api/Position.md](api/Position.md) / [api/Direction.md](api/Direction.md) | Core primitives. |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -118,8 +118,8 @@ using (var canvas = new SKCanvas(bitmap))
 ### `void LoadSpriteSheet(string name, string path)`
 
 Loads a full character spritesheet from a file path and registers it under `name`. Throws when
-the name is already loaded, the image cannot be decoded, or its dimensions are not exactly
-576×384.
+the name is already loaded, the image cannot be decoded, or its dimensions do not form a
+valid 12×8 grid (positive width divisible by 12 and positive height divisible by 8).
 
 ```csharp
 engine.LoadSpriteSheet("hero", "assets/characters/character_full.png");

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -18,7 +18,7 @@ state and calls `Move(direction, 1, dt)` in its update loop.
 ### `const double DefaultBaseSpeed = 96`
 
 The default movement speed in pixels per second of a player created by the parameterless
-constructor (96 px/s, i.e. one 48px tile every half second).
+constructor (96 px/s, i.e. two 48px map tiles every second).
 
 ## Constructors
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -48,5 +48,6 @@ documented**. Every page below includes a commented, compilable example; the tes
 
 The most important convention to understand before using the API: a `SpriteSheetRef(Name,
 CharacterIndex)` (and `SpriteSheet.GetSprite(characterIndex, …)`) selects one of the **8
-characters** in a **576×384** sheet. Both full and part sheets use this layout. See
+characters** in a sheet whose cells form the normative **12×8** grid (e.g. 576×384 with 48×48
+cells, or 936×864 with 78×108 cells). Both full and part sheets use this layout. See
 [SpriteSheet.md](SpriteSheet.md) and [SpriteSheetRef.md](SpriteSheetRef.md).

--- a/docs/api/SpriteSheet.md
+++ b/docs/api/SpriteSheet.md
@@ -2,30 +2,28 @@
 
 Namespace: `RPGEngine.Sprites` — a single RPG Maker MZ spritesheet.
 
-A 576×384 image made of 48×48 cells arranged in a 12-column × 8-row grid. It contains **8
-characters** laid out as a 4×2 grid; each character occupies a 3×4 block of cells (3 animation
+An image whose cells form the normative **12-column × 8-row grid**. The cell size is **derived
+from the image dimensions** (`width / 12` × `height / 8`), so both the standard 576×384 sheet
+(48×48 cells) and larger sheets such as a 936×864 sheet (78×108 cells) are supported. It contains
+**8 characters** laid out as a 4×2 grid; each character occupies a 3×4 block of cells (3 animation
 frames × 4 directions). Both full sheets and part sheets use this same layout.
 
 ## Remarks
 
 - `SpriteSheetRef(Name, CharacterIndex)` and `SpriteSheet.GetSprite(characterIndex, ...)` select
-  one of the **8 characters** in a **576×384** sheet (both full and part sheets).
+  one of the **8 characters** in a sheet (both full and part sheets).
 - Instances are created through `SpriteSheetManager` (the constructor is internal) and own the
   single decoded `SKImage` that backs every sprite returned by `GetSprite`.
 
 ## Constants
 
-### `const int CellSize = 48`
+### `const int Columns = 12`
 
-The width and height of a single character cell in pixels (normative RPG Maker MZ value).
+The normative grid width, in cells.
 
-### `const int SheetWidth = 576`
+### `const int Rows = 8`
 
-The width of a full or part spritesheet in pixels (12 cells).
-
-### `const int SheetHeight = 384`
-
-The height of a full or part spritesheet in pixels (8 cells).
+The normative grid height, in cells.
 
 ## Properties
 
@@ -43,7 +41,12 @@ Gets the character layer this part sheet provides, or `null` when `Type` is `Ful
 
 ### `int CellWidth` / `int CellHeight`
 
-Get the width and height of a single cell in pixels (always 48).
+Get the derived width and height of a single cell in pixels (`sheet width / Columns` and
+`sheet height / Rows`). For a 576×384 sheet this is 48×48; for a 936×864 sheet it is 78×108.
+
+### `int SheetWidth` / `int SheetHeight`
+
+Get the total sheet size in pixels (`Columns × CellWidth`, `Rows × CellHeight`).
 
 ### `int CharacterCount`
 
@@ -53,9 +56,10 @@ Gets the number of characters contained in the sheet (always 8).
 
 ### `SKImage GetSprite(int characterIndex, Direction direction, int frame)`
 
-Returns the 48×48 sprite at `(direction, frame)` for the character `characterIndex` (1-based,
-1..8). The returned image is an independent raster crop the caller owns and disposes. Throws
-`ArgumentOutOfRangeException` when `characterIndex` is outside 1..8 or `frame` is outside 0..2.
+Returns the `CellWidth × CellHeight` sprite at `(direction, frame)` for the character
+`characterIndex` (1-based, 1..8). The returned image is an independent raster crop the caller owns
+and disposes. Throws `ArgumentOutOfRangeException` when `characterIndex` is outside 1..8 or
+`frame` is outside 0..2.
 
 Character `i` is located at `charCol = (i - 1) % 4`, `charRow = (i - 1) / 4`; its cell
 `(frame, direction)` is at column `charCol * 3 + frame` and row `charRow * 4 + direction.RowIndex()`.
@@ -76,8 +80,9 @@ using (var stream = File.OpenRead("assets/characters/character_full.png"))
     var sheet = manager.Load("hero", stream);
 
     Console.WriteLine(sheet.CharacterCount); // 8
+    Console.WriteLine($"{sheet.CellWidth}×{sheet.CellHeight}"); // 48×48 for a 576×384 sheet
 
-    // Every 1-based index 1..8 yields an independent 48×48 sprite.
+    // Every 1-based index 1..8 yields an independent sprite at the derived cell size.
     for (var characterIndex = 1; characterIndex <= 8; characterIndex++)
     {
         using var sprite = sheet.GetSprite(characterIndex, Direction.Down, frame: 1);
@@ -94,3 +99,5 @@ using (var stream = File.OpenRead("assets/characters/character_full.png"))
     }
 }
 ```
+
+A 936×864 sheet derives 78×108 cells, so the same example reports `78×108` sprites.

--- a/docs/api/SpriteSheetManager.md
+++ b/docs/api/SpriteSheetManager.md
@@ -17,8 +17,9 @@ unique name.
 ### `SpriteSheet Load(string name, string path)`
 
 Loads the full character spritesheet at `path` and registers it under `name`. Throws for a null
-name/path, an empty trimmed name, a non-576×384 image, an undecodable image, or a duplicate
-name.
+name/path, an empty trimmed name, an image whose dimensions do not form a valid 12×8 grid
+(positive width divisible by 12 and positive height divisible by 8), an undecodable image, or
+a duplicate name.
 
 ```csharp
 var manager = new SpriteSheetManager();

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -166,7 +166,7 @@ public sealed class Character
     /// <paramref name="spriteSheetManager"/>, which the engine supplies at draw time.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
-    /// <param name="screenPosition">The top-left screen position of the 48×48 sprite.</param>
+    /// <param name="screenPosition">The top-left screen position of the sprite (its size is the sheet's derived cell size).</param>
     /// <param name="dt">The elapsed time in seconds (reserved for future animation timing).</param>
     /// <param name="spriteSheetManager">The manager that resolves the referenced sheet names.</param>
     /// <exception cref="InvalidOperationException">
@@ -179,6 +179,30 @@ public sealed class Character
     internal void Draw(SKCanvas canvas, Position screenPosition, double dt, SpriteSheetManager spriteSheetManager)
     {
         _compositor.Draw(canvas, screenPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager);
+    }
+
+    /// <summary>
+    /// Resolves the pixel size of the character's sprite: the first entry of
+    /// <see cref="SpriteSheets"/> is looked up through <paramref name="manager"/> and that sheet's
+    /// derived <see cref="SpriteSheet.CellWidth"/>/<see cref="SpriteSheet.CellHeight"/> are
+    /// returned. When <see cref="SpriteSheets"/> is empty, the documented default of 48×48 is
+    /// returned (the classic RPG Maker MZ cell size).
+    /// </summary>
+    /// <param name="manager">The manager that resolves the referenced sheet names.</param>
+    /// <returns>The sprite size <c>(width, height)</c> in pixels.</returns>
+    /// <remarks>
+    /// Used by the engine to clamp a character (notably the player) inside the map bounds using
+    /// its actual rendered size, whatever the sheet's derived cell size is.
+    /// </remarks>
+    internal (int Width, int Height) GetSpriteSize(SpriteSheetManager manager)
+    {
+        if (_spriteSheets.Count == 0)
+        {
+            return (48, 48);
+        }
+
+        var sheet = manager.Get(_spriteSheets[0].Name);
+        return (sheet.CellWidth, sheet.CellHeight);
     }
 
     private void AdvanceFrame()

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -192,7 +192,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by <see cref="SpriteSheet.Columns"/> and positive height divisible by <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public void LoadSpriteSheet(string name, string path) => _spriteSheetManager.Load(name, path);
@@ -207,7 +207,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by <see cref="SpriteSheet.Columns"/> and positive height divisible by <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -226,7 +226,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by <see cref="SpriteSheet.Columns"/> and positive height divisible by <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -248,7 +248,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by <see cref="SpriteSheet.Columns"/> and positive height divisible by <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -267,7 +267,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by <see cref="SpriteSheet.Columns"/> and positive height divisible by <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -288,7 +288,7 @@ public sealed class GameEngine
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by <see cref="SpriteSheet.Columns"/> and positive height divisible by <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>The caller remains the owner of <paramref name="stream"/>; it is not disposed here.</remarks>
@@ -325,14 +325,17 @@ public sealed class GameEngine
     }
 
     /// <summary>
-    /// Clamps the player's top-left position so the 48×48 sprite stays inside the map bounds:
-    /// <c>x ∈ [0, PixelWidth - 48]</c>, <c>y ∈ [0, PixelHeight - 48]</c>. Called after every
-    /// move while a map is set.
+    /// Clamps the player's top-left position so its sprite stays inside the map bounds. The
+    /// sprite size is resolved from the player's configured spritesheet (see
+    /// <see cref="Character.GetSpriteSize"/>); when no sheet is configured it falls back to the
+    /// 48×48 default. <c>x ∈ [0, PixelWidth - spriteWidth]</c>, <c>y ∈ [0, PixelHeight - spriteHeight]</c>.
+    /// Called after every move while a map is set.
     /// </summary>
     private void ClampPlayerToMap()
     {
-        var maxX = Math.Max(0, Map!.PixelWidth - SpriteSheet.CellSize);
-        var maxY = Math.Max(0, Map!.PixelHeight - SpriteSheet.CellSize);
+        var (spriteWidth, spriteHeight) = Player.Character.GetSpriteSize(_spriteSheetManager);
+        var maxX = Math.Max(0, Map!.PixelWidth - spriteWidth);
+        var maxY = Math.Max(0, Map!.PixelHeight - spriteHeight);
 
         var position = Player.Position;
         Player.Position = new Position(

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -24,7 +24,8 @@ public sealed class Player
 {
     /// <summary>
     /// The default movement speed, in pixels per second, of a player created by the parameterless
-    /// constructor: 96 px/s, i.e. one 48px tile every half second. This is a gameplay tuning
+    /// constructor: 96 px/s, i.e. two 48px map tiles every second (the tile grid is fixed at
+    /// 48px regardless of the sprite's derived cell size). This is a gameplay tuning
     /// constant and is expected to be adjusted later.
     /// </summary>
     public const double DefaultBaseSpeed = 96;

--- a/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
+++ b/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
@@ -10,8 +10,9 @@ namespace RPGEngine.Sprites;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The part composition reproduces the epic's PIXI.js example with 48×48 cells. For the current
-/// animation frame and direction the 48×48 cell of each part is drawn bottom → top in exactly
+/// The part composition reproduces the epic's PIXI.js example. For the current animation
+/// frame and direction the cell of each part (at the sheet's derived cell size, e.g. 48×48
+/// for a 576×384 sheet or 78×108 for a 936×864 sheet) is drawn bottom → top in exactly
 /// this order (missing parts are skipped):
 /// </para>
 /// <list type="number">
@@ -40,7 +41,7 @@ internal sealed class CharacterSpriteCompositor
     /// <paramref name="screenPosition"/>.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
-    /// <param name="screenPosition">The top-left screen position of the 48×48 sprite.</param>
+    /// <param name="screenPosition">The top-left screen position of the sprite (its size is the sheet's derived cell size).</param>
     /// <param name="spriteSheetRefs">The spritesheet references to use (sheet name + character index).</param>
     /// <param name="direction">The direction the character faces.</param>
     /// <param name="frame">The animation frame (0..2).</param>
@@ -178,7 +179,7 @@ internal sealed class CharacterSpriteCompositor
         DrawCell(canvas, screenPosition, part.Value, direction, frame);
     }
 
-    /// <summary>Draws the 48×48 cell selected by the part's own character index.</summary>
+    /// <summary>Draws the cell selected by the part's own character index at its native size.</summary>
     private static void DrawCell(
         SKCanvas canvas,
         Position screenPosition,
@@ -187,7 +188,7 @@ internal sealed class CharacterSpriteCompositor
         int frame)
     {
         // GetSprite validates the index/frame again defensively and returns an independent
-        // 48×48 image that the caller owns.
+        // image at the sheet's derived cell size that the caller owns.
         using var sprite = part.Sheet.GetSprite(part.Ref.CharacterIndex, direction, frame);
         canvas.DrawImage(sprite, new SKPoint((float)screenPosition.X, (float)screenPosition.Y));
     }

--- a/src/RPGEngine/Sprites/SpriteSheet.cs
+++ b/src/RPGEngine/Sprites/SpriteSheet.cs
@@ -3,9 +3,12 @@ using SkiaSharp;
 namespace RPGEngine.Sprites;
 
 /// <summary>
-/// A single RPG Maker MZ spritesheet: a 576×384 image made of 48×48 cells arranged in a
-/// 12-column × 8-row grid. It contains 8 characters laid out as a 4×2 grid; each character
-/// occupies a 3×4 block of cells (3 animation frames × 4 directions).
+/// A single RPG Maker MZ spritesheet: an image whose cells form a normative 12-column × 8-row
+/// grid. The cell size is derived from the image dimensions (<c>width / 12</c> ×
+/// <c>height / 8</c>), so the standard 576×384 sheet (48×48 cells) and larger sheets such as a
+/// 936×864 sheet (78×108 cells) are both supported. The sheet contains 8 characters laid out
+/// as a 4×2 grid; each character occupies a 3×4 block of cells (3 animation frames ×
+/// 4 directions).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,21 +24,16 @@ namespace RPGEngine.Sprites;
 /// </remarks>
 public sealed class SpriteSheet
 {
-    private const int CellsPerRow = 12;
-    private const int CellRows = 8;
     private const int CharactersPerRow = 4;
     private const int CharacterRowCount = 2;
     private const int FramesPerCharacter = 3;
     private const int DirectionsPerCharacter = 4;
 
-    /// <summary>The width and height of a single character cell in pixels (normative RPG Maker MZ value).</summary>
-    public const int CellSize = 48;
+    /// <summary>The normative grid width, in cells.</summary>
+    public const int Columns = 12;
 
-    /// <summary>The width of a full or part spritesheet in pixels (normative RPG Maker MZ value: 12 cells).</summary>
-    public const int SheetWidth = CellsPerRow * CellSize; // 576
-
-    /// <summary>The height of a full or part spritesheet in pixels (normative RPG Maker MZ value: 8 cells).</summary>
-    public const int SheetHeight = CellRows * CellSize; // 384
+    /// <summary>The normative grid height, in cells.</summary>
+    public const int Rows = 8;
 
     private readonly SKImage _source;
 
@@ -51,11 +49,23 @@ public sealed class SpriteSheet
     /// </summary>
     public CharacterPartType? PartType { get; }
 
-    /// <summary>Gets the width of a single cell in pixels (always 48).</summary>
-    public int CellWidth => CellSize;
+    /// <summary>Gets the width of a single cell in pixels (<c>sheet width / Columns</c>).</summary>
+    /// <remarks>
+    /// Derived from the decoded image: 48 for a 576×384 sheet, 78 for a 936×864 sheet.
+    /// </remarks>
+    public int CellWidth { get; }
 
-    /// <summary>Gets the height of a single cell in pixels (always 48).</summary>
-    public int CellHeight => CellSize;
+    /// <summary>Gets the height of a single cell in pixels (<c>sheet height / Rows</c>).</summary>
+    /// <remarks>
+    /// Derived from the decoded image: 48 for a 576×384 sheet, 108 for a 936×864 sheet.
+    /// </remarks>
+    public int CellHeight { get; }
+
+    /// <summary>Gets the total sheet width in pixels (<see cref="Columns"/> × <see cref="CellWidth"/>).</summary>
+    public int SheetWidth => Columns * CellWidth;
+
+    /// <summary>Gets the total sheet height in pixels (<see cref="Rows"/> × <see cref="CellHeight"/>).</summary>
+    public int SheetHeight => Rows * CellHeight;
 
     /// <summary>Gets the number of characters contained in the sheet (always 8).</summary>
     public int CharacterCount => CharactersPerRow * CharacterRowCount;
@@ -67,18 +77,30 @@ public sealed class SpriteSheet
     /// <param name="name">The unique name used to reference the sheet.</param>
     /// <param name="type">The kind of sheet (full or part).</param>
     /// <param name="partType">The character layer for part sheets, or <see langword="null"/> for full sheets.</param>
-    /// <param name="source">The decoded sheet image, already validated as 576×384.</param>
-    internal SpriteSheet(string name, SpriteSheetType type, CharacterPartType? partType, SKImage source)
+    /// <param name="source">The decoded sheet image, already validated as a 12×8 grid.</param>
+    /// <param name="cellWidth">The derived cell width (<c>source.Width / Columns</c>).</param>
+    /// <param name="cellHeight">The derived cell height (<c>source.Height / Rows</c>).</param>
+    internal SpriteSheet(
+        string name,
+        SpriteSheetType type,
+        CharacterPartType? partType,
+        SKImage source,
+        int cellWidth,
+        int cellHeight)
     {
         Name = name;
         Type = type;
         PartType = partType;
         _source = source ?? throw new ArgumentNullException(nameof(source));
+        CellWidth = cellWidth;
+        CellHeight = cellHeight;
     }
 
     /// <summary>
-    /// Returns the 48×48 sprite at (<paramref name="direction"/>, <paramref name="frame"/>) for
-    /// the character <paramref name="characterIndex"/> (1-based) within the sheet.
+    /// Returns the <see cref="CellWidth"/>×<see cref="CellHeight"/> sprite at
+    /// (<paramref name="direction"/>, <paramref name="frame"/>) for the character
+    /// <paramref name="characterIndex"/> (1-based) within the sheet. For a standard 576×384
+    /// sheet this is a 48×48 crop; for a 936×864 sheet it is 78×108.
     /// </summary>
     /// <param name="characterIndex">The 1-based index (1..8) of the character in the sheet.</param>
     /// <param name="direction">The direction the sprite faces. Cardinal directions map to
@@ -96,11 +118,11 @@ public sealed class SpriteSheet
     /// its cell <c>(frame, direction)</c> is at column <c>charCol * 3 + frame</c> and row
     /// <c>charRow * 4 + direction.RowIndex()</c>.
     /// <para>
-    /// The returned image is an independent 48×48 raster crop of the decoded source, produced
-    /// with nearest-neighbour sampling (a 1:1 pixel copy, never a re-encode). We deliberately
-    /// avoid <c>SKImage.Subset</c> here: on SkiaSharp 3.119.4, subsets of an image decoded from
-    /// encoded data crash the native runtime once an earlier subset has been disposed (the same
-    /// reasoning as <c>TileSet.GetTileImage</c>).
+    /// The returned image is an independent <see cref="CellWidth"/>×<see cref="CellHeight"/>
+    /// raster crop of the decoded source, produced with nearest-neighbour sampling (a 1:1 pixel
+    /// copy, never a re-encode). We deliberately avoid <c>SKImage.Subset</c> here: on SkiaSharp
+    /// 3.119.4, subsets of an image decoded from encoded data crash the native runtime once an
+    /// earlier subset has been disposed (the same reasoning as <c>TileSet.GetTileImage</c>).
     /// </para>
     /// </remarks>
     public SKImage GetSprite(int characterIndex, Direction direction, int frame)
@@ -127,21 +149,21 @@ public sealed class SpriteSheet
         var row = (charRow * DirectionsPerCharacter) + direction.RowIndex();
 
         var source = new SKRectI(
-            col * CellSize,
-            row * CellSize,
-            (col + 1) * CellSize,
-            (row + 1) * CellSize);
+            col * CellWidth,
+            row * CellHeight,
+            (col + 1) * CellWidth,
+            (row + 1) * CellHeight);
 
         // Raster crop of the decoded source with nearest-neighbour sampling (1:1 pixel copy, no
         // re-encode). SKImage.FromBitmap copies the pixels, so the returned image is independent
         // of _source and of the temporary bitmap disposed below.
-        var spriteBitmap = new SKBitmap(CellSize, CellSize);
+        var spriteBitmap = new SKBitmap(CellWidth, CellHeight);
         try
         {
             using var canvas = new SKCanvas(spriteBitmap);
             canvas.Clear(SKColors.Transparent);
 
-            var destination = new SKRect(0, 0, CellSize, CellSize);
+            var destination = new SKRect(0, 0, CellWidth, CellHeight);
             var sampling = new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
             canvas.DrawImage(_source, source, destination, sampling);
 

--- a/src/RPGEngine/Sprites/SpriteSheetManager.cs
+++ b/src/RPGEngine/Sprites/SpriteSheetManager.cs
@@ -18,6 +18,13 @@ namespace RPGEngine.Sprites;
 /// given layer. The kind and part type are stored on the returned <see cref="SpriteSheet"/>.
 /// </para>
 /// <para>
+/// Any image whose dimensions form a valid 12×8 grid is accepted: the width must be a positive
+/// multiple of <see cref="SpriteSheet.Columns"/> and the height a positive multiple of
+/// <see cref="SpriteSheet.Rows"/>. The cell size is derived from the decoded image
+/// (<c>width / 12</c> × <c>height / 8</c>), so both the standard 576×384 sheet (48×48 cells)
+/// and e.g. a 936×864 sheet (78×108 cells) load correctly.
+/// </para>
+/// <para>
 /// Names are case-sensitive and trimmed on registration, lookup and duplicate checks. Loading a
 /// name that is already registered throws <see cref="InvalidOperationException"/>.
 /// </para>
@@ -36,7 +43,9 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by
+    /// <see cref="SpriteSheet.Columns"/> and positive height divisible by
+    /// <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public SpriteSheet Load(string name, string path)
@@ -60,7 +69,9 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by
+    /// <see cref="SpriteSheet.Columns"/> and positive height divisible by
+    /// <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -90,7 +101,9 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by
+    /// <see cref="SpriteSheet.Columns"/> and positive height divisible by
+    /// <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -126,7 +139,9 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by
+    /// <see cref="SpriteSheet.Columns"/> and positive height divisible by
+    /// <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     public SpriteSheet LoadPart(string name, string path, CharacterPartType partType)
@@ -151,7 +166,9 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by
+    /// <see cref="SpriteSheet.Columns"/> and positive height divisible by
+    /// <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -180,7 +197,9 @@ public sealed class SpriteSheetManager
     /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="name"/> is empty after trimming, the image cannot be decoded, or its
-    /// dimensions are not exactly <see cref="SpriteSheet.SheetWidth"/>×<see cref="SpriteSheet.SheetHeight"/>.
+    /// dimensions do not form a valid 12×8 grid (positive width divisible by
+    /// <see cref="SpriteSheet.Columns"/> and positive height divisible by
+    /// <see cref="SpriteSheet.Rows"/>).
     /// </exception>
     /// <exception cref="InvalidOperationException">A sheet named <paramref name="name"/> is already loaded.</exception>
     /// <remarks>
@@ -247,7 +266,13 @@ public sealed class SpriteSheetManager
 
     private SpriteSheet Register(string name, SpriteSheetType type, CharacterPartType? partType, SKImage source)
     {
-        var sheet = new SpriteSheet(name, type, partType, source);
+        var sheet = new SpriteSheet(
+            name,
+            type,
+            partType,
+            source,
+            source.Width / SpriteSheet.Columns,
+            source.Height / SpriteSheet.Rows);
         _sheets.Add(name, sheet);
         return sheet;
     }
@@ -275,12 +300,14 @@ public sealed class SpriteSheetManager
         // Dispose() would be a native use-after-free).
         var width = image.Width;
         var height = image.Height;
-        if (width != SpriteSheet.SheetWidth || height != SpriteSheet.SheetHeight)
+        if (width <= 0 || height <= 0 || width % SpriteSheet.Columns != 0 || height % SpriteSheet.Rows != 0)
         {
             image.Dispose();
             throw new ArgumentException(
-                $"Spritesheet '{name}' must be {SpriteSheet.SheetWidth}×{SpriteSheet.SheetHeight} pixels " +
-                $"(RPG Maker MZ full or part sheet), but was {width}×{height}.");
+                $"Spritesheet '{name}' must be an image whose dimensions form a valid " +
+                $"{SpriteSheet.Columns}×{SpriteSheet.Rows} grid (positive width divisible by " +
+                $"{SpriteSheet.Columns} and positive height divisible by {SpriteSheet.Rows}), " +
+                $"but was {width}×{height}.");
         }
 
         return image;

--- a/tests/RPGEngine.Tests/CharacterTestHelper.cs
+++ b/tests/RPGEngine.Tests/CharacterTestHelper.cs
@@ -5,7 +5,8 @@ namespace RPGEngine.Tests;
 /// <summary>
 /// Generates RPG Maker MZ spritesheet fixtures for the <see cref="CharacterTests"/>.
 /// Each sheet is identified by a <em>seed</em> so that different sheets (different character
-/// parts) get globally distinct cell colors; within a sheet, every 48×48 cell is uniquely
+/// parts) get globally distinct cell colors; within a sheet, every cell (at the sheet's derived
+/// size) is uniquely
 /// colored by (row, column). This lets pixel-level composition tests tell which part ended up
 /// on top.
 /// </summary>
@@ -51,8 +52,21 @@ internal static class CharacterTestHelper
     /// filled with the unique color from <see cref="CellColor(int, int, int)"/>.
     /// </summary>
     public static byte[] CreateSheetPng(int seed, bool transparent = false)
+        => CreateSheetPng(seed, SheetWidth, SheetHeight, transparent);
+
+    /// <summary>
+    /// Encodes a sheet of the requested dimensions as PNG. The grid is always the normative
+    /// 12×8 layout, so the cell size is derived from the image (e.g. 48×48 for 576×384,
+    /// 78×108 for 936×864). When <paramref name="transparent"/> is <see langword="true"/>
+    /// every cell is fully transparent; otherwise each cell is filled with the unique color from
+    /// <see cref="CellColor(int, int, int)"/> at the derived cell size.
+    /// </summary>
+    public static byte[] CreateSheetPng(int seed, int width, int height, bool transparent = false)
     {
-        using var bitmap = new SKBitmap(SheetWidth, SheetHeight);
+        var cellWidth = width / Columns;
+        var cellHeight = height / Rows;
+
+        using var bitmap = new SKBitmap(width, height);
         using (var canvas = new SKCanvas(bitmap))
         {
             canvas.Clear(SKColors.Transparent);
@@ -65,7 +79,7 @@ internal static class CharacterTestHelper
                     {
                         using var paint = new SKPaint { Color = CellColor(seed, row, col), IsAntialias = false };
                         canvas.DrawRect(
-                            new SKRect(col * CellSize, row * CellSize, (col + 1) * CellSize, (row + 1) * CellSize),
+                            new SKRect(col * cellWidth, row * cellHeight, (col + 1) * cellWidth, (row + 1) * cellHeight),
                             paint);
                     }
                 }
@@ -79,7 +93,11 @@ internal static class CharacterTestHelper
 
     /// <summary>Returns a read-only stream containing a 576×384 sheet encoded as PNG.</summary>
     public static MemoryStream CreateSheetStream(int seed, bool transparent = false)
-        => new(CreateSheetPng(seed, transparent), writable: false);
+        => CreateSheetStream(seed, SheetWidth, SheetHeight, transparent);
+
+    /// <summary>Returns a read-only stream containing a sheet of the requested dimensions encoded as PNG.</summary>
+    public static MemoryStream CreateSheetStream(int seed, int width, int height, bool transparent = false)
+        => new(CreateSheetPng(seed, width, height, transparent), writable: false);
 
     /// <summary>
     /// Computes the sheet cell (row, col) that <c>SpriteSheet.GetSprite</c> crops for the given

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -367,6 +367,57 @@ public class CharacterTests
     }
 
     // ---------------------------------------------------------------------
+    // Acceptance (story 23): a character using a 936×864 sheet (78×108 cells)
+    // renders a 78×108 sprite at its position; part composition works on the
+    // derived cell size.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a character with a single full 936×864 sheet renders a 78×108 sprite at its position.</summary>
+    [Fact]
+    public void Draw_LargeFullSheet_Renders78x108SpriteAtPosition()
+    {
+        var manager = new SpriteSheetManager();
+        using (var stream = CharacterTestHelper.CreateSheetStream(seed: 0, width: 936, height: 864))
+        {
+            manager.Load("hero", stream);
+        }
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        character.Move(Direction.Down, speedFactor: 0);
+
+        using var bitmap = Render(character, manager, width: 78, height: 108);
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.Down, StandingFrame);
+        AssertPixel(bitmap, expected, width: 78, height: 108);
+    }
+
+    /// <summary>Verifies 936×864 part sheets still compose on the derived 78×108 cell size (hair2 on top when facing up).</summary>
+    [Fact]
+    public void Draw_LargePartSheets_ComposeOnDerivedCellSize()
+    {
+        var manager = new SpriteSheetManager();
+        using (var bodyStream = CharacterTestHelper.CreateSheetStream(seed: 1, width: 936, height: 864))
+        {
+            manager.LoadPart("body", bodyStream, CharacterPartType.Body);
+        }
+        using (var hairStream = CharacterTestHelper.CreateSheetStream(seed: 3, width: 936, height: 864))
+        {
+            manager.LoadPart("hair2", hairStream, CharacterPartType.Hair2);
+        }
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("body", CharacterIndex: 1));
+        character.SpriteSheets.Add(new SpriteSheetRef("hair2", CharacterIndex: 1));
+
+        // Facing up: the per-direction adjustment draws hair2 over the body on the 78×108 sprite.
+        character.Move(Direction.Up, speedFactor: 0);
+        using var bitmap = Render(character, manager, width: 78, height: 108);
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 1, Direction.Up, StandingFrame); // hair2
+        AssertPixel(bitmap, expected, width: 78, height: 108);
+    }
+
+    // ---------------------------------------------------------------------
     // Additional coverage: a character with no sprite sheets draws nothing.
     // ---------------------------------------------------------------------
     /// <summary>Verifies a character with an empty SpriteSheets list draws nothing (no exception, transparent output).</summary>
@@ -423,10 +474,14 @@ public class CharacterTests
         return manager;
     }
 
-    /// <summary>Renders the character into a fresh 48×48 bitmap at the origin.</summary>
-    private static SKBitmap Render(Character character, SpriteSheetManager manager)
+    /// <summary>Renders the character into a fresh bitmap of the requested size at the origin.</summary>
+    private static SKBitmap Render(
+        Character character,
+        SpriteSheetManager manager,
+        int width = CharacterTestHelper.CellSize,
+        int height = CharacterTestHelper.CellSize)
     {
-        var bitmap = new SKBitmap(CharacterTestHelper.CellSize, CharacterTestHelper.CellSize);
+        var bitmap = new SKBitmap(width, height);
         using (var canvas = new SKCanvas(bitmap))
         {
             canvas.Clear(SKColors.Transparent);
@@ -437,10 +492,14 @@ public class CharacterTests
     }
 
     /// <summary>Asserts the centre and both corners of the sprite have the expected color.</summary>
-    private static void AssertPixel(SKBitmap bitmap, SKColor expected)
+    private static void AssertPixel(
+        SKBitmap bitmap,
+        SKColor expected,
+        int width = CharacterTestHelper.CellSize,
+        int height = CharacterTestHelper.CellSize)
     {
-        Assert.Equal(expected, bitmap.GetPixel(24, 24));
+        Assert.Equal(expected, bitmap.GetPixel(width / 2, height / 2));
         Assert.Equal(expected, bitmap.GetPixel(0, 0));
-        Assert.Equal(expected, bitmap.GetPixel(47, 47));
+        Assert.Equal(expected, bitmap.GetPixel(width - 1, height - 1));
     }
 }

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -1,5 +1,6 @@
 using RPGEngine.Sprites;
 using RPGEngine.Tests.Fixtures;
+using RPGEngine.Tests.Sprites;
 using RPGEngine.Tiled;
 using SkiaSharp;
 using Xunit;
@@ -76,31 +77,52 @@ public class DocsExamplesTests
     // docs/api/SpriteSheet.md: the character index 1..8 semantics.
     // ---------------------------------------------------------------------
     /// <summary>
-    /// Verifies <see cref="SpriteSheet.GetSprite"/> selects one of the 8 characters in a
-    /// 576×384 sheet (both full and part sheets share this layout) and that the returned sprite
-    /// is a 48×48 image the caller owns.
+    /// Verifies <see cref="SpriteSheet.GetSprite"/> selects one of the 8 characters in a sheet
+    /// and that the returned sprite is an independent crop at the sheet's derived cell size
+    /// (48×48 for a standard 576×384 sheet, 78×108 for a 936×864 sheet) which the caller
+    /// owns. Both full and part sheets share this layout.
     /// </summary>
     [Fact]
     public void CharacterIndex_SelectsOneOfEightCharacters()
     {
-        using var sheetStream = FixtureAssets.DecodePngStream(FixtureAssets.FullSheet);
-        var manager = new SpriteSheetManager();
-        var sheet = manager.Load("hero", sheetStream);
-
-        Assert.Equal(8, sheet.CharacterCount);
-
-        // Every 1-based index 1..8 yields an independent 48×48 sprite; the 8 slots are the
-        // sheet's 4×2 character grid, each a 3-frame × 4-direction block.
-        for (var characterIndex = 1; characterIndex <= 8; characterIndex++)
+        // Standard RPG Maker MZ sheet: 576×384 &#8594; 48×48 cells.
+        using (var sheetStream = FixtureAssets.DecodePngStream(FixtureAssets.FullSheet))
         {
-            using var sprite = sheet.GetSprite(characterIndex, Direction.Down, frame: 1);
-            Assert.Equal(48, sprite.Width);
-            Assert.Equal(48, sprite.Height);
+            var manager = new SpriteSheetManager();
+            var sheet = manager.Load("hero", sheetStream);
+
+            Assert.Equal(8, sheet.CharacterCount);
+            Assert.Equal(48, sheet.CellWidth);
+            Assert.Equal(48, sheet.CellHeight);
+
+            // Every 1-based index 1..8 yields an independent sprite at the derived cell size;
+            // the 8 slots are the sheet's 4×2 character grid, each a 3-frame × 4-direction block.
+            for (var characterIndex = 1; characterIndex <= 8; characterIndex++)
+            {
+                using var sprite = sheet.GetSprite(characterIndex, Direction.Down, frame: 1);
+                Assert.Equal(sheet.CellWidth, sprite.Width);
+                Assert.Equal(sheet.CellHeight, sprite.Height);
+            }
+
+            // An index outside 1..8 is rejected.
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GetSprite(0, Direction.Down, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GetSprite(9, Direction.Down, 1));
         }
 
-        // An index outside 1..8 is rejected.
-        Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GetSprite(0, Direction.Down, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GetSprite(9, Direction.Down, 1));
+        // A 936×864 sheet derives 78×108 cells.
+        using (var largeStream = new MemoryStream(SpriteSheetTestHelper.CreateSheetPng(936, 864), writable: false))
+        {
+            var manager = new SpriteSheetManager();
+            var sheet = manager.Load("large", largeStream);
+
+            Assert.Equal(8, sheet.CharacterCount);
+            Assert.Equal(78, sheet.CellWidth);
+            Assert.Equal(108, sheet.CellHeight);
+
+            using var sprite = sheet.GetSprite(1, Direction.Down, frame: 1);
+            Assert.Equal(78, sprite.Width);
+            Assert.Equal(108, sprite.Height);
+        }
 
         // SpriteSheetRef pairs a sheet name with the 1-based character index; the range is
         // enforced where the reference is consumed (e.g. at render time).

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -368,6 +368,63 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Acceptance (story 23): the player is clamped inside the map using its
+    // actual sprite size (78×108 for a 936×864 sheet), verified through
+    // ComputeCameraOrigin/rendering.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies ClampPlayerToMap uses the player's derived 78×108 sprite size (maxX = PixelWidth - 78, maxY = PixelHeight - 108).</summary>
+    [Fact]
+    public void ClampPlayerToMap_UsesPlayerSpriteSize()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480×480 px
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        using (var stream = CharacterTestHelper.CreateSheetStream(seed: 1, width: 936, height: 864))
+        {
+            engine.LoadSpriteSheet("hero", stream);
+        }
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+
+        // Beyond the bottom-right corner: clamps to (480 - 78, 480 - 108) = (402, 372).
+        engine.Player.Position = new Position(1000, 1000);
+        engine.Update(FrameDt);
+        Assert.Equal(480 - 78, engine.Player.Position.X, precision: 6);
+        Assert.Equal(480 - 108, engine.Player.Position.Y, precision: 6);
+
+        // Negative position clamps to (0, 0).
+        engine.Player.Position = new Position(-100, -100);
+        engine.Update(FrameDt);
+        Assert.Equal(0, engine.Player.Position.X, precision: 6);
+        Assert.Equal(0, engine.Player.Position.Y, precision: 6);
+    }
+
+    /// <summary>Verifies the 78×108 clamp through ComputeCameraOrigin and rendered output.</summary>
+    [Fact]
+    public void ClampPlayerToMap_LargeSheet_VerifiedViaCameraAndRender()
+    {
+        const int canvasSize = 240;
+        using var fixture = CreateFilledMapFixture(10, 10); // 480×480 px
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        using (var stream = CharacterTestHelper.CreateSheetStream(seed: 1, width: 936, height: 864))
+        {
+            engine.LoadSpriteSheet("hero", stream);
+        }
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+
+        engine.Player.Position = new Position(1000, 1000);
+        engine.Update(FrameDt); // clamps to (402, 372)
+
+        // The camera origin clamps to the map: maxX = maxY = 480 - 240 = 240.
+        Assert.Equal(new Position(240, 240), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+
+        // The 78×108 sprite renders at screen (402 - 240, 372 - 240) = (162, 132).
+        using var bitmap = Render(engine, canvasSize, canvasSize);
+        var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(162 + 39, 132 + 54));
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 

--- a/tests/RPGEngine.Tests/Sprites/SpriteSheetTestHelper.cs
+++ b/tests/RPGEngine.Tests/Sprites/SpriteSheetTestHelper.cs
@@ -1,10 +1,14 @@
+using System.IO.Compression;
+using System.Text;
 using SkiaSharp;
 
 namespace RPGEngine.Tests.Sprites;
 
 /// <summary>
-/// Generates RPG Maker MZ spritesheet fixtures: 576×384 images whose 48×48 cells are uniquely
-/// colored by (row, column), so tests can assert exact crops without shipping binary assets.
+/// Generates RPG Maker MZ spritesheet fixtures: images whose cells form a 12×8 grid and are
+/// uniquely colored by (row, column), so tests can assert exact crops without shipping binary
+/// assets. The standard 576×384 sheet yields 48×48 cells; arbitrary valid sizes such as
+/// 936×864 yield 78×108 cells.
 /// </summary>
 internal static class SpriteSheetTestHelper
 {
@@ -19,17 +23,33 @@ internal static class SpriteSheetTestHelper
         => new((byte)col, (byte)row, (byte)((row * Columns) + col), alpha: 255);
 
     /// <summary>
-    /// Encodes a PNG of the requested dimensions. A 576×384 sheet gets the unique per-cell
-    /// colors; any other size is left transparent (only its dimensions matter for validation).
+    /// Encodes a PNG of the requested dimensions. When the dimensions form a valid 12×8 grid
+    /// (positive width divisible by <see cref="Columns"/> and positive height divisible by
+    /// <see cref="Rows"/>), every cell is filled with the unique per-cell color from
+    /// <see cref="CellColor(int,int)"/> at the derived cell size (e.g. 48×48 for 576×384,
+    /// 78×108 for 936×864); any other size is left transparent (only its dimensions matter
+    /// for validation tests).
     /// </summary>
     public static byte[] CreateSheetPng(int width = SheetWidth, int height = SheetHeight)
     {
+        if (width <= 0 || height <= 0)
+        {
+            // SkiaSharp cannot encode a zero-dimension image, so hand-build raw PNG bytes that
+            // represent those dimensions. They are not decodable (PNG requires positive
+            // dimensions), but they let the loader's ArgumentException path be exercised.
+            return CreateRawPng(width, height);
+        }
+
+        var cellWidth = width / Columns;
+        var cellHeight = height / Rows;
+        var validGrid = width % Columns == 0 && height % Rows == 0;
+
         using var bitmap = new SKBitmap(width, height);
         using (var canvas = new SKCanvas(bitmap))
         {
             canvas.Clear(SKColors.Transparent);
 
-            if (width == SheetWidth && height == SheetHeight)
+            if (validGrid)
             {
                 for (var row = 0; row < Rows; row++)
                 {
@@ -37,7 +57,7 @@ internal static class SpriteSheetTestHelper
                     {
                         using var paint = new SKPaint { Color = CellColor(row, col), IsAntialias = false };
                         canvas.DrawRect(
-                            new SKRect(col * CellSize, row * CellSize, (col + 1) * CellSize, (row + 1) * CellSize),
+                            new SKRect(col * cellWidth, row * cellHeight, (col + 1) * cellWidth, (row + 1) * cellHeight),
                             paint);
                     }
                 }
@@ -51,4 +71,91 @@ internal static class SpriteSheetTestHelper
 
     /// <summary>Returns a read-only stream containing a standard 576×384 sheet encoded as PNG.</summary>
     public static MemoryStream CreateSheetStream() => new(CreateSheetPng(), writable: false);
+
+    /// <summary>
+    /// Hand-builds raw PNG bytes with the requested (possibly zero) dimensions without going
+    /// through the SkiaSharp encoder, using 8-bit RGBA (color type 6) and valid chunk CRCs.
+    /// </summary>
+    private static byte[] CreateRawPng(int width, int height)
+    {
+        using var ms = new MemoryStream();
+        ms.Write(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, 0, 8);
+
+        var ihdr = new byte[13];
+        WriteBigEndian(ihdr, 0, width);
+        WriteBigEndian(ihdr, 4, height);
+        ihdr[8] = 8;  // bit depth
+        ihdr[9] = 6;  // color type: RGBA
+        ihdr[10] = 0; // compression
+        ihdr[11] = 0; // filter
+        ihdr[12] = 0; // interlace
+        ms.Write(Chunk("IHDR", ihdr), 0, 4 + 4 + 13 + 4);
+
+        // One scanline per row: a filter byte (0 = none) plus the row's pixel bytes. With a zero
+        // width the scanlines carry only the filter bytes; with a zero height IDAT is empty.
+        var raw = new List<byte>();
+        var rowBytes = checked(width * 4);
+        for (var y = 0; y < height; y++)
+        {
+            raw.Add(0);
+            for (var x = 0; x < rowBytes; x++)
+            {
+                raw.Add(0);
+            }
+        }
+
+        using var compressed = new MemoryStream();
+        using (var zlib = new ZLibStream(compressed, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            zlib.Write(raw.ToArray(), 0, raw.Count);
+        }
+
+        var idat = Chunk("IDAT", compressed.ToArray());
+        ms.Write(idat, 0, idat.Length);
+
+        var iend = Chunk("IEND", Array.Empty<byte>());
+        ms.Write(iend, 0, iend.Length);
+        return ms.ToArray();
+    }
+
+    private static void WriteBigEndian(byte[] buffer, int offset, int value)
+    {
+        buffer[offset] = (byte)(value >> 24);
+        buffer[offset + 1] = (byte)(value >> 16);
+        buffer[offset + 2] = (byte)(value >> 8);
+        buffer[offset + 3] = (byte)value;
+    }
+
+    private static byte[] Chunk(string type, byte[] data)
+    {
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        using var ms = new MemoryStream();
+        WriteBigEndian(ms, data.Length);
+        ms.Write(typeBytes, 0, 4);
+        ms.Write(data, 0, data.Length);
+        WriteBigEndian(ms, (int)Crc32(typeBytes.Concat(data).ToArray()));
+        return ms.ToArray();
+    }
+
+    private static void WriteBigEndian(Stream stream, int value)
+    {
+        stream.WriteByte((byte)(value >> 24));
+        stream.WriteByte((byte)(value >> 16));
+        stream.WriteByte((byte)(value >> 8));
+        stream.WriteByte((byte)value);
+    }
+
+    private static uint Crc32(byte[] data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (var i = 0; i < 8; i++)
+            {
+                crc = (crc >> 1) ^ ((crc & 1) != 0 ? 0xEDB88320u : 0u);
+            }
+        }
+        return crc ^ 0xFFFFFFFF;
+    }
 }

--- a/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
+++ b/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
@@ -6,7 +6,8 @@ namespace RPGEngine.Tests.Sprites;
 
 /// <summary>
 /// Acceptance tests for <see cref="SpriteSheet"/> and <see cref="SpriteSheetManager"/>
-/// (story 10: RPG Maker MZ spritesheets — full sheets &amp; part sheets).
+/// (story 10: RPG Maker MZ spritesheets — full sheets &amp; part sheets; story 23: sheets of
+/// arbitrary cell size on the normative 12×8 grid).
 /// </summary>
 public class SpriteSheetTests
 {
@@ -23,11 +24,13 @@ public class SpriteSheetTests
         using var stream = SpriteSheetTestHelper.CreateSheetStream();
         var sheet = manager.Load("hero", stream);
 
-        // Normative full-sheet metadata.
+        // Normative full-sheet metadata: the standard 576×384 sheet derives 48×48 cells.
         Assert.Equal(SpriteSheetType.Full, sheet.Type);
         Assert.Null(sheet.PartType);
         Assert.Equal(48, sheet.CellWidth);
         Assert.Equal(48, sheet.CellHeight);
+        Assert.Equal(576, sheet.SheetWidth);
+        Assert.Equal(384, sheet.SheetHeight);
         Assert.Equal(8, sheet.CharacterCount);
 
         // Character 1, down, frame 0 → cell (row 0, col 0).
@@ -57,6 +60,54 @@ public class SpriteSheetTests
 
         using var sprite = sheet.GetSprite(1, direction, frame: 0);
         AssertCell(sprite, expectedRow, col: 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance (story 23): a 936×864 sheet derives 78×108 cells and
+    // GetSprite(1, Down, 0) returns the correct 78×108 crop.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a 936×864 sheet reports the derived 78×108 cell size and crops the correct cell.</summary>
+    [Fact]
+    public void Load_LargeSheet_ReportsDerivedCellSize_AndCropsCorrectCell()
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new MemoryStream(
+            SpriteSheetTestHelper.CreateSheetPng(936, 864),
+            writable: false);
+        var sheet = manager.Load("large", stream);
+
+        Assert.Equal(78, sheet.CellWidth);
+        Assert.Equal(108, sheet.CellHeight);
+        Assert.Equal(936, sheet.SheetWidth);
+        Assert.Equal(864, sheet.SheetHeight);
+        Assert.Equal(8, sheet.CharacterCount);
+
+        // Character 1, down, frame 0 → cell (row 0, col 0), cropped at the derived 78×108 size.
+        using (var sprite = sheet.GetSprite(1, Direction.Down, 0))
+        {
+            Assert.Equal(78, sprite.Width);
+            Assert.Equal(108, sprite.Height);
+            AssertCell(sprite, row: 0, col: 0, cellWidth: 78, cellHeight: 108);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance (story 23) regression: the standard 576×384 sheet still
+    // reports 48×48 cells.
+    // ---------------------------------------------------------------------
+    /// <summary>Regression: a 576×384 sheet still reports 48×48 cells and the normative sheet size.</summary>
+    [Fact]
+    public void Load_StandardSheet_Reports48x48Cells()
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = SpriteSheetTestHelper.CreateSheetStream();
+        var sheet = manager.Load("hero", stream);
+
+        Assert.Equal(48, sheet.CellWidth);
+        Assert.Equal(48, sheet.CellHeight);
+        Assert.Equal(576, sheet.SheetWidth);
+        Assert.Equal(384, sheet.SheetHeight);
+        Assert.Equal(8, sheet.CharacterCount);
     }
 
     // ---------------------------------------------------------------------
@@ -101,14 +152,30 @@ public class SpriteSheetTests
     }
 
     // ---------------------------------------------------------------------
-    // Acceptance 3: invalid dimensions throw ArgumentException. The 144×192
-    // single-character '$' sheet variant is deliberately not supported.
+    // Acceptance 3: invalid dimensions throw ArgumentException. Any image whose
+    // dimensions do not form a positive 12×8 grid is rejected. The 144×192
+    // single-character '$' sheet variant is deliberately out of scope (it is a
+    // valid 12×8 grid and therefore loads, but its semantics are unsupported).
     // ---------------------------------------------------------------------
-    /// <summary>Verifies loading an image whose dimensions are not 576×384 throws ArgumentException.</summary>
+    /// <summary>Verifies loading an image whose dimensions are not a positive 12×8 grid throws ArgumentException.</summary>
     [Theory]
-    [InlineData(144, 192)] // the single-character '$' sheet variant (out of scope)
-    [InlineData(100, 100)]
-    public void Load_ThrowsArgumentException_ForInvalidDimensions(int width, int height)
+    [InlineData(100, 100)]  // not divisible by 12×8
+    [InlineData(500, 300)]  // not divisible by 12×8
+    public void Load_ThrowsArgumentException_ForNonDivisibleDimensions(int width, int height)
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new MemoryStream(
+            SpriteSheetTestHelper.CreateSheetPng(width, height),
+            writable: false);
+
+        Assert.Throws<ArgumentException>(() => manager.Load("bad", stream));
+    }
+
+    /// <summary>Verifies loading an image with a zero width or height throws ArgumentException.</summary>
+    [Theory]
+    [InlineData(0, 384)]
+    [InlineData(576, 0)]
+    public void Load_ThrowsArgumentException_ForZeroDimension(int width, int height)
     {
         var manager = new SpriteSheetManager();
         using var stream = new MemoryStream(
@@ -247,6 +314,23 @@ public class SpriteSheetTests
         AssertCell(sprite, row: 0, col: 0);
     }
 
+    /// <summary>Verifies the async path derives the cell size of a 936×864 sheet (78×108).</summary>
+    [Fact]
+    public async Task LoadAsync_LargeSheet_ReportsDerivedCellSize()
+    {
+        var manager = new SpriteSheetManager();
+        using var stream = new AsyncOnlyStream(new MemoryStream(
+            SpriteSheetTestHelper.CreateSheetPng(936, 864),
+            writable: false));
+
+        var sheet = await manager.LoadAsync("large", stream);
+
+        Assert.Equal(78, sheet.CellWidth);
+        Assert.Equal(108, sheet.CellHeight);
+        Assert.Equal(936, sheet.SheetWidth);
+        Assert.Equal(864, sheet.SheetHeight);
+    }
+
     /// <summary>Verifies LoadPartAsync round-trips every character part type.</summary>
     [Theory]
     [InlineData(CharacterPartType.Body)]
@@ -281,10 +365,12 @@ public class SpriteSheetTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => manager.LoadAsync("hero", duplicate));
     }
 
-    /// <summary>Verifies the async path keeps the invalid-dimensions failure mode (ArgumentException).</summary>
+    /// <summary>Verifies the async path keeps the invalid-dimensions failure mode (ArgumentException) for non-divisible and zero dimensions.</summary>
     [Theory]
-    [InlineData(144, 192)] // the single-character '$' sheet variant (out of scope)
     [InlineData(100, 100)]
+    [InlineData(500, 300)]
+    [InlineData(0, 384)]
+    [InlineData(576, 0)]
     public async Task LoadAsync_ThrowsArgumentException_ForInvalidDimensions(int width, int height)
     {
         var manager = new SpriteSheetManager();
@@ -299,23 +385,27 @@ public class SpriteSheetTests
     // Helpers
     // ---------------------------------------------------------------------
 
-    /// <summary>Asserts the sprite is a 48×48 crop whose every pixel has the expected cell color.</summary>
-    private static void AssertCell(SKImage sprite, int row, int col)
+    /// <summary>
+    /// Asserts the sprite is a crop of the expected cell size whose every pixel has the expected
+    /// cell color. The standard sheet uses 48×48 cells; the derived size can be overridden for
+    /// arbitrary sheets.
+    /// </summary>
+    private static void AssertCell(SKImage sprite, int row, int col, int cellWidth = 48, int cellHeight = 48)
     {
-        Assert.Equal(48, sprite.Width);
-        Assert.Equal(48, sprite.Height);
+        Assert.Equal(cellWidth, sprite.Width);
+        Assert.Equal(cellHeight, sprite.Height);
 
         var expected = SpriteSheetTestHelper.CellColor(row, col);
-        using var bitmap = new SKBitmap(48, 48);
+        using var bitmap = new SKBitmap(cellWidth, cellHeight);
         using (var canvas = new SKCanvas(bitmap))
         {
             canvas.Clear(SKColors.Transparent);
             canvas.DrawImage(sprite, new SKPoint(0, 0));
         }
 
-        for (var y = 0; y < 48; y++)
+        for (var y = 0; y < cellHeight; y++)
         {
-            for (var x = 0; x < 48; x++)
+            for (var x = 0; x < cellWidth; x++)
             {
                 Assert.Equal(expected, bitmap.GetPixel(x, y));
             }


### PR DESCRIPTION
Closes #23 — spritesheets of arbitrary cell size on the normative 12×8 grid.

## What changed

### `SpriteSheet` (`RPGEngine.Sprites`)
- Removed the hard-coded consts `CellSize`, `SheetWidth`, `SheetHeight`.
- Added the normative grid consts `Columns = 12` and `Rows = 8`, plus derived `CellWidth`/`CellHeight` properties (`sheet width / Columns`, `sheet height / Rows`) and computed `SheetWidth`/`SheetHeight`.
- The internal constructor now takes the derived `cellWidth`/`cellHeight` (computed by the manager from the decoded image).
- `GetSprite` crops a `CellWidth × CellHeight` sprite and selects the row via `direction.RowIndex()` (unchanged cardinal rows; diagonal fallback from the movement story).
- XML docs updated: the grid is normative 12×8, the cell size is derived from the image, and examples mention both 48×48 (576×384) and 78×108 (936×864).

### `SpriteSheetManager` (`RPGEngine.Sprites`)
- `Decode` validation changed from "exactly 576×384" to `width > 0 && height > 0 && width % Columns == 0 && height % Rows == 0`, throwing `ArgumentException` with a descriptive message naming the 12×8 grid and the offending dimensions. Both sync and async load paths share the same `Decode` helper.
- The derived cell size is passed to the `SpriteSheet` constructor.

### `Character` / `GameEngine` (clamp)
- Added `internal (int Width, int Height) GetSpriteSize(SpriteSheetManager manager)` on `Character`: resolves the first `SpriteSheets` entry through the manager and returns that sheet's `CellWidth`/`CellHeight`, falling back to the documented 48×48 default when the list is empty.
- `GameEngine.ClampPlayerToMap` now clamps with `maxX = max(0, PixelWidth - spriteWidth)` and `maxY = max(0, PixelHeight - spriteHeight)` using the player's actual sprite size.
- Comments that claimed a fixed 48×48 sprite (`Character.Draw`, `Player`, `CharacterSpriteCompositor`) were updated (the compositor's `DrawCell` already draws at the cell's native size — no code change).

### Tests
- `SpriteSheetTestHelper` now generates sheets of arbitrary size (per-cell coloring at the derived cell size, keeping the standard 576×384 coloring), including hand-built raw PNGs for the zero-dimension validation cases.
- `SpriteSheetTests`: 936×864 → 78×108 cells with correct crop; 576×384 → 48×48 regression; invalid dims throw `ArgumentException` (100×100, 500×300, 0×384, 576×0); `GetSprite` 1..8 / frame 0..2 validation unchanged; async large-sheet coverage.
- `CharacterTests`: a 936×864 character renders a 78×108 sprite; part composition works on the derived cell size.
- `GameEngineTests`: a player with a 78×108 sheet is clamped to `PixelWidth - 78` / `PixelHeight - 108`, verified through `ComputeCameraOrigin`/rendering.
- `DocsExamplesTests.CharacterIndex_SelectsOneOfEightCharacters` asserts the derived cell size (keeps the 576×384 assertion and adds a 936×864 one).

### Docs
- `docs/api/SpriteSheet.md`, `SpriteSheetManager.md`, `GameEngine.md`, `Player.md`, `README.md`, `api/README.md` and `Architecture.md` updated to describe the derived cell size and the 12×8 grid validation.

## Verification
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~SpriteSheetTests|FullyQualifiedName~CharacterTests|FullyQualifiedName~GameEngineTests|FullyQualifiedName~DocsExamplesTests"` → 98 passed.
- Full test suite → 234 passed. Desktop sample builds with 0 warnings/errors.