### PR TITLE
Story 24: map centering, black background and above-player layers

### DIFF
--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -16,6 +16,13 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   SkiaSharp GL view or a WebAssembly `SKSurface` created from a `GRContext`), the drawing is
   hardware accelerated. The engine has **zero platform-specific dependencies**.
 - The camera is internal: `Render` follows the player and clamps the viewport inside the map.
+  When the map is smaller than the canvas on an axis it is centered and the area around it is
+  filled with black, so the map is never letterboxed with transparent or leftover pixels.
+- When a map is set, `Render` clears the whole canvas to black first, then draws the map's
+  below-player layers, then every NPC, then the player, and finally the map's `above_player`
+  layers (tile layers declaring the Tiled `above_player` custom property) so those tiles appear
+  on top of the player. Without a map the canvas is left untouched and only the characters are
+  drawn.
 - Movement input combines every held bound key into a single 8-direction vector: opposite keys
   cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
   at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
@@ -102,9 +109,12 @@ engine.Update(dt: 1.0 / 60);
 
 ### `void Render(SKCanvas canvas, double dt)`
 
-Draws one frame onto the canvas: the visible part of the map (when set), then every NPC, then
-the player on top. The camera follows the player and is clamped so the viewport stays inside the
-map; the canvas size is read from the canvas clip bounds.
+Draws one frame onto the canvas. When a map is set the canvas is cleared to black first (the
+black background behind/around a map smaller than the canvas), then the map's below-player
+layers are drawn, then every NPC, then the player on top, and finally the map's `above_player`
+layers so those tiles appear above the player. The camera follows the player, centers a map
+smaller than the canvas, and is clamped so the viewport stays inside the map; the canvas size is
+read from the canvas clip bounds.
 
 ```csharp
 using var bitmap = new SKBitmap(640, 480);

--- a/docs/api/TileMap.md
+++ b/docs/api/TileMap.md
@@ -9,6 +9,10 @@ Namespace: `RPGEngine.Tiled` — a tile map loaded from a Tiled `.tmx` file (and
   are not registered anywhere globally. Loading a map never touches the engine's tilesets.
 - Tile coordinates are 0-based. Layer data is stored row-major. Only the orthogonal map layout
   is supported by this epic.
+- Rendering happens in **two passes**: the layers **below** the player (every layer whose
+  `TileMapLayer.AbovePlayer` is `false`) are drawn first, and the layers **above** the player
+  (those declaring the Tiled `above_player` custom property set to `true`) are drawn afterwards,
+  so those tiles appear in front of the player.
 
 ## Properties
 

--- a/docs/api/TileMapLayer.md
+++ b/docs/api/TileMapLayer.md
@@ -12,8 +12,13 @@ corresponding flip flags are stored in a parallel list.
 | `Name` | Gets the name of the layer (as declared in the map). |
 | `Visible` | Gets whether the layer is visible (shown) in the map. |
 | `Opacity` | Gets the opacity of the layer, from 0 (fully transparent) to 1 (fully opaque). |
+| `AbovePlayer` | Gets whether the layer is rendered **above** the player (declared by the Tiled `above_player` boolean custom property set to `true`). |
 | `Width` / `Height` | Get the size of the layer in tiles. |
 | `TileIds` | Gets the tile IDs in row-major order (0 = empty cell). |
+
+`AbovePlayer` is `true` when the layer declares a custom boolean property named `above_player`
+with value `true` (Tiled convention, case-sensitive). When the property is absent, is not a
+boolean, or is `false`, it is `false` and the layer is rendered below the player.
 
 ## Methods
 
@@ -43,6 +48,7 @@ var ground = map.Layers[0];
 Console.WriteLine(ground.Name);           // "ground"
 Console.WriteLine(ground.Visible);        // True
 Console.WriteLine(ground.Opacity);        // 1
+Console.WriteLine(ground.AbovePlayer);    // False
 Console.WriteLine(ground.Width);          // 16
 Console.WriteLine(ground.Height);         // 12
 Console.WriteLine(ground.TileIds.Count);  // 192

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -26,8 +26,17 @@ namespace RPGEngine;
 /// </para>
 /// <para>
 /// The camera is internal to the engine: <see cref="Render"/> follows the player and clamps the
-/// viewport inside the map. If a public camera API becomes necessary later it can be extracted
-/// without breaking this class's API.
+/// viewport inside the map. When the map is smaller than the canvas on an axis it is centered
+/// in that axis and the area around it is filled with black (the map background), so the map is
+/// never letterboxed with transparent or leftover pixels. If a public camera API becomes
+/// necessary later it can be extracted without breaking this class's API.
+/// </para>
+/// <para>
+/// When a map is set, <see cref="Render"/> clears the whole canvas to black first, then draws
+/// the map's below-player layers, then every NPC, then the player, and finally the map's
+/// <c>above_player</c> layers (tile layers declaring the Tiled <c>above_player</c> custom
+/// property) so those tiles appear on top of the player. Without a map the canvas is left
+/// untouched and only the characters are drawn.
 /// </para>
 /// <para>
 /// Movement input combines every held bound key into a single 8-direction vector: each key that
@@ -135,10 +144,13 @@ public sealed class GameEngine
     }
 
     /// <summary>
-    /// Draws one frame onto <paramref name="canvas"/>: the visible part of the map (when a map is
-    /// set), then every NPC, then the player on top. The camera follows the player and is clamped
-    /// so the viewport stays inside the map; the canvas size is read from the canvas clip bounds
-    /// so the view adapts to the current surface size automatically.
+    /// Draws one frame onto <paramref name="canvas"/>. When a map is set the canvas is cleared to
+    /// black first (the black background behind/around a map smaller than the canvas), then the
+    /// map's below-player layers are drawn, then every NPC, then the player on top, and finally
+    /// the map's <c>above_player</c> layers so those tiles appear above the player. The camera
+    /// follows the player, centers a map smaller than the canvas, and is clamped so the viewport
+    /// stays inside the map; the canvas size is read from the canvas clip bounds so the view
+    /// adapts to the current surface size automatically.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto (CPU or GPU backed; see the class remarks).</param>
     /// <param name="dt">The elapsed time in seconds since the previous frame (reserved for future animation timing).</param>
@@ -151,9 +163,24 @@ public sealed class GameEngine
         var canvasHeight = Math.Max(0, (int)Math.Ceiling(bounds.Height));
 
         var origin = ComputeCameraOrigin(canvasWidth, canvasHeight);
+        var viewport = new SKRect(
+            (float)origin.X,
+            (float)origin.Y,
+            (float)(origin.X + canvasWidth),
+            (float)(origin.Y + canvasHeight));
+
+        // When a map is set the whole canvas is cleared to black first: this is the black
+        // background behind/around a map that is smaller than the canvas. Without a map the
+        // canvas is left untouched (characters only), so hosts keep full control of the backdrop.
+        if (Map is not null)
+        {
+            canvas.Clear(SKColors.Black);
+        }
 
         // Draw everything in world coordinates and let the translate apply the camera: the map
         // draws its tiles at world positions, and each character is drawn at its world position.
+        // Draw order is: below-player map layers -> each NPC -> the player -> above-player map
+        // layers, so tiles marked with the Tiled above_player property appear on top of the player.
         canvas.Save();
         try
         {
@@ -161,11 +188,6 @@ public sealed class GameEngine
 
             if (Map is not null)
             {
-                var viewport = new SKRect(
-                    (float)origin.X,
-                    (float)origin.Y,
-                    (float)(origin.X + canvasWidth),
-                    (float)(origin.Y + canvasHeight));
                 Map.Draw(canvas, viewport);
             }
 
@@ -175,6 +197,11 @@ public sealed class GameEngine
             }
 
             Player.Character.Draw(canvas, Player.Position, dt, _spriteSheetManager);
+
+            if (Map is not null)
+            {
+                Map.DrawAbovePlayer(canvas, viewport);
+            }
         }
         finally
         {
@@ -298,8 +325,10 @@ public sealed class GameEngine
     /// <summary>
     /// Computes the camera origin: the world pixel position that maps to the canvas' top-left
     /// corner. The desired origin centers the player; it is then clamped so the viewport stays
-    /// inside the map (<c>origin ∈ [0, max(0, PixelSize - canvasSize)]</c> per axis). When no
-    /// map is set the origin is <c>(0, 0)</c>.
+    /// inside the map (<c>origin ∈ [0, max(0, PixelSize - canvasSize)]</c> per axis). When the
+    /// map is smaller than the canvas on an axis, half the difference is subtracted so the map is
+    /// centered and the origin becomes negative (<c>origin = clamp(desired, 0, max) - max(0,
+    /// (canvasSize - PixelSize) / 2)</c> per axis). When no map is set the origin is <c>(0, 0)</c>.
     /// </summary>
     /// <param name="canvasWidth">The width of the canvas in pixels.</param>
     /// <param name="canvasHeight">The height of the canvas in pixels.</param>
@@ -315,13 +344,25 @@ public sealed class GameEngine
             return new Position(0, 0);
         }
 
+        // The maximum viewport origin keeps the view inside the map: 0 when the map is smaller
+        // than the canvas on an axis (the map cannot scroll on that axis), otherwise
+        // PixelSize - canvasSize.
         var maxX = Math.Max(0, Map.PixelWidth - canvasWidth);
         var maxY = Math.Max(0, Map.PixelHeight - canvasHeight);
+
+        // When the map is smaller than the canvas on an axis it is centered by shifting the
+        // origin by half the difference, producing a negative origin. When the map fills (or
+        // exceeds) the canvas the offset is 0 and the behavior is exactly the follow + clamp
+        // described above.
+        var offsetX = Math.Max(0, (canvasWidth - Map.PixelWidth) / 2.0);
+        var offsetY = Math.Max(0, (canvasHeight - Map.PixelHeight) / 2.0);
 
         var desiredX = Player.Position.X - (canvasWidth / 2.0);
         var desiredY = Player.Position.Y - (canvasHeight / 2.0);
 
-        return new Position(Math.Clamp(desiredX, 0, maxX), Math.Clamp(desiredY, 0, maxY));
+        return new Position(
+            Math.Clamp(desiredX, 0, maxX) - offsetX,
+            Math.Clamp(desiredY, 0, maxY) - offsetY);
     }
 
     /// <summary>

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -20,6 +20,14 @@ namespace RPGEngine.Tiled;
 /// Tile coordinates are 0-based. Layer data is stored row-major. Only the orthogonal map
 /// layout is supported by this story; collision, pathfinding and <c>.tmj</c> are out of scope.
 /// </para>
+/// <para>
+/// Rendering happens in two passes. <see cref="Draw"/> draws the layers below the player
+/// (every layer whose <see cref="TileMapLayer.AbovePlayer"/> is <see langword="false"/>), and
+/// <see cref="DrawAbovePlayer"/> draws the layers above the player (those marked with the
+/// Tiled <c>above_player</c> custom property set to <see langword="true"/>). The engine
+/// renders the below-player pass, then the characters, then the above-player pass so those
+/// tiles appear in front of the player.
+/// </para>
 /// </remarks>
 public sealed class TileMap
 {
@@ -199,14 +207,48 @@ public sealed class TileMap
     public bool IsSolid(int tileX, int tileY) => false;
 
     /// <summary>
-    /// Draws the visible part of the map to <paramref name="canvas"/>. Only tiles intersecting
-    /// <paramref name="viewport"/> are drawn; the viewport is in the same (world) coordinate space
-    /// that tiles are drawn into, so callers that apply a camera transform must pass the
-    /// corresponding viewport rectangle.
+    /// Draws the visible part of the map to <paramref name="canvas"/>, rendering only the
+    /// layers that belong <em>below</em> the player (those whose
+    /// <see cref="TileMapLayer.AbovePlayer"/> is <see langword="false"/>). Only tiles
+    /// intersecting <paramref name="viewport"/> are drawn; the viewport is in the same
+    /// (world) coordinate space that tiles are drawn into, so callers that apply a camera
+    /// transform must pass the corresponding viewport rectangle.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
     /// <param name="viewport">The visible world-space rectangle used to cull tiles.</param>
+    /// <remarks>
+    /// This is the first render pass: the engine calls it before drawing the characters, then
+    /// calls <see cref="DrawAbovePlayer"/> afterwards so <c>above_player</c> layers appear on
+    /// top of the player.
+    /// </remarks>
     internal void Draw(SKCanvas canvas, SKRect viewport)
+        => DrawLayers(canvas, viewport, abovePlayerOnly: false);
+
+    /// <summary>
+    /// Draws the visible part of the map to <paramref name="canvas"/>, rendering only the
+    /// layers that belong <em>above</em> the player (those whose
+    /// <see cref="TileMapLayer.AbovePlayer"/> is <see langword="true"/>). The culling,
+    /// opacity and flip handling are identical to <see cref="Draw"/>; only the layer
+    /// selection differs.
+    /// </summary>
+    /// <param name="canvas">The canvas to draw onto.</param>
+    /// <param name="viewport">The visible world-space rectangle used to cull tiles.</param>
+    /// <remarks>
+    /// This is the second render pass: the engine calls it after the NPCs and the player have
+    /// been drawn, so the tiles of <c>above_player</c> layers appear in front of the player.
+    /// </remarks>
+    internal void DrawAbovePlayer(SKCanvas canvas, SKRect viewport)
+        => DrawLayers(canvas, viewport, abovePlayerOnly: true);
+
+    /// <summary>
+    /// Shared implementation of the two map render passes. When
+    /// <paramref name="abovePlayerOnly"/> is <see langword="false"/> only layers below the
+    /// player are drawn (see <see cref="Draw"/>); when <see langword="true"/> only layers
+    /// above the player are drawn (see <see cref="DrawAbovePlayer"/>). In both cases the
+    /// visible layers are culled to <paramref name="viewport"/> and drawn in file order with
+    /// their opacity and flip flags applied.
+    /// </summary>
+    private void DrawLayers(SKCanvas canvas, SKRect viewport, bool abovePlayerOnly)
     {
         var startX = Math.Max(0, (int)MathF.Floor(viewport.Left / TileWidth));
         var endX = Math.Min(Width - 1, (int)MathF.Ceiling(viewport.Right / TileWidth) - 1);
@@ -216,7 +258,7 @@ public sealed class TileMap
         for (var layerIndex = 0; layerIndex < Layers.Count; layerIndex++)
         {
             var layer = Layers[layerIndex];
-            if (!layer.Visible)
+            if (!layer.Visible || layer.AbovePlayer != abovePlayerOnly)
             {
                 continue;
             }

--- a/src/RPGEngine/Tiled/TileMapLayer.cs
+++ b/src/RPGEngine/Tiled/TileMapLayer.cs
@@ -100,7 +100,7 @@ public sealed class TileMapLayer
             if (rawIds.Length != count)
             {
                 throw new InvalidOperationException(
-                    $"Tile layer '{layer.Name}' declares {count} cells ({width}\u00d7{height}) but its data contains {rawIds.Length} values.");
+                    $"Tile layer '{layer.Name}' declares {count} cells ({width}×{height}) but its data contains {rawIds.Length} values.");
             }
 
             ids = new uint[count];
@@ -130,7 +130,7 @@ public sealed class TileMapLayer
         {
             throw new ArgumentOutOfRangeException(
                 y < 0 || y >= Height ? nameof(y) : nameof(x),
-                $"Coordinates ({x}, {y}) are outside the bounds of layer '{Name}' ({Width}\u00d7{Height}).");
+                $"Coordinates ({x}, {y}) are outside the bounds of layer '{Name}' ({Width}×{Height}).");
         }
 
         return (y * Width) + x;

--- a/src/RPGEngine/Tiled/TileMapLayer.cs
+++ b/src/RPGEngine/Tiled/TileMapLayer.cs
@@ -28,6 +28,15 @@ public sealed class TileMapLayer
     public int Height { get; }
 
     /// <summary>
+    /// Gets whether the layer is rendered <em>above</em> the player. A layer declares this by
+    /// setting a custom boolean property named <c>above_player</c> to <see langword="true"/>
+    /// (Tiled convention). When the property is absent, is not a boolean, or is
+    /// <see langword="false"/>, this is <see langword="false"/> and the layer is rendered
+    /// below the player.
+    /// </summary>
+    public bool AbovePlayer { get; }
+
+    /// <summary>
     /// Gets the tile IDs of the layer in row-major order. A value of 0 means the cell is empty;
     /// all other values are global tile IDs with the flip bits masked off.
     /// </summary>
@@ -45,7 +54,8 @@ public sealed class TileMapLayer
         IReadOnlyList<uint> tileIds,
         IReadOnlyList<TileFlags> tileFlags,
         int width,
-        int height)
+        int height,
+        bool abovePlayer)
     {
         Name = name;
         Visible = visible;
@@ -54,6 +64,7 @@ public sealed class TileMapLayer
         _tileFlags = tileFlags;
         Width = width;
         Height = height;
+        AbovePlayer = abovePlayer;
     }
 
     /// <summary>
@@ -67,7 +78,8 @@ public sealed class TileMapLayer
 
     /// <summary>
     /// Builds a <see cref="TileMapLayer"/> from a DotTiled <see cref="TileLayer"/>. The raw GIDs
-    /// (which may carry flip bits) are split into masked tile IDs and <see cref="TileFlags"/>.
+    /// (which may carry flip bits) are split into masked tile IDs and <see cref="TileFlags"/>,
+    /// and the layer's custom properties are consulted for the <c>above_player</c> flag.
     /// </summary>
     internal static TileMapLayer FromDotTiled(TileLayer layer)
     {
@@ -88,7 +100,7 @@ public sealed class TileMapLayer
             if (rawIds.Length != count)
             {
                 throw new InvalidOperationException(
-                    $"Tile layer '{layer.Name}' declares {count} cells ({width}×{height}) but its data contains {rawIds.Length} values.");
+                    $"Tile layer '{layer.Name}' declares {count} cells ({width}\u00d7{height}) but its data contains {rawIds.Length} values.");
             }
 
             ids = new uint[count];
@@ -106,7 +118,10 @@ public sealed class TileMapLayer
             flags = new TileFlags[count];
         }
 
-        return new TileMapLayer(layer.Name, layer.Visible, layer.Opacity, ids, flags, width, height);
+        var abovePlayer = layer.Properties.Any(p =>
+            p.Name == "above_player" && p is BoolProperty boolProperty && boolProperty.Value);
+
+        return new TileMapLayer(layer.Name, layer.Visible, layer.Opacity, ids, flags, width, height, abovePlayer);
     }
 
     private int Index(int x, int y)
@@ -115,7 +130,7 @@ public sealed class TileMapLayer
         {
             throw new ArgumentOutOfRangeException(
                 y < 0 || y >= Height ? nameof(y) : nameof(x),
-                $"Coordinates ({x}, {y}) are outside the bounds of layer '{Name}' ({Width}×{Height}).");
+                $"Coordinates ({x}, {y}) are outside the bounds of layer '{Name}' ({Width}\u00d7{Height}).");
         }
 
         return (y * Width) + x;

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -1,6 +1,7 @@
 using RPGEngine.Sprites;
 using RPGEngine.Tests.Fixtures;
 using RPGEngine.Tests.Sprites;
+using RPGEngine.Tests.Tiled;
 using RPGEngine.Tiled;
 using SkiaSharp;
 using Xunit;
@@ -71,6 +72,44 @@ public class DocsExamplesTests
         }
 
         Assert.NotEqual(0, bitmap.GetPixel(320, 240).Alpha);
+    }
+
+    // ---------------------------------------------------------------------
+    // docs/api/GameEngine.md: the Render example. When a map is smaller than the
+    // canvas it is centered and the area around it is black (story 24).
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies the Render example's black background: a map smaller than the canvas is
+    /// centered and every pixel outside it is black (alpha 255, RGB 0), with the map's own
+    /// tiles drawn over the black backdrop.
+    /// </summary>
+    [Fact]
+    public void Render_Example_BlackBackgroundAroundSmallMap()
+    {
+        // A 2×2 map (96×96 px) rendered on a 240×240 canvas, mirroring the docs'
+        // Render snippet but with a map smaller than the canvas so the letterboxing is visible.
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 }) });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        using var bitmap = new SKBitmap(240, 240);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.Render(canvas, FrameDt);
+        }
+
+        // The centered map occupies (72..168, 72..168); a tile pixel is present at its centre.
+        Assert.NotEqual(0, bitmap.GetPixel(120, 120).Alpha);
+
+        // Outside the centered map the background is black.
+        var black = new SKColor(0, 0, 0, 255);
+        Assert.Equal(black, bitmap.GetPixel(10, 10));
+        Assert.Equal(black, bitmap.GetPixel(230, 230));
+        Assert.Equal(black, bitmap.GetPixel(20, 120));
+        Assert.Equal(black, bitmap.GetPixel(120, 220));
     }
 
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -151,26 +151,30 @@ public class GameEngineTests
         // NPC drawn at screen (96,96).
         Assert.Equal(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), bitmap.GetPixel(120, 120));
 
-        // Replacing the map changes the output: a 2×2 (96×96) map leaves (200,200) transparent.
+        // Replacing the map changes the output: the 2×2 (96×96) map is now centered on the
+        // 240×240 canvas (origin -72,-72), so the player/NPC move to screen (72,72)/(168,168)
+        // and the pixel at (200,100) is outside the map and every sprite: it is black (the black
+        // background around a smaller map), instead of the red tile of the 10×10 map.
         using (var smallFixture = CreateFilledMapFixture(2, 2))
         {
             engine.Map = TileMap.Load(smallFixture.MapPath);
             using var replaced = Render(engine, canvasSize, canvasSize);
-            Assert.Equal(0, replaced.GetPixel(200, 200).Alpha);
+            Assert.Equal(SKColors.Black, replaced.GetPixel(200, 100));
             Assert.NotEqual(0, bitmap.GetPixel(200, 200).Alpha);
         }
 
-        // Removing the NPC removes its pixels; re-adding restores them.
+        // Removing the NPC removes its pixels; re-adding restores them. On the centered 2×2
+        // map the NPC (world 96,96) is at screen (168,168); its centre pixel is (192,192).
         engine.Characters.Remove(npc);
         using (var withoutNpc = Render(engine, canvasSize, canvasSize))
         {
-            Assert.NotEqual(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), withoutNpc.GetPixel(120, 120));
+            Assert.NotEqual(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), withoutNpc.GetPixel(192, 192));
         }
 
         engine.Characters.Add(npc);
         using (var withNpc = Render(engine, canvasSize, canvasSize))
         {
-            Assert.Equal(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), withNpc.GetPixel(120, 120));
+            Assert.Equal(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), withNpc.GetPixel(192, 192));
         }
     }
 
@@ -422,6 +426,113 @@ public class GameEngineTests
         using var bitmap = Render(engine, canvasSize, canvasSize);
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
         Assert.Equal(expected, bitmap.GetPixel(162 + 39, 132 + 54));
+    }
+
+    // ---------------------------------------------------------------------
+    // Story 24: map centering + black background, and above_player layers.
+    // When a map is smaller than the canvas the camera origin becomes negative so the
+    // map is centered, and Render clears the surrounding area to black. Tile layers
+    // declaring the Tiled above_player property are drawn after the player.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a map smaller than the canvas is centered (negative origin) and the surrounding pixels are black.</summary>
+    [Fact]
+    public void Camera_MapSmallerThanCanvas_CentersMapWithBlackBackground()
+    {
+        const int canvasSize = 240;
+        using var fixture = CreateFilledMapFixture(2, 2); // 96×96 px
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        engine.Player.Position = new Position(0, 0);
+
+        // offset = (240 - 96) / 2 = 72 on each axis; the origin is the negative offset.
+        Assert.Equal(new Position(-72, -72), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+
+        using var bitmap = Render(engine, canvasSize, canvasSize);
+
+        // The centered 96×96 map occupies (72..168, 72..168); its centre (120,120) is a tile.
+        Assert.NotEqual(0, bitmap.GetPixel(120, 120).Alpha);
+
+        // Every pixel outside the map is black (alpha 255, RGB 0).
+        var black = new SKColor(0, 0, 0, 255);
+        Assert.Equal(black, bitmap.GetPixel(10, 10));
+        Assert.Equal(black, bitmap.GetPixel(230, 10));
+        Assert.Equal(black, bitmap.GetPixel(10, 230));
+        Assert.Equal(black, bitmap.GetPixel(230, 230));
+        Assert.Equal(black, bitmap.GetPixel(20, 120));  // left of the map
+        Assert.Equal(black, bitmap.GetPixel(220, 120)); // right of the map
+        Assert.Equal(black, bitmap.GetPixel(120, 20));  // above the map
+        Assert.Equal(black, bitmap.GetPixel(120, 220)); // below the map
+    }
+
+    /// <summary>Verifies a map that fills (or exceeds) the canvas keeps the previous follow + clamp camera behavior (offset == 0).</summary>
+    [Fact]
+    public void Camera_MapFillsCanvas_KeepsFollowAndClampBehavior()
+    {
+        const int canvasSize = 240;
+        using var fixture = CreateFilledMapFixture(10, 10); // 480×480 px
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        // Top-left: origin (0,0).
+        engine.Player.Position = new Position(0, 0);
+        Assert.Equal(new Position(0, 0), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+
+        // Bottom-right: origin clamped to PixelSize - canvasSize.
+        engine.Player.Position = new Position(480 - CellSize, 480 - CellSize);
+        Assert.Equal(new Position(240, 240), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+
+        // Middle: origin = player - canvas/2 (follow, no clamping).
+        engine.Player.Position = new Position(216, 216);
+        Assert.Equal(new Position(96, 96), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+    }
+
+    /// <summary>Verifies a tile on an above_player layer is drawn on top of the player, and without the flag the player is on top.</summary>
+    [Fact]
+    public void Render_AbovePlayerLayer_TileDrawsOverPlayer()
+    {
+        const int canvasSize = 96; // a 2×2 map exactly fills the canvas, so the origin is (0,0)
+        var ground = FilledLayer(2, 2);
+        var colors = new[] { SKColors.Red, SKColors.Green };
+
+        // With the flag: the green tile at (0,0) overlaps the player and is drawn on top.
+        using (var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[]
+            {
+                ground,
+                new TileLayerSpec(
+                    "above",
+                    new uint[] { 2, 0, 0, 0 },
+                    Properties: new[] { new LayerProperty("above_player", "bool", "true") }),
+            },
+            tileColors: colors))
+        {
+            var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+            ConfigurePlayerSprite(engine, seed: 1);
+            engine.Player.Position = new Position(0, 0);
+
+            using var bitmap = Render(engine, canvasSize, canvasSize);
+            Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(24, 24));
+        }
+
+        // Without the flag: the green tile is part of the below-player pass and the player is on top.
+        using (var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[]
+            {
+                ground,
+                new TileLayerSpec("above", new uint[] { 2, 0, 0, 0 }),
+            },
+            tileColors: colors))
+        {
+            var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+            ConfigurePlayerSprite(engine, seed: 1);
+            engine.Player.Position = new Position(0, 0);
+
+            using var bitmap = Render(engine, canvasSize, canvasSize);
+            var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+            Assert.Equal(expected, bitmap.GetPixel(24, 24));
+        }
     }
 
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
+++ b/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
@@ -190,6 +190,86 @@ public class TileMapTests
     }
 
     // ---------------------------------------------------------------------
+    // Above-player layers (story 24): a layer declaring the Tiled
+    // <property name="above_player" type="bool" value="true"/> custom property is
+    // reported by TileMapLayer.AbovePlayer and rendered by DrawAbovePlayer (after the
+    // player); every other layer is rendered by Draw (below the player).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies TileMapLayer.AbovePlayer is true for a layer declaring the above_player bool property and false for a layer without it.</summary>
+    [Fact]
+    public void AbovePlayer_ReadsCustomProperty_FromTmx()
+    {
+        var ground = new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 });
+        var above = new TileLayerSpec(
+            "above",
+            new uint[] { 0, 0, 0, 0 },
+            Properties: new[] { new LayerProperty("above_player", "bool", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { ground, above });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.Layers[0].AbovePlayer);
+        Assert.True(map.Layers[1].AbovePlayer);
+    }
+
+    /// <summary>Verifies a layer without the property (or with it set to false, or with a non-bool property of that name) reports AbovePlayer == false.</summary>
+    [Fact]
+    public void AbovePlayer_AbsentFalseOrNonBool_ReportsFalse()
+    {
+        var absent = new TileLayerSpec("absent", new uint[] { 1, 1, 1, 1 });
+        var falseValue = new TileLayerSpec(
+            "false_value",
+            new uint[] { 0, 0, 0, 0 },
+            Properties: new[] { new LayerProperty("above_player", "bool", "false") });
+        var nonBool = new TileLayerSpec(
+            "non_bool",
+            new uint[] { 0, 0, 0, 0 },
+            Properties: new[] { new LayerProperty("above_player", "string", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { absent, falseValue, nonBool });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.Layers[0].AbovePlayer);
+        Assert.False(map.Layers[1].AbovePlayer);
+        Assert.False(map.Layers[2].AbovePlayer);
+    }
+
+    /// <summary>Verifies Draw renders only the below-player layer and DrawAbovePlayer only the above-player layer, at pixel level with two distinct tile colors.</summary>
+    [Fact]
+    public void Draw_And_DrawAbovePlayer_RenderSeparatePasses()
+    {
+        var ground = new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 }); // all red
+        var above = new TileLayerSpec(
+            "above",
+            new uint[] { 2, 2, 2, 2 }, // all green
+            Properties: new[] { new LayerProperty("above_player", "bool", "true") });
+
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { ground, above },
+            tileColors: new[] { SKColors.Red, SKColors.Green });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.Layers[0].AbovePlayer);
+        Assert.True(map.Layers[1].AbovePlayer);
+
+        // The below-player pass draws only the ground (red) layer.
+        using (var bitmap = RenderMap(map, draw: map.Draw))
+        {
+            Assert.Equal(new SKColor(255, 0, 0, 255), bitmap.GetPixel(24, 24));
+            Assert.Equal(new SKColor(255, 0, 0, 255), bitmap.GetPixel(72, 72));
+        }
+
+        // The above-player pass draws only the above (green) layer.
+        using (var bitmap = RenderMap(map, draw: map.DrawAbovePlayer))
+        {
+            Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(24, 24));
+            Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(72, 72));
+        }
+    }
+
+    // ---------------------------------------------------------------------
     // TileSet factories (replacing the removed TileSetManager): standalone
     // tilesets are loaded directly, from the file system or from a stream
     // resolved over HTTP (the WebAssembly-compatible path).
@@ -504,13 +584,13 @@ public class TileMapTests
         };
     }
 
-    private static SKBitmap RenderMap(TileMap map)
+    private static SKBitmap RenderMap(TileMap map, Action<SKCanvas, SKRect>? draw = null)
     {
         var size = Math.Max(map.PixelWidth, map.PixelHeight);
         var bitmap = new SKBitmap(size, size);
         var canvas = new SKCanvas(bitmap);
         canvas.Clear(SKColors.Transparent);
-        map.Draw(canvas, new SKRect(0, 0, size, size));
+        (draw ?? map.Draw)(canvas, new SKRect(0, 0, size, size));
         canvas.Dispose();
         return bitmap;
     }

--- a/tests/RPGEngine.Tests/Tiled/TiledTestFixture.cs
+++ b/tests/RPGEngine.Tests/Tiled/TiledTestFixture.cs
@@ -4,12 +4,24 @@ using SkiaSharp;
 
 namespace RPGEngine.Tests.Tiled;
 
+/// <summary>A single custom property to be written into a generated layer's <c>&lt;properties&gt;</c> block.</summary>
+/// <param name="Name">The property name (e.g. <c>above_player</c>).</param>
+/// <param name="Type">The Tiled property type (e.g. <c>bool</c>, <c>string</c>, <c>int</c>).</param>
+/// <param name="Value">The property value as a string (e.g. <c>true</c>).</param>
+internal sealed record LayerProperty(string Name, string Type, string Value);
+
 /// <summary>Specifies a tile layer to be written into a generated TMX fixture.</summary>
 /// <param name="Name">The layer name.</param>
 /// <param name="Gids">The raw tile GIDs in row-major order (flip bits allowed).</param>
 /// <param name="Visible">Whether the layer is visible.</param>
 /// <param name="Opacity">The layer opacity, from 0 to 1.</param>
-internal sealed record TileLayerSpec(string Name, uint[] Gids, bool Visible = true, float Opacity = 1f);
+/// <param name="Properties">Optional custom properties emitted inside the layer.</param>
+internal sealed record TileLayerSpec(
+    string Name,
+    uint[] Gids,
+    bool Visible = true,
+    float Opacity = 1f,
+    IReadOnlyList<LayerProperty>? Properties = null);
 
 /// <summary>The visual pattern painted into the generated 48×48 tile PNG.</summary>
 internal enum TilePattern
@@ -29,6 +41,20 @@ internal enum TilePattern
 /// an external single-tile TSX referencing it, and a TMX referencing the TSX. Everything is
 /// cleaned up on <see cref="Dispose"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// By default the fixture generates a single 48×48 tile image (see <see cref="TilePattern"/>).
+/// Passing a list of tile colors to the constructor generates a tileset with one tile per color
+/// (the image is laid out in a single row, each tile solid in its color), which lets tests
+/// distinguish two tile GIDs by color (e.g. a below-player layer in red and an
+/// <c>above_player</c> layer in green).
+/// </para>
+/// <para>
+/// Each layer may declare custom properties via <see cref="TileLayerSpec.Properties"/>; these
+/// are emitted as a <c>&lt;properties&gt;</c> block inside the <c>&lt;layer&gt;</c> element,
+/// matching the Tiled format.
+/// </para>
+/// </remarks>
 internal sealed class TiledTestFixture : IDisposable
 {
     public const int TileSize = 48;
@@ -50,7 +76,12 @@ internal sealed class TiledTestFixture : IDisposable
     /// <summary>Gets the path to the generated tileset PNG image.</summary>
     public string ImagePath { get; }
 
-    public TiledTestFixture(int width, int height, IReadOnlyList<TileLayerSpec> layers, TilePattern pattern = TilePattern.Solid)
+    public TiledTestFixture(
+        int width,
+        int height,
+        IReadOnlyList<TileLayerSpec> layers,
+        TilePattern pattern = TilePattern.Solid,
+        IReadOnlyList<SKColor>? tileColors = null)
     {
         Width = width;
         Height = height;
@@ -61,8 +92,8 @@ internal sealed class TiledTestFixture : IDisposable
         TilesetPath = Path.Combine(_root, "tiles.tsx");
         MapPath = Path.Combine(_root, "map.tmx");
 
-        CreateTileImage(ImagePath, pattern);
-        File.WriteAllText(TilesetPath, TilesetXml);
+        CreateTileImage(ImagePath, pattern, tileColors);
+        File.WriteAllText(TilesetPath, TilesetXml(tileColors));
         File.WriteAllText(MapPath, MapXml(layers));
     }
 
@@ -82,10 +113,29 @@ internal sealed class TiledTestFixture : IDisposable
         }
     }
 
-    private static void CreateTileImage(string path, TilePattern pattern)
+    private static void CreateTileImage(string path, TilePattern pattern, IReadOnlyList<SKColor>? tileColors)
     {
-        using var bitmap = new SKBitmap(TileSize, TileSize);
-        using (var canvas = new SKCanvas(bitmap))
+        if (tileColors is { Count: > 0 })
+        {
+            // Multi-tile solid-color image: one 48×48 tile per color, laid out in a single row.
+            using var bitmap = new SKBitmap(TileSize * tileColors.Count, TileSize);
+            using (var canvas = new SKCanvas(bitmap))
+            {
+                canvas.Clear(SKColors.Transparent);
+                using var paint = new SKPaint { IsAntialias = false };
+                for (var i = 0; i < tileColors.Count; i++)
+                {
+                    paint.Color = tileColors[i];
+                    canvas.DrawRect(new SKRect(i * TileSize, 0, (i + 1) * TileSize, TileSize), paint);
+                }
+            }
+
+            EncodePng(bitmap, path);
+            return;
+        }
+
+        using var singleBitmap = new SKBitmap(TileSize, TileSize);
+        using (var canvas = new SKCanvas(singleBitmap))
         {
             canvas.Clear(SKColors.Transparent);
             using var paint = new SKPaint { Color = SKColors.Red, IsAntialias = false };
@@ -102,18 +152,30 @@ internal sealed class TiledTestFixture : IDisposable
             }
         }
 
+        EncodePng(singleBitmap, path);
+    }
+
+    /// <summary>Encodes <paramref name="bitmap"/> as a PNG file at <paramref name="path"/>.</summary>
+    private static void EncodePng(SKBitmap bitmap, string path)
+    {
         using var image = SKImage.FromBitmap(bitmap);
         using var data = image.Encode(SKEncodedImageFormat.Png, 100);
         using var stream = File.Create(path);
         data.SaveTo(stream);
     }
 
-    private string TilesetXml => $"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <tileset version="1.10" tiledversion="1.10.2" name="test_tiles" tilewidth="{TileSize}" tileheight="{TileSize}" tilecount="1" columns="1">
-          <image source="tiles.png" width="{TileSize}" height="{TileSize}"/>
-        </tileset>
-        """;
+    private string TilesetXml(IReadOnlyList<SKColor>? tileColors)
+    {
+        var tileCount = tileColors?.Count ?? 1;
+        var columns = tileCount;
+        var imageWidth = TileSize * columns;
+        return $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <tileset version="1.10" tiledversion="1.10.2" name="test_tiles" tilewidth="{TileSize}" tileheight="{TileSize}" tilecount="{tileCount}" columns="{columns}">
+              <image source="tiles.png" width="{imageWidth}" height="{TileSize}"/>
+            </tileset>
+            """;
+    }
 
     private string MapXml(IReadOnlyList<TileLayerSpec> layers)
     {
@@ -128,6 +190,19 @@ internal sealed class TiledTestFixture : IDisposable
             var layer = layers[i];
             sb.AppendLine(
                 $"""  <layer id="{i + 1}" name="{layer.Name}" width="{Width}" height="{Height}" visible="{(layer.Visible ? 1 : 0)}" opacity="{layer.Opacity.ToString(CultureInfo.InvariantCulture)}">""");
+
+            if (layer.Properties is { Count: > 0 })
+            {
+                sb.AppendLine("    <properties>");
+                foreach (var property in layer.Properties)
+                {
+                    sb.AppendLine(
+                        $"      <property name=\"{property.Name}\" type=\"{property.Type}\" value=\"{property.Value}\"/>");
+                }
+
+                sb.AppendLine("    </properties>");
+            }
+
             sb.AppendLine("    <data encoding=\"csv\">");
             for (var y = 0; y < Height; y++)
             {


### PR DESCRIPTION
Implements [#24](https://github.com/elliottv/rpg-engine/issues/24): two rendering adjustments from Epic #1 follow-up.

## Changes

### Source (`RPGEngine`)
- **`TileMapLayer`**: new `public bool AbovePlayer { get; }` — `true` when the layer declares a `BoolProperty` named `above_player` with value `true` (case-sensitive, per Tiled convention; absent/non-bool → `false`). `FromDotTiled(TileLayer)` reads the layer's custom properties.
- **`TileMap`**: `Draw` now renders only layers with `AbovePlayer == false`; new `internal void DrawAbovePlayer` renders only `AbovePlayer == true` layers with the same viewport culling, opacity and flip handling. The shared per-layer loop was refactored into a private `DrawLayers(canvas, viewport, abovePlayerOnly)` helper (no duplicated logic). Class remarks describe the two render passes.
- **`GameEngine`**:
  - `Render` clears the canvas to **black** when `Map != null`, and uses the new draw order: below-player map layers → each NPC → the player → `Map.DrawAbovePlayer`. When `Map == null` the canvas is left untouched.
  - `ComputeCameraOrigin` centers a map smaller than the canvas on an axis (`offset = max(0, (canvasSize - mapPixelSize) / 2)`; `origin = clamp(desired, 0, max) - offset`), producing a negative origin; when the map fills/exceeds the canvas `offset == 0` and behavior is unchanged.
  - Class remarks updated (black background, centering, above-player ordering).

### Tests
- `TiledTestFixture` now emits layer custom properties (`<properties><property .../></properties>`) and supports a multi-tile solid-color tileset so pixel-level pass assertions can use two distinct tile colors.
- `TileMapTests`: `AbovePlayer` flag read from TMX (true/false as declared); absent/false/non-bool → `false`; `Draw` vs `DrawAbovePlayer` render separate passes (pixel-level).
- `GameEngineTests`: 2×2 map on 240×240 → `ComputeCameraOrigin == (-72, -72)` with black background outside the centered map; a map that fills the canvas keeps the previous follow/clamp behavior; `above_player` tile drawn on top of the player (and player on top without the flag); the small-map assertion that previously expected a transparent canvas now asserts black.
- `DocsExamplesTests`: new render-example test asserts black background around a map smaller than the canvas.
- Docs (`docs/api/GameEngine.md`, `TileMap.md`, `TileMapLayer.md`) updated to mirror the new remarks.

## Verification
- `dotnet test tests/RPGEngine.Tests` → **241 passed** (was 234).
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~TileMapTests|FullyQualifiedName~GameEngineTests|FullyQualifiedName~DocsExamplesTests"` → **60 passed**.
- Desktop sample builds; Wasm sample requires the `wasm-tools` workload (pre-existing environment constraint).

Closes #24.