### PR TITLE
Story 25: map custom properties and object layers

### DIFF
--- a/docs/api/MapProperty.md
+++ b/docs/api/MapProperty.md
@@ -1,0 +1,26 @@
+# MapProperty
+
+Namespace: `RPGEngine.Tiled` — a single custom property attached to a map, a tile layer, an
+object layer or an object, in the Tiled format.
+
+The value is **boxed** according to `Type`, so the read model wraps DotTiled without leaking any
+DotTiled types into the public API.
+
+## Properties
+
+| Property | Description |
+| --- | --- |
+| `Name` | The property name, as declared in the map (case-sensitive). |
+| `Type` | The property type (see `MapPropertyType`). |
+| `Value` | The boxed value. `bool` / `int` / `float` / `string` / `SKColor` (colors) / `string` (file paths). `Object` exposes the referenced object's ID as a string; `Class` and `Unknown` expose `null`. |
+
+## Example
+
+```csharp
+var map = TileMap.Load("assets/map.tmx");
+var difficulty = map.GetProperty("difficulty");
+
+Console.WriteLine(difficulty?.Name);   // "difficulty"
+Console.WriteLine(difficulty?.Type);   // MapPropertyType.String
+Console.WriteLine(difficulty?.Value);  // e.g. "hard"
+```

--- a/docs/api/MapPropertyType.md
+++ b/docs/api/MapPropertyType.md
@@ -1,0 +1,32 @@
+# MapPropertyType
+
+Namespace: `RPGEngine.Tiled` — the type of a custom property attached to a map, a tile layer,
+an object layer or an object. Mirrors the property types Tiled can store in a
+`<property>` element.
+
+## Values
+
+| Value | Boxed `MapProperty.Value` |
+| --- | --- |
+| `Bool` | `bool` |
+| `Int` | `int` |
+| `Float` | `float` |
+| `String` | `string` |
+| `Color` | `SKColor` (Tiled stores colors as `#AARRGGBB`) |
+| `File` | `string` (the file path, as declared in the map) |
+| `Object` | `string` (the referenced object's ID, the raw string form) |
+| `Class` | `null` (structured access to custom-class members is out of scope) |
+| `Unknown` | `null` (an unrecognised property type) |
+
+## Example
+
+```csharp
+var map = TileMap.Load("assets/map.tmx");
+var tint = map.GetProperty("tint");
+
+if (tint?.Type == MapPropertyType.Color)
+{
+    var color = (SKColor)tint.Value!;
+    Console.WriteLine(color.Red); // 255
+}
+```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -40,6 +40,11 @@ documented**. Every page below includes a commented, compilable example; the tes
 | `TileSet` | class | [TileSet.md](TileSet.md) |
 | `TileMap` | class | [TileMap.md](TileMap.md) |
 | `TileMapLayer` | class | [TileMapLayer.md](TileMapLayer.md) |
+| `MapProperty` | sealed record | [MapProperty.md](MapProperty.md) |
+| `MapPropertyType` | enum | [MapPropertyType.md](MapPropertyType.md) |
+| `TileMapObjectLayer` | class | [TileMapObjectLayer.md](TileMapObjectLayer.md) |
+| `TileMapObject` | class | [TileMapObject.md](TileMapObject.md) |
+| `TileMapObjectShape` | enum | [TileMapObjectShape.md](TileMapObjectShape.md) |
 | `TileFlags` | enum (`[Flags]`) | [TileFlags.md](TileFlags.md) |
 | `TiledAssetFetcher` | delegate | [TiledAssetFetcher.md](TiledAssetFetcher.md) |
 | `TiledAssetFetcherAsync` | delegate (async) | [TiledAssetFetcherAsync.md](TiledAssetFetcherAsync.md) |

--- a/docs/api/TileMap.md
+++ b/docs/api/TileMap.md
@@ -22,6 +22,8 @@ Namespace: `RPGEngine.Tiled` — a tile map loaded from a Tiled `.tmx` file (and
 | `TileWidth` / `TileHeight` | Get the size of a single tile in pixels. |
 | `PixelWidth` / `PixelHeight` | Get the total size of the map in pixels. |
 | `Layers` | Gets the tile layers in file order (bottom → top). |
+| `Properties` | Gets the map's custom properties, in file order. |
+| `ObjectLayers` | Gets the object layers (and their objects), in file order. |
 
 ## Methods
 
@@ -74,6 +76,20 @@ var map = await TileMap.LoadAsync(
     uri => http.GetByteArrayAsync(uri));
 ```
 
+### `MapProperty? GetProperty(string name)`
+
+Returns the map property named `name` using a **case-sensitive** comparison, or `null` when no
+property with that exact name exists. The value is boxed according to `MapPropertyType` (e.g. a
+Tiled `bool` property is a C# `bool`, a `color` property is an `SKColor`).
+
+```csharp
+var difficulty = map.GetProperty("difficulty");
+if (difficulty is not null)
+{
+    Console.WriteLine($"{difficulty.Name} = {difficulty.Value}");
+}
+```
+
 ### `uint GetTileId(string layerName, int x, int y)`
 
 Returns the global tile ID of the tile at `(x, y)` in the layer named `layerName`, with all flip
@@ -112,4 +128,19 @@ Console.WriteLine(map.Layers.Count);       // 2 ("ground" + "decor")
 Console.WriteLine(map.Layers[0].Name);     // "ground"
 Console.WriteLine(map.GetTileId("ground", 0, 0)); // >= 1 (a grass tile)
 Console.WriteLine(map.IsSolid(1, 1));      // False
+
+// Map custom properties (looked up case-sensitively; null when absent).
+var difficulty = map.GetProperty("difficulty");
+Console.WriteLine(difficulty?.Value);      // e.g. "hard"
+
+// Object layers expose the map's objects and their custom properties.
+foreach (var layer in map.ObjectLayers)
+{
+    Console.WriteLine(layer.Name);         // e.g. "objects"
+    foreach (var obj in layer.Objects)
+    {
+        Console.WriteLine($"{obj.Name} @ {obj.Position} ({obj.Shape})");
+        Console.WriteLine(obj.Properties.Single(p => p.Name == "coins").Value);
+    }
+}
 ```

--- a/docs/api/TileMapLayer.md
+++ b/docs/api/TileMapLayer.md
@@ -13,6 +13,7 @@ corresponding flip flags are stored in a parallel list.
 | `Visible` | Gets whether the layer is visible (shown) in the map. |
 | `Opacity` | Gets the opacity of the layer, from 0 (fully transparent) to 1 (fully opaque). |
 | `AbovePlayer` | Gets whether the layer is rendered **above** the player (declared by the Tiled `above_player` boolean custom property set to `true`). |
+| `Properties` | Gets the layer's custom properties, in file order (includes `above_player` when declared). |
 | `Width` / `Height` | Get the size of the layer in tiles. |
 | `TileIds` | Gets the tile IDs in row-major order (0 = empty cell). |
 
@@ -52,4 +53,5 @@ Console.WriteLine(ground.AbovePlayer);    // False
 Console.WriteLine(ground.Width);          // 16
 Console.WriteLine(ground.Height);         // 12
 Console.WriteLine(ground.TileIds.Count);  // 192
+Console.WriteLine(ground.Properties.Count); // custom properties declared on the layer
 ```

--- a/docs/api/TileMapObject.md
+++ b/docs/api/TileMapObject.md
@@ -1,0 +1,31 @@
+# TileMapObject
+
+Namespace: `RPGEngine.Tiled` — a single object in an object layer of a `TileMap`, wrapping the
+Tiled object's identity, geometry, shape and custom properties. This is a read-only view;
+editing or adding objects is out of scope.
+
+## Properties
+
+| Property | Description |
+| --- | --- |
+| `Id` | The object's unique ID within the map. |
+| `Name` | The object's name, as declared in the map (may be empty). |
+| `Type` | The object's "class" string, as declared in the map (may be empty). |
+| `Position` | The object's top-left position in pixels. |
+| `Width` / `Height` | The object's size in pixels (0 for shapes without a size, e.g. points). |
+| `Shape` | The object's geometric shape (see `TileMapObjectShape`). |
+| `Properties` | The object's custom properties, in file order. |
+
+## Example
+
+```csharp
+var map = TileMap.Load("assets/map.tmx");
+var chest = map.ObjectLayers
+    .SelectMany(layer => layer.Objects)
+    .Single(obj => obj.Name == "chest");
+
+Console.WriteLine(chest.Type);                                  // "treasure"
+Console.WriteLine(chest.Position);                              // e.g. (48, 96)
+Console.WriteLine(chest.Shape);                                 // TileMapObjectShape.Rectangle
+Console.WriteLine(chest.Properties.Single(p => p.Name == "coins").Value); // 100
+```

--- a/docs/api/TileMapObjectLayer.md
+++ b/docs/api/TileMapObjectLayer.md
@@ -1,0 +1,27 @@
+# TileMapObjectLayer
+
+Namespace: `RPGEngine.Tiled` — an object layer of a `TileMap`: a named collection of
+`TileMapObject`s with their own visibility, opacity and custom properties. Object layers do not
+render tiles; rendering objects on the map is out of scope.
+
+## Properties
+
+| Property | Description |
+| --- | --- |
+| `Name` | The name of the object layer (as declared in the map). |
+| `Visible` | Whether the object layer is visible (shown) in the map. |
+| `Opacity` | The opacity of the object layer, from 0 (fully transparent) to 1 (fully opaque). |
+| `Objects` | The objects of the layer, in file order. |
+| `Properties` | The object layer's custom properties, in file order. |
+
+## Example
+
+```csharp
+var map = TileMap.Load("assets/map.tmx");
+var layer = map.ObjectLayers.Single();
+
+Console.WriteLine(layer.Name);            // "objects"
+Console.WriteLine(layer.Visible);         // True
+Console.WriteLine(layer.Opacity);         // 1
+Console.WriteLine(layer.Objects.Count);   // number of objects in the layer
+```

--- a/docs/api/TileMapObjectShape.md
+++ b/docs/api/TileMapObjectShape.md
@@ -1,0 +1,29 @@
+# TileMapObjectShape
+
+Namespace: `RPGEngine.Tiled` — the geometric shape of an object in an object layer. Detected
+from the object's shape in the Tiled file.
+
+## Values
+
+| Value | Tiled declaration |
+| --- | --- |
+| `Rectangle` | A plain `<object>` (no marker; the Tiled default shape). |
+| `Ellipse` | An `<ellipse/>` child element. |
+| `Point` | A `<point/>` child element. |
+| `Polygon` | A `<polygon>` child element. |
+| `Polyline` | A `<polyline>` child element. |
+| `Tile` | A `gid` attribute (a tile object). |
+| `Text` | A `<text>` child element. |
+
+## Example
+
+```csharp
+var map = TileMap.Load("assets/map.tmx");
+foreach (var layer in map.ObjectLayers)
+{
+    foreach (var obj in layer.Objects)
+    {
+        Console.WriteLine($"{obj.Name}: {obj.Shape}");
+    }
+}
+```

--- a/src/RPGEngine/Tiled/MapProperty.cs
+++ b/src/RPGEngine/Tiled/MapProperty.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using SkiaSharp;
+
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// A single custom property attached to a map, a tile layer, an object layer or an object, in
+/// the Tiled format. The value is boxed according to <see cref="Type"/> (see the
+/// <see cref="MapPropertyType"/> members for the exact boxed shape per type).
+/// </summary>
+/// <param name="Name">The property name, as declared in the map (case-sensitive).</param>
+/// <param name="Type">The property type.</param>
+/// <param name="Value">The boxed value; <see langword="null"/> for <see cref="MapPropertyType.Class"/> and <see cref="MapPropertyType.Unknown"/>.</param>
+public sealed record MapProperty(string Name, MapPropertyType Type, object? Value)
+{
+    /// <summary>
+    /// Converts a DotTiled property into the engine's read-model representation. The read model
+    /// wraps DotTiled so no DotTiled types leak into the public API.
+    /// </summary>
+    /// <param name="property">The DotTiled property to convert.</param>
+    /// <returns>The corresponding <see cref="MapProperty"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="property"/> is <see langword="null"/>.</exception>
+    internal static MapProperty Create(DotTiled.IProperty property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        return property switch
+        {
+            DotTiled.BoolProperty p => new MapProperty(p.Name, MapPropertyType.Bool, p.Value),
+            DotTiled.IntProperty p => new MapProperty(p.Name, MapPropertyType.Int, p.Value),
+            DotTiled.FloatProperty p => new MapProperty(p.Name, MapPropertyType.Float, p.Value),
+            DotTiled.StringProperty p => new MapProperty(p.Name, MapPropertyType.String, p.Value),
+            DotTiled.ColorProperty p => new MapProperty(p.Name, MapPropertyType.Color, ToSkColor(p)),
+            DotTiled.FileProperty p => new MapProperty(p.Name, MapPropertyType.File, p.Value),
+            DotTiled.ObjectProperty p => new MapProperty(p.Name, MapPropertyType.Object, p.Value.ToString(CultureInfo.InvariantCulture)),
+            DotTiled.ClassProperty p => new MapProperty(p.Name, MapPropertyType.Class, null),
+            _ => new MapProperty(property.Name, MapPropertyType.Unknown, null),
+        };
+    }
+
+    /// <summary>
+    /// Converts the optional DotTiled color into an <see cref="SKColor"/>, or
+    /// <see langword="null"/> when the property carries no color value.
+    /// </summary>
+    private static SKColor? ToSkColor(DotTiled.ColorProperty property)
+        => property.Value.HasValue
+            ? new SKColor(
+                property.Value.Value.R,
+                property.Value.Value.G,
+                property.Value.Value.B,
+                property.Value.Value.A)
+            : null;
+}

--- a/src/RPGEngine/Tiled/MapPropertyType.cs
+++ b/src/RPGEngine/Tiled/MapPropertyType.cs
@@ -1,0 +1,49 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// The type of a custom property attached to a map, a tile layer, an object layer or an object.
+/// Mirrors the property types Tiled can store in a <c>&lt;property&gt;</c> element.
+/// </summary>
+public enum MapPropertyType
+{
+    /// <summary>A boolean property (value is a <see cref="bool"/>).</summary>
+    Bool,
+
+    /// <summary>A 32-bit signed integer property (value is an <see cref="int"/>).</summary>
+    Int,
+
+    /// <summary>A single-precision floating point property (value is a <see cref="float"/>).</summary>
+    Float,
+
+    /// <summary>A text property (value is a <see cref="string"/>).</summary>
+    String,
+
+    /// <summary>
+    /// A color property (value is a <see cref="SkiaSharp.SKColor"/>). Tiled stores colors in
+    /// <c>#AARRGGBB</c> form; the engine exposes them as <c>SKColor</c> so the rest of the
+    /// rendering stack can use them directly.
+    /// </summary>
+    Color,
+
+    /// <summary>
+    /// A file path property (value is a <see cref="string"/> containing the path, relative to
+    /// the map as Tiled declared it).
+    /// </summary>
+    File,
+
+    /// <summary>
+    /// An object reference property. The value is the referenced object's ID as a
+    /// <see cref="string"/> (the raw string form from the file); resolving the reference to a
+    /// <see cref="TileMapObject"/> is not exposed yet.
+    /// </summary>
+    Object,
+
+    /// <summary>
+    /// A custom-class property. The value is <see langword="null"/>: structured access to the
+    /// members of a custom class is explicitly out of scope.
+    /// </summary>
+    Class,
+
+    /// <summary>A property whose type the engine does not recognise (value is <see langword="null"/>).</summary>
+    Unknown,
+}

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -40,7 +40,9 @@ public sealed class TileMap
         int tileWidth,
         int tileHeight,
         IReadOnlyList<TileSet> tileSets,
-        IReadOnlyList<TileMapLayer> layers)
+        IReadOnlyList<TileMapLayer> layers,
+        IReadOnlyList<MapProperty> properties,
+        IReadOnlyList<TileMapObjectLayer> objectLayers)
     {
         Width = width;
         Height = height;
@@ -48,6 +50,8 @@ public sealed class TileMap
         TileHeight = tileHeight;
         _tileSets = tileSets.OrderBy(t => t.FirstGid).ToArray();
         Layers = layers;
+        Properties = properties;
+        ObjectLayers = objectLayers;
 
         _layersByName = new Dictionary<string, TileMapLayer>(StringComparer.Ordinal);
         foreach (var layer in layers)
@@ -76,9 +80,46 @@ public sealed class TileMap
 
     /// <summary>
     /// Gets the tile layers of the map, in the order they appear in the file (bottom → top).
-    /// Only tile layers are represented; object, image and group layers are ignored for now.
+    /// Only tile layers are represented here; object layers are exposed through
+    /// <see cref="ObjectLayers"/>, and image and group layers are ignored for now.
     /// </summary>
     public IReadOnlyList<TileMapLayer> Layers { get; }
+
+    /// <summary>
+    /// Gets the map's custom properties (from the map's <c>&lt;properties&gt;</c> block), in file
+    /// order. Map properties are typically used for per-map configuration such as ambient light
+    /// or difficulty settings.
+    /// </summary>
+    public IReadOnlyList<MapProperty> Properties { get; }
+
+    /// <summary>
+    /// Gets the object layers of the map, in the order they appear in the file. Only object
+    /// layers are represented here; tile layers are exposed through <see cref="Layers"/> and
+    /// image/group layers are ignored for now.
+    /// </summary>
+    public IReadOnlyList<TileMapObjectLayer> ObjectLayers { get; }
+
+    /// <summary>
+    /// Returns the map property named <paramref name="name"/> using a case-sensitive comparison,
+    /// or <see langword="null"/> when no property with that exact name exists.
+    /// </summary>
+    /// <param name="name">The exact property name to look up.</param>
+    /// <returns>The matching <see cref="MapProperty"/>, or <see langword="null"/> when absent.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    public MapProperty? GetProperty(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        foreach (var property in Properties)
+        {
+            if (property.Name == name)
+            {
+                return property;
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Loads the Tiled map at <paramref name="path"/>, parsing the referenced external tilesets
@@ -385,15 +426,28 @@ public sealed class TileMap
         }
 
         var layers = new List<TileMapLayer>();
+        var objectLayers = new List<TileMapObjectLayer>();
         foreach (var layer in map.Layers)
         {
             if (layer is TileLayer tileLayer)
             {
                 layers.Add(TileMapLayer.FromDotTiled(tileLayer));
             }
+            else if (layer is ObjectLayer objectLayer)
+            {
+                objectLayers.Add(TileMapObjectLayer.FromDotTiled(objectLayer));
+            }
         }
 
-        return new TileMap(map.Width, map.Height, map.TileWidth, map.TileHeight, tileSets, layers);
+        return new TileMap(
+            map.Width,
+            map.Height,
+            map.TileWidth,
+            map.TileHeight,
+            tileSets,
+            layers,
+            map.Properties.Select(MapProperty.Create).ToArray(),
+            objectLayers);
     }
 
     private static TileSet CreateFileSystemTileSet(Tileset dotTiledTileset, string mapDirectory)

--- a/src/RPGEngine/Tiled/TileMapLayer.cs
+++ b/src/RPGEngine/Tiled/TileMapLayer.cs
@@ -37,6 +37,13 @@ public sealed class TileMapLayer
     public bool AbovePlayer { get; }
 
     /// <summary>
+    /// Gets the layer's custom properties (from the layer's <c>&lt;properties&gt;</c> block), in
+    /// file order. The Tiled <c>above_player</c> flag, when present, appears here too; the flag
+    /// is additionally surfaced as <see cref="AbovePlayer"/>.
+    /// </summary>
+    public IReadOnlyList<MapProperty> Properties { get; }
+
+    /// <summary>
     /// Gets the tile IDs of the layer in row-major order. A value of 0 means the cell is empty;
     /// all other values are global tile IDs with the flip bits masked off.
     /// </summary>
@@ -55,7 +62,8 @@ public sealed class TileMapLayer
         IReadOnlyList<TileFlags> tileFlags,
         int width,
         int height,
-        bool abovePlayer)
+        bool abovePlayer,
+        IReadOnlyList<MapProperty> properties)
     {
         Name = name;
         Visible = visible;
@@ -65,6 +73,7 @@ public sealed class TileMapLayer
         Width = width;
         Height = height;
         AbovePlayer = abovePlayer;
+        Properties = properties;
     }
 
     /// <summary>
@@ -79,7 +88,8 @@ public sealed class TileMapLayer
     /// <summary>
     /// Builds a <see cref="TileMapLayer"/> from a DotTiled <see cref="TileLayer"/>. The raw GIDs
     /// (which may carry flip bits) are split into masked tile IDs and <see cref="TileFlags"/>,
-    /// and the layer's custom properties are consulted for the <c>above_player</c> flag.
+    /// and the layer's custom properties are consulted for the <c>above_player</c> flag and
+    /// exposed through <see cref="Properties"/>.
     /// </summary>
     internal static TileMapLayer FromDotTiled(TileLayer layer)
     {
@@ -118,10 +128,20 @@ public sealed class TileMapLayer
             flags = new TileFlags[count];
         }
 
+        var properties = layer.Properties.Select(MapProperty.Create).ToArray();
         var abovePlayer = layer.Properties.Any(p =>
             p.Name == "above_player" && p is BoolProperty boolProperty && boolProperty.Value);
 
-        return new TileMapLayer(layer.Name, layer.Visible, layer.Opacity, ids, flags, width, height, abovePlayer);
+        return new TileMapLayer(
+            layer.Name,
+            layer.Visible,
+            layer.Opacity,
+            ids,
+            flags,
+            width,
+            height,
+            abovePlayer,
+            properties);
     }
 
     private int Index(int x, int y)

--- a/src/RPGEngine/Tiled/TileMapObject.cs
+++ b/src/RPGEngine/Tiled/TileMapObject.cs
@@ -1,0 +1,88 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// A single object in an object layer of a <see cref="TileMap"/>, wrapping the Tiled object's
+/// identity, geometry, shape and custom properties. This is a read-only view; editing or adding
+/// objects is out of scope.
+/// </summary>
+public sealed class TileMapObject
+{
+    /// <summary>Gets the object's unique ID within the map.</summary>
+    public uint Id { get; }
+
+    /// <summary>Gets the object's name, as declared in the map (may be empty).</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the object's "class" string, as declared in the map (may be empty). This is the
+    /// object's <c>type</c>/<c>class</c> attribute in the Tiled file.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>Gets the object's top-left position in pixels.</summary>
+    public Position Position { get; }
+
+    /// <summary>Gets the object's width in pixels (0 for shapes without a size, e.g. points).</summary>
+    public float Width { get; }
+
+    /// <summary>Gets the object's height in pixels (0 for shapes without a size, e.g. points).</summary>
+    public float Height { get; }
+
+    /// <summary>Gets the object's geometric shape.</summary>
+    public TileMapObjectShape Shape { get; }
+
+    /// <summary>Gets the object's custom properties, in file order.</summary>
+    public IReadOnlyList<MapProperty> Properties { get; }
+
+    internal TileMapObject(
+        uint id,
+        string name,
+        string type,
+        Position position,
+        float width,
+        float height,
+        TileMapObjectShape shape,
+        IReadOnlyList<MapProperty> properties)
+    {
+        Id = id;
+        Name = name;
+        Type = type;
+        Position = position;
+        Width = width;
+        Height = height;
+        Shape = shape;
+        Properties = properties;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="TileMapObject"/> from a DotTiled <see cref="DotTiled.Object"/>,
+    /// detecting the shape from the object subtype and converting the custom properties.
+    /// </summary>
+    /// <param name="obj">The DotTiled object to convert.</param>
+    /// <returns>The corresponding <see cref="TileMapObject"/>.</returns>
+    internal static TileMapObject FromDotTiled(DotTiled.Object obj)
+    {
+        var shape = obj switch
+        {
+            DotTiled.RectangleObject => TileMapObjectShape.Rectangle,
+            DotTiled.EllipseObject => TileMapObjectShape.Ellipse,
+            DotTiled.PointObject => TileMapObjectShape.Point,
+            DotTiled.PolygonObject => TileMapObjectShape.Polygon,
+            DotTiled.PolylineObject => TileMapObjectShape.Polyline,
+            DotTiled.TileObject => TileMapObjectShape.Tile,
+            DotTiled.TextObject => TileMapObjectShape.Text,
+            _ => throw new InvalidOperationException(
+                $"Unsupported Tiled object type '{obj.GetType().Name}'."),
+        };
+
+        return new TileMapObject(
+            obj.ID.GetValueOr(0),
+            obj.Name ?? string.Empty,
+            obj.Type ?? string.Empty,
+            new Position(obj.X, obj.Y),
+            obj.Width,
+            obj.Height,
+            shape,
+            obj.Properties.Select(MapProperty.Create).ToArray());
+    }
+}

--- a/src/RPGEngine/Tiled/TileMapObjectLayer.cs
+++ b/src/RPGEngine/Tiled/TileMapObjectLayer.cs
@@ -1,0 +1,52 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// An object layer of a <see cref="TileMap"/>: a named collection of <see cref="TileMapObject"/>s
+/// with their own visibility, opacity and custom properties. Object layers do not render tiles;
+/// rendering objects on the map is out of scope.
+/// </summary>
+public sealed class TileMapObjectLayer
+{
+    /// <summary>Gets the name of the object layer (as declared in the map).</summary>
+    public string Name { get; }
+
+    /// <summary>Gets whether the object layer is visible (shown) in the map.</summary>
+    public bool Visible { get; }
+
+    /// <summary>Gets the opacity of the object layer, from 0 (fully transparent) to 1 (fully opaque).</summary>
+    public float Opacity { get; }
+
+    /// <summary>Gets the objects of the layer, in file order.</summary>
+    public IReadOnlyList<TileMapObject> Objects { get; }
+
+    /// <summary>Gets the object layer's custom properties, in file order.</summary>
+    public IReadOnlyList<MapProperty> Properties { get; }
+
+    internal TileMapObjectLayer(
+        string name,
+        bool visible,
+        float opacity,
+        IReadOnlyList<TileMapObject> objects,
+        IReadOnlyList<MapProperty> properties)
+    {
+        Name = name;
+        Visible = visible;
+        Opacity = opacity;
+        Objects = objects;
+        Properties = properties;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="TileMapObjectLayer"/> from a DotTiled <see cref="DotTiled.ObjectLayer"/>,
+    /// converting each object and the layer's custom properties.
+    /// </summary>
+    /// <param name="layer">The DotTiled object layer to convert.</param>
+    /// <returns>The corresponding <see cref="TileMapObjectLayer"/>.</returns>
+    internal static TileMapObjectLayer FromDotTiled(DotTiled.ObjectLayer layer)
+        => new(
+            layer.Name ?? string.Empty,
+            layer.Visible,
+            layer.Opacity,
+            layer.Objects.Select(TileMapObject.FromDotTiled).ToArray(),
+            layer.Properties.Select(MapProperty.Create).ToArray());
+}

--- a/src/RPGEngine/Tiled/TileMapObjectShape.cs
+++ b/src/RPGEngine/Tiled/TileMapObjectShape.cs
@@ -1,0 +1,31 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// The geometric shape of an object in an object layer. Detected from the object's shape in the
+/// Tiled file: a plain <c>&lt;object&gt;</c> is a rectangle, while <c>&lt;ellipse/&gt;</c>,
+/// <c>&lt;point/&gt;</c>, <c>&lt;polygon&gt;</c>, <c>&lt;polyline&gt;</c>, a <c>gid</c>
+/// attribute and <c>&lt;text&gt;</c> produce the other shapes.
+/// </summary>
+public enum TileMapObjectShape
+{
+    /// <summary>A rectangle (the default shape of a plain <c>&lt;object&gt;</c>).</summary>
+    Rectangle,
+
+    /// <summary>An ellipse (declared with an <c>&lt;ellipse/&gt;</c> child element).</summary>
+    Ellipse,
+
+    /// <summary>A point (declared with a <c>&lt;point/&gt;</c> child element).</summary>
+    Point,
+
+    /// <summary>A polygon (declared with a <c>&lt;polygon&gt;</c> child element).</summary>
+    Polygon,
+
+    /// <summary>A polyline (declared with a <c>&lt;polyline&gt;</c> child element).</summary>
+    Polyline,
+
+    /// <summary>A tile object (declared with a <c>gid</c> attribute referencing a tile).</summary>
+    Tile,
+
+    /// <summary>A text object (declared with a <c>&lt;text&gt;</c> child element).</summary>
+    Text,
+}

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -124,7 +124,7 @@ public class DocsExamplesTests
     [Fact]
     public void CharacterIndex_SelectsOneOfEightCharacters()
     {
-        // Standard RPG Maker MZ sheet: 576×384 → 48×48 cells.
+        // Standard RPG Maker MZ sheet: 576×384 &#8594; 48×48 cells.
         using (var sheetStream = FixtureAssets.DecodePngStream(FixtureAssets.FullSheet))
         {
             var manager = new SpriteSheetManager();

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -124,7 +124,7 @@ public class DocsExamplesTests
     [Fact]
     public void CharacterIndex_SelectsOneOfEightCharacters()
     {
-        // Standard RPG Maker MZ sheet: 576×384 &#8594; 48×48 cells.
+        // Standard RPG Maker MZ sheet: 576×384 → 48×48 cells.
         using (var sheetStream = FixtureAssets.DecodePngStream(FixtureAssets.FullSheet))
         {
             var manager = new SpriteSheetManager();
@@ -357,6 +357,70 @@ public class DocsExamplesTests
 
         Assert.Equal(map.Width, streamMap.Width);
         Assert.Equal(map.Height, streamMap.Height);
+    }
+
+    // ---------------------------------------------------------------------
+    // docs/api/TileMap.md: reading map custom properties, object layers and
+    // object properties (story 25).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies the TileMap custom-properties and object-layer examples: map properties via GetProperty, object layers in file order, and per-object properties.</summary>
+    [Fact]
+    public void TileMap_CustomPropertiesAndObjectLayers()
+    {
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 }) },
+            mapProperties: new[]
+            {
+                new FixtureProperty("difficulty", "string", "hard"),
+                new FixtureProperty("ambient_light", "float", "0.8"),
+            },
+            objectLayers: new[]
+            {
+                new ObjectLayerSpec(
+                    "objects",
+                    new[]
+                    {
+                        new ObjectSpec(
+                            Id: 1,
+                            Name: "chest",
+                            Type: "treasure",
+                            X: 48,
+                            Y: 96,
+                            Width: 32,
+                            Height: 32,
+                            Shape: FixtureObjectShape.Rectangle,
+                            Properties: new[] { new FixtureProperty("coins", "int", "100") }),
+                        new ObjectSpec(Id: 2, Name: "spawn", Type: "point", X: 0, Y: 0, Width: 0, Height: 0, Shape: FixtureObjectShape.Point),
+                    }),
+            });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // Map custom properties: GetProperty looks up by exact (case-sensitive) name.
+        var difficulty = map.GetProperty("difficulty");
+        Assert.NotNull(difficulty);
+        Assert.Equal(MapPropertyType.String, difficulty.Type);
+        Assert.Equal("hard", Assert.IsType<string>(difficulty.Value));
+        Assert.Null(map.GetProperty("Difficulty"));
+        Assert.Equal(0.8f, Assert.IsType<float>(map.GetProperty("ambient_light")!.Value));
+
+        // Object layers are exposed separately from the tile layers, in file order.
+        Assert.Single(map.ObjectLayers);
+        Assert.Equal("objects", map.ObjectLayers[0].Name);
+        Assert.Single(map.Layers); // only the tile layer
+
+        // Objects expose identity, geometry, shape and their own custom properties.
+        var chest = map.ObjectLayers[0].Objects.Single(o => o.Name == "chest");
+        Assert.Equal(1u, chest.Id);
+        Assert.Equal("treasure", chest.Type);
+        Assert.Equal(new Position(48, 96), chest.Position);
+        Assert.Equal(TileMapObjectShape.Rectangle, chest.Shape);
+        Assert.Equal(100, chest.Properties.Single(p => p.Name == "coins").Value);
+
+        var spawn = map.ObjectLayers[0].Objects.Single(o => o.Name == "spawn");
+        Assert.Equal(TileMapObjectShape.Point, spawn.Shape);
+        Assert.Equal(new Position(0, 0), spawn.Position);
     }
 
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -325,7 +325,7 @@ public class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // UpRight = (+½√2, -½√2); one second at 96 px/s → (±96·√½) ≈ (±67.88) per axis.
+        // UpRight = (+√½, -√½); one second at 96 px/s → (±96·√½) ≈ (±67.88) per axis.
         var component = 96 * Math.Sqrt(0.5);
         Assert.Equal(200 + component, engine.Player.Position.X, precision: 6);
         Assert.Equal(200 - component, engine.Player.Position.Y, precision: 6);

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -310,7 +310,7 @@ public class GameEngineTests
     // diagonally, opposite keys cancel, and releasing one key of a held
     // diagonal pair reverts to the remaining cardinal direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies holding W+D for one second at 96 px/s moves diagonally up-right (±67.88 px per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
+    /// <summary>Verifies holding W+D for one second at 96 px/s moves diagonally up-right (~±67.88 px per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
     [Fact]
     public void Update_HoldingDiagonalPair_MovesDiagonallyAndRevertsOnRelease()
     {
@@ -325,7 +325,7 @@ public class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // UpRight = (+½√2, -½√2); one second at 96 px/s → (±96·√2/2) ≈ (±67.88) per axis.
+        // UpRight = (+½√2, -½√2); one second at 96 px/s → (±96·√½) ≈ (±67.88) per axis.
         var component = 96 * Math.Sqrt(0.5);
         Assert.Equal(200 + component, engine.Player.Position.X, precision: 6);
         Assert.Equal(200 - component, engine.Player.Position.Y, precision: 6);

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -310,7 +310,7 @@ public class GameEngineTests
     // diagonally, opposite keys cancel, and releasing one key of a held
     // diagonal pair reverts to the remaining cardinal direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies holding W+D for one second at 96 px/s moves diagonally up-right (~±67.88 px per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
+    /// <summary>Verifies holding W+D for one second at 96 px/s moves diagonally up-right (±67.88 px per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
     [Fact]
     public void Update_HoldingDiagonalPair_MovesDiagonallyAndRevertsOnRelease()
     {
@@ -325,7 +325,7 @@ public class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // UpRight = (+√½, -√½); one second at 96 px/s → (±96·√½) ≈ (±67.88) per axis.
+        // UpRight = (+½√2, -½√2); one second at 96 px/s → (±96·√2/2) ≈ (±67.88) per axis.
         var component = 96 * Math.Sqrt(0.5);
         Assert.Equal(200 + component, engine.Player.Position.X, precision: 6);
         Assert.Equal(200 - component, engine.Player.Position.Y, precision: 6);
@@ -502,7 +502,7 @@ public class GameEngineTests
                 new TileLayerSpec(
                     "above",
                     new uint[] { 2, 0, 0, 0 },
-                    Properties: new[] { new LayerProperty("above_player", "bool", "true") }),
+                    Properties: new[] { new FixtureProperty("above_player", "bool", "true") }),
             },
             tileColors: colors))
         {

--- a/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
+++ b/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
@@ -203,7 +203,7 @@ public class TileMapTests
         var above = new TileLayerSpec(
             "above",
             new uint[] { 0, 0, 0, 0 },
-            Properties: new[] { new LayerProperty("above_player", "bool", "true") });
+            Properties: new[] { new FixtureProperty("above_player", "bool", "true") });
 
         using var fixture = TiledTestFixture.Create2x2(new[] { ground, above });
         var map = TileMap.Load(fixture.MapPath);
@@ -220,11 +220,11 @@ public class TileMapTests
         var falseValue = new TileLayerSpec(
             "false_value",
             new uint[] { 0, 0, 0, 0 },
-            Properties: new[] { new LayerProperty("above_player", "bool", "false") });
+            Properties: new[] { new FixtureProperty("above_player", "bool", "false") });
         var nonBool = new TileLayerSpec(
             "non_bool",
             new uint[] { 0, 0, 0, 0 },
-            Properties: new[] { new LayerProperty("above_player", "string", "true") });
+            Properties: new[] { new FixtureProperty("above_player", "string", "true") });
 
         using var fixture = TiledTestFixture.Create2x2(new[] { absent, falseValue, nonBool });
         var map = TileMap.Load(fixture.MapPath);
@@ -242,7 +242,7 @@ public class TileMapTests
         var above = new TileLayerSpec(
             "above",
             new uint[] { 2, 2, 2, 2 }, // all green
-            Properties: new[] { new LayerProperty("above_player", "bool", "true") });
+            Properties: new[] { new FixtureProperty("above_player", "bool", "true") });
 
         using var fixture = new TiledTestFixture(
             2,
@@ -267,6 +267,214 @@ public class TileMapTests
             Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(24, 24));
             Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(72, 72));
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Map custom properties, object layers and layer properties (story 25).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a map's custom properties are exposed with their name, type and typed value, and that GetProperty performs a case-sensitive lookup.</summary>
+    [Fact]
+    public void MapProperties_ExposeTypedValues_AndGetPropertyLooksUpCaseSensitively()
+    {
+        var mapProperties = new[]
+        {
+            new FixtureProperty("flag", "bool", "true"),
+            new FixtureProperty("count", "int", "42"),
+            new FixtureProperty("ratio", "float", "1.5"),
+            new FixtureProperty("name", "string", "hello"),
+            new FixtureProperty("tint", "color", "#ff0000"),
+            new FixtureProperty("data", "file", "data.txt"),
+        };
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground }, mapProperties: mapProperties);
+        var map = TileMap.Load(fixture.MapPath);
+
+        // Properties are exposed in file order with the correct type and typed value.
+        Assert.Equal(6, map.Properties.Count);
+        AssertMapProperty(map.Properties[0], "flag", MapPropertyType.Bool, true);
+        AssertMapProperty(map.Properties[1], "count", MapPropertyType.Int, 42);
+        AssertMapProperty(map.Properties[2], "ratio", MapPropertyType.Float, 1.5f);
+        AssertMapProperty(map.Properties[3], "name", MapPropertyType.String, "hello");
+        Assert.Equal(MapPropertyType.Color, map.Properties[4].Type);
+        Assert.Equal(new SKColor(255, 0, 0, 255), Assert.IsType<SKColor>(map.Properties[4].Value));
+        AssertMapProperty(map.Properties[5], "data", MapPropertyType.File, "data.txt");
+
+        // GetProperty returns the value by exact (case-sensitive) name.
+        Assert.Equal(true, map.GetProperty("flag")!.Value);
+        Assert.Equal(42, map.GetProperty("count")!.Value);
+        Assert.Equal("hello", map.GetProperty("name")!.Value);
+        Assert.Null(map.GetProperty("Flag"));
+        Assert.Null(map.GetProperty("missing"));
+    }
+
+    /// <summary>Verifies an object layer exposes its objects (identity, geometry, shape) and the custom properties of both the layer and each object.</summary>
+    [Fact]
+    public void ObjectLayers_ExposeObjects_AndTheirProperties()
+    {
+        var objects = new[]
+        {
+            new ObjectSpec(
+                Id: 1,
+                Name: "player",
+                Type: "hero",
+                X: 10,
+                Y: 20,
+                Width: 32,
+                Height: 48,
+                Shape: FixtureObjectShape.Rectangle,
+                Properties: new[]
+                {
+                    new FixtureProperty("hp", "int", "100"),
+                    new FixtureProperty("alive", "bool", "true"),
+                    new FixtureProperty("label", "string", "player"),
+                }),
+            new ObjectSpec(
+                Id: 2,
+                Name: "door",
+                Type: "prop",
+                X: 100,
+                Y: 200,
+                Width: 48,
+                Height: 48,
+                Shape: FixtureObjectShape.Point),
+        };
+        var objectLayer = new ObjectLayerSpec(
+            "objects",
+            objects,
+            Visible: true,
+            Opacity: 0.75f,
+            Properties: new[] { new FixtureProperty("owner", "string", "level1") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground }, objectLayers: new[] { objectLayer });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.Single(map.ObjectLayers);
+        var layer = map.ObjectLayers[0];
+        Assert.Equal("objects", layer.Name);
+        Assert.True(layer.Visible);
+        Assert.Equal(0.75f, layer.Opacity);
+        Assert.Equal(2, layer.Objects.Count);
+
+        // The object layer's own custom properties are exposed.
+        Assert.Equal("owner", layer.Properties[0].Name);
+        Assert.Equal("level1", layer.Properties[0].Value);
+
+        // The first object exposes identity, geometry, shape and custom properties.
+        var player = layer.Objects[0];
+        Assert.Equal(1u, player.Id);
+        Assert.Equal("player", player.Name);
+        Assert.Equal("hero", player.Type);
+        Assert.Equal(new Position(10, 20), player.Position);
+        Assert.Equal(32f, player.Width);
+        Assert.Equal(48f, player.Height);
+        Assert.Equal(TileMapObjectShape.Rectangle, player.Shape);
+        Assert.Equal(3, player.Properties.Count);
+        Assert.Equal(100, player.Properties.Single(p => p.Name == "hp").Value);
+        Assert.Equal(true, player.Properties.Single(p => p.Name == "alive").Value);
+        Assert.Equal("player", player.Properties.Single(p => p.Name == "label").Value);
+
+        // The second object exposes its own identity and geometry.
+        var door = layer.Objects[1];
+        Assert.Equal(2u, door.Id);
+        Assert.Equal("door", door.Name);
+        Assert.Equal(new Position(100, 200), door.Position);
+        Assert.Equal(TileMapObjectShape.Point, door.Shape);
+        Assert.Empty(door.Properties);
+    }
+
+    /// <summary>Verifies every object shape is detected from the Tiled object subtype (a plain object is a rectangle; markers/gid/text produce the others).</summary>
+    [Fact]
+    public void ObjectLayers_DetectObjectShapes()
+    {
+        var objects = new[]
+        {
+            new ObjectSpec(1, "rect", "x", 0, 0, 8, 9, FixtureObjectShape.Rectangle),
+            new ObjectSpec(2, "ellipse", "x", 0, 0, 6, 7, FixtureObjectShape.Ellipse),
+            new ObjectSpec(3, "point", "x", 0, 0, 0, 0, FixtureObjectShape.Point),
+            new ObjectSpec(4, "polygon", "x", 0, 0, 0, 0, FixtureObjectShape.Polygon),
+            new ObjectSpec(5, "polyline", "x", 0, 0, 0, 0, FixtureObjectShape.Polyline),
+            new ObjectSpec(6, "tile", "x", 0, 0, 0, 0, FixtureObjectShape.Tile),
+            new ObjectSpec(7, "text", "x", 0, 0, 50, 20, FixtureObjectShape.Text),
+        };
+
+        using var fixture = TiledTestFixture.Create2x2(
+            new[] { Ground },
+            objectLayers: new[] { new ObjectLayerSpec("objects", objects) });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.Equal(
+            new[]
+            {
+                TileMapObjectShape.Rectangle,
+                TileMapObjectShape.Ellipse,
+                TileMapObjectShape.Point,
+                TileMapObjectShape.Polygon,
+                TileMapObjectShape.Polyline,
+                TileMapObjectShape.Tile,
+                TileMapObjectShape.Text,
+            },
+            map.ObjectLayers[0].Objects.Select(o => o.Shape));
+    }
+
+    /// <summary>Verifies Layers still contains only tile layers when the file also declares object layers (regression).</summary>
+    [Fact]
+    public void Layers_ContainsOnlyTileLayers_NotObjectLayers()
+    {
+        var objectLayer = new ObjectLayerSpec(
+            "objects",
+            new[] { new ObjectSpec(1, "o", "x", 0, 0, 10, 10, FixtureObjectShape.Point) });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground, Decor }, objectLayers: new[] { objectLayer });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // Object layers must never be mixed into Layers; they are exposed via ObjectLayers.
+        Assert.Equal(2, map.Layers.Count);
+        Assert.Equal(new[] { "ground", "decor" }, map.Layers.Select(l => l.Name));
+        Assert.Single(map.ObjectLayers);
+        Assert.Equal("objects", map.ObjectLayers[0].Name);
+    }
+
+    /// <summary>Verifies maps without custom properties or object layers load with empty lists (regression).</summary>
+    [Fact]
+    public void Maps_WithoutPropertiesOrObjectLayers_LoadWithEmptyLists()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.Empty(map.Properties);
+        Assert.Empty(map.ObjectLayers);
+        Assert.Null(map.GetProperty("anything"));
+    }
+
+    /// <summary>Verifies a tile layer exposes its custom properties, including the above_player flag that also drives the dedicated AbovePlayer member.</summary>
+    [Fact]
+    public void TileMapLayer_ExposesCustomProperties()
+    {
+        var ground = new TileLayerSpec(
+            "ground",
+            new uint[] { 1, 1, 1, 1 },
+            Properties: new[]
+            {
+                new FixtureProperty("above_player", "bool", "true"),
+                new FixtureProperty("owner", "string", "me"),
+            });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { ground });
+        var map = TileMap.Load(fixture.MapPath);
+
+        var layer = map.Layers[0];
+        Assert.Equal(2, layer.Properties.Count);
+        Assert.True(layer.AbovePlayer); // the dedicated flag still comes from the property
+        AssertMapProperty(layer.Properties[0], "above_player", MapPropertyType.Bool, true);
+        AssertMapProperty(layer.Properties[1], "owner", MapPropertyType.String, "me");
+    }
+
+    /// <summary>Asserts a <see cref="MapProperty"/> matches the expected name, type and boxed value.</summary>
+    private static void AssertMapProperty(MapProperty property, string name, MapPropertyType type, object? value)
+    {
+        Assert.Equal(name, property.Name);
+        Assert.Equal(type, property.Type);
+        Assert.Equal(value, property.Value);
     }
 
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/Tiled/TiledTestFixture.cs
+++ b/tests/RPGEngine.Tests/Tiled/TiledTestFixture.cs
@@ -4,11 +4,11 @@ using SkiaSharp;
 
 namespace RPGEngine.Tests.Tiled;
 
-/// <summary>A single custom property to be written into a generated layer's <c>&lt;properties&gt;</c> block.</summary>
+/// <summary>A single custom property to be written into a generated <c>&lt;properties&gt;</c> block.</summary>
 /// <param name="Name">The property name (e.g. <c>above_player</c>).</param>
 /// <param name="Type">The Tiled property type (e.g. <c>bool</c>, <c>string</c>, <c>int</c>).</param>
 /// <param name="Value">The property value as a string (e.g. <c>true</c>).</param>
-internal sealed record LayerProperty(string Name, string Type, string Value);
+internal sealed record FixtureProperty(string Name, string Type, string Value);
 
 /// <summary>Specifies a tile layer to be written into a generated TMX fixture.</summary>
 /// <param name="Name">The layer name.</param>
@@ -21,7 +21,66 @@ internal sealed record TileLayerSpec(
     uint[] Gids,
     bool Visible = true,
     float Opacity = 1f,
-    IReadOnlyList<LayerProperty>? Properties = null);
+    IReadOnlyList<FixtureProperty>? Properties = null);
+
+/// <summary>The geometric shape of a generated object; controls which marker element is emitted.</summary>
+internal enum FixtureObjectShape
+{
+    /// <summary>A plain <c>&lt;object&gt;</c> (no marker; the Tiled default shape).</summary>
+    Rectangle,
+
+    /// <summary>An <c>&lt;ellipse/&gt;</c> marker.</summary>
+    Ellipse,
+
+    /// <summary>A <c>&lt;point/&gt;</c> marker.</summary>
+    Point,
+
+    /// <summary>A <c>&lt;polygon&gt;</c> marker.</summary>
+    Polygon,
+
+    /// <summary>A <c>&lt;polyline&gt;</c> marker.</summary>
+    Polyline,
+
+    /// <summary>A <c>gid</c> attribute (a tile object).</summary>
+    Tile,
+
+    /// <summary>A <c>&lt;text&gt;</c> marker.</summary>
+    Text,
+}
+
+/// <summary>Specifies a single object to be written into a generated object layer.</summary>
+/// <param name="Id">The object ID (must be unique within the map).</param>
+/// <param name="Name">The object name.</param>
+/// <param name="Type">The object "class"/type string.</param>
+/// <param name="X">The object's X position in pixels.</param>
+/// <param name="Y">The object's Y position in pixels.</param>
+/// <param name="Width">The object's width in pixels.</param>
+/// <param name="Height">The object's height in pixels.</param>
+/// <param name="Shape">The object's geometric shape.</param>
+/// <param name="Properties">Optional custom properties emitted inside the object.</param>
+internal sealed record ObjectSpec(
+    uint Id,
+    string Name,
+    string Type,
+    float X,
+    float Y,
+    float Width,
+    float Height,
+    FixtureObjectShape Shape,
+    IReadOnlyList<FixtureProperty>? Properties = null);
+
+/// <summary>Specifies an object layer to be written into a generated TMX fixture.</summary>
+/// <param name="Name">The layer name.</param>
+/// <param name="Objects">The objects of the layer, in file order.</param>
+/// <param name="Visible">Whether the layer is visible.</param>
+/// <param name="Opacity">The layer opacity, from 0 to 1.</param>
+/// <param name="Properties">Optional custom properties emitted inside the layer.</param>
+internal sealed record ObjectLayerSpec(
+    string Name,
+    IReadOnlyList<ObjectSpec> Objects,
+    bool Visible = true,
+    float Opacity = 1f,
+    IReadOnlyList<FixtureProperty>? Properties = null);
 
 /// <summary>The visual pattern painted into the generated 48×48 tile PNG.</summary>
 internal enum TilePattern
@@ -50,8 +109,10 @@ internal enum TilePattern
 /// <c>above_player</c> layer in green).
 /// </para>
 /// <para>
-/// Each layer may declare custom properties via <see cref="TileLayerSpec.Properties"/>; these
-/// are emitted as a <c>&lt;properties&gt;</c> block inside the <c>&lt;layer&gt;</c> element,
+/// Each tile layer may declare custom properties via <see cref="TileLayerSpec.Properties"/>, the
+/// map may declare its own via the <c>mapProperties</c> constructor argument, and object layers
+/// (with per-object custom properties) can be added via the <c>objectLayers</c> argument; these
+/// are emitted as <c>&lt;properties&gt;</c> blocks and <c>&lt;objectgroup&gt;</c> elements
 /// matching the Tiled format.
 /// </para>
 /// </remarks>
@@ -81,7 +142,9 @@ internal sealed class TiledTestFixture : IDisposable
         int height,
         IReadOnlyList<TileLayerSpec> layers,
         TilePattern pattern = TilePattern.Solid,
-        IReadOnlyList<SKColor>? tileColors = null)
+        IReadOnlyList<SKColor>? tileColors = null,
+        IReadOnlyList<FixtureProperty>? mapProperties = null,
+        IReadOnlyList<ObjectLayerSpec>? objectLayers = null)
     {
         Width = width;
         Height = height;
@@ -94,12 +157,16 @@ internal sealed class TiledTestFixture : IDisposable
 
         CreateTileImage(ImagePath, pattern, tileColors);
         File.WriteAllText(TilesetPath, TilesetXml(tileColors));
-        File.WriteAllText(MapPath, MapXml(layers));
+        File.WriteAllText(MapPath, MapXml(layers, mapProperties, objectLayers));
     }
 
     /// <summary>Creates the standard 2×2 fixture used by most tests.</summary>
-    public static TiledTestFixture Create2x2(IReadOnlyList<TileLayerSpec> layers, TilePattern pattern = TilePattern.Solid)
-        => new(2, 2, layers, pattern);
+    public static TiledTestFixture Create2x2(
+        IReadOnlyList<TileLayerSpec> layers,
+        TilePattern pattern = TilePattern.Solid,
+        IReadOnlyList<FixtureProperty>? mapProperties = null,
+        IReadOnlyList<ObjectLayerSpec>? objectLayers = null)
+        => new(2, 2, layers, pattern, mapProperties: mapProperties, objectLayers: objectLayers);
 
     public void Dispose()
     {
@@ -177,13 +244,23 @@ internal sealed class TiledTestFixture : IDisposable
             """;
     }
 
-    private string MapXml(IReadOnlyList<TileLayerSpec> layers)
+    private string MapXml(
+        IReadOnlyList<TileLayerSpec> layers,
+        IReadOnlyList<FixtureProperty>? mapProperties,
+        IReadOnlyList<ObjectLayerSpec>? objectLayers)
     {
         var sb = new StringBuilder();
         sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+
+        var objectCount = objectLayers?.Sum(layer => layer.Objects.Count) ?? 0;
+        var nextObjectId = Math.Max(1, objectCount + 1); // object IDs are 1-based
+        var nextLayerId = layers.Count + (objectLayers?.Count ?? 0) + 1;
+
         sb.AppendLine(
-            $"""<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="{Width}" height="{Height}" tilewidth="{TileSize}" tileheight="{TileSize}" infinite="0" nextlayerid="{layers.Count + 1}" nextobjectid="1">""");
+            $"""<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="{Width}" height="{Height}" tilewidth="{TileSize}" tileheight="{TileSize}" infinite="0" nextlayerid="{nextLayerId}" nextobjectid="{nextObjectId}">""");
         sb.AppendLine("  <tileset firstgid=\"1\" source=\"tiles.tsx\"/>");
+
+        AppendProperties(sb, "  ", mapProperties);
 
         for (var i = 0; i < layers.Count; i++)
         {
@@ -191,17 +268,7 @@ internal sealed class TiledTestFixture : IDisposable
             sb.AppendLine(
                 $"""  <layer id="{i + 1}" name="{layer.Name}" width="{Width}" height="{Height}" visible="{(layer.Visible ? 1 : 0)}" opacity="{layer.Opacity.ToString(CultureInfo.InvariantCulture)}">""");
 
-            if (layer.Properties is { Count: > 0 })
-            {
-                sb.AppendLine("    <properties>");
-                foreach (var property in layer.Properties)
-                {
-                    sb.AppendLine(
-                        $"      <property name=\"{property.Name}\" type=\"{property.Type}\" value=\"{property.Value}\"/>");
-                }
-
-                sb.AppendLine("    </properties>");
-            }
+            AppendProperties(sb, "    ", layer.Properties);
 
             sb.AppendLine("    <data encoding=\"csv\">");
             for (var y = 0; y < Height; y++)
@@ -217,7 +284,78 @@ internal sealed class TiledTestFixture : IDisposable
             sb.AppendLine("  </layer>");
         }
 
+        if (objectLayers is { Count: > 0 })
+        {
+            var layerId = layers.Count + 1;
+            foreach (var objectLayer in objectLayers)
+            {
+                sb.AppendLine(
+                    $"""  <objectgroup id="{layerId}" name="{objectLayer.Name}" visible="{(objectLayer.Visible ? 1 : 0)}" opacity="{objectLayer.Opacity.ToString(CultureInfo.InvariantCulture)}">""");
+
+                AppendProperties(sb, "    ", objectLayer.Properties);
+
+                foreach (var obj in objectLayer.Objects)
+                {
+                    AppendObject(sb, obj);
+                }
+
+                sb.AppendLine("  </objectgroup>");
+                layerId++;
+            }
+        }
+
         sb.AppendLine("</map>");
         return sb.ToString();
+    }
+
+    /// <summary>Appends a <c>&lt;properties&gt;</c> block for <paramref name="properties"/> (nothing when empty).</summary>
+    private static void AppendProperties(StringBuilder sb, string indent, IReadOnlyList<FixtureProperty>? properties)
+    {
+        if (properties is { Count: > 0 })
+        {
+            sb.AppendLine(indent + "<properties>");
+            foreach (var property in properties)
+            {
+                sb.AppendLine(
+                    indent + $"  <property name=\"{property.Name}\" type=\"{property.Type}\" value=\"{property.Value}\"/>");
+            }
+
+            sb.AppendLine(indent + "</properties>");
+        }
+    }
+
+    /// <summary>Appends a single <c>&lt;object&gt;</c> element (with its properties and shape marker).</summary>
+    private static void AppendObject(StringBuilder sb, ObjectSpec obj)
+    {
+        // A tile object is declared with a gid attribute (instead of a marker element).
+        var gidAttribute = obj.Shape == FixtureObjectShape.Tile ? " gid=\"1\"" : string.Empty;
+        sb.AppendLine(
+            $"    <object id=\"{obj.Id}\" name=\"{obj.Name}\" type=\"{obj.Type}\" x=\"{obj.X.ToString(CultureInfo.InvariantCulture)}\" y=\"{obj.Y.ToString(CultureInfo.InvariantCulture)}\" width=\"{obj.Width.ToString(CultureInfo.InvariantCulture)}\" height=\"{obj.Height.ToString(CultureInfo.InvariantCulture)}\"{gidAttribute}>");
+
+        AppendProperties(sb, "      ", obj.Properties);
+
+        switch (obj.Shape)
+        {
+            case FixtureObjectShape.Ellipse:
+                sb.AppendLine("      <ellipse/>");
+                break;
+            case FixtureObjectShape.Point:
+                sb.AppendLine("      <point/>");
+                break;
+            case FixtureObjectShape.Polygon:
+                sb.AppendLine("      <polygon points=\"0,0 16,0 16,16 0,16\"/>");
+                break;
+            case FixtureObjectShape.Polyline:
+                sb.AppendLine("      <polyline points=\"0,0 16,16\"/>");
+                break;
+            case FixtureObjectShape.Text:
+                sb.AppendLine("      <text>Object text</text>");
+                break;
+            default:
+                // A plain <object> is a rectangle; a tile object carries only the gid attribute.
+                break;
+        }
+
+        sb.AppendLine("    </object>");
     }
 }


### PR DESCRIPTION
## Summary

Implements [#25](https://github.com/elliottv/rpg-engine/issues/25): gives users access to the **map's custom properties** and to **object layers** (the map's objects and their custom properties). The read model wraps DotTiled so no DotTiled types leak into the public API.

Closes #25

### New public types (`RPGEngine.Tiled`)
- `MapPropertyType` — enum (`Bool, Int, Float, String, Color, File, Object, Class, Unknown`).
- `MapProperty` — sealed record `(string Name, MapPropertyType Type, object? Value)` with an internal `MapProperty.Create(DotTiled.IProperty)` factory that pattern-matches the DotTiled property subtypes (colors → `SKColor`, `Object` → the referenced object ID as a string, `Class`/unknown → `null`).
- `TileMapObjectShape` — enum (`Rectangle, Ellipse, Point, Polygon, Polyline, Tile, Text`), detected from the DotTiled object subtype.
- `TileMapObject` — sealed class exposing `Id`, `Name`, `Type`, `Position`, `Width`, `Height`, `Shape` and `Properties`.
- `TileMapObjectLayer` — sealed class exposing `Name`, `Visible`, `Opacity`, `Objects` and `Properties`.

### Changed types
- `TileMap` — new `Properties` (map custom properties, file order), `ObjectLayers` (object layers in file order), and a case-sensitive `GetProperty(string)` lookup. `Layers` remains **tile layers only** (unchanged API); `BuildMap` now populates all three.
- `TileMapLayer` — new `Properties` (layer custom properties, including `above_player` when declared; the dedicated `AbovePlayer` bool is unchanged).

### Tests
- `TiledTestFixture` now emits map properties, object layers (objects with id/name/type/x/y/width/height/shape and per-object properties) and layer properties; `LayerProperty` renamed to `FixtureProperty`.
- New `TileMapTests` cover all five acceptance criteria: typed map properties + `GetProperty` (case-sensitive, `null` when absent), object layers/objects with their properties, shape detection, `Layers` staying tile-layers-only (regression) and empty lists for maps without properties/object layers (regression), plus layer properties.
- New `DocsExamplesTests.TileMap_CustomPropertiesAndObjectLayers` compiles and runs against the real API.

### Docs
- Added `docs/api` pages for the five new types, updated the API index, and documented `Properties`/`ObjectLayers`/`GetProperty` on `TileMap` and `Properties` on `TileMapLayer`.

### Verification
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~TileMapTests|FullyQualifiedName~DocsExamplesTests"` → 48 passed.
- Full test suite → 248 passed.

### Out of scope (as specified)
Rendering objects, polygon/polyline point lists, tile objects' referenced tiles, editing/adding objects or properties, and mapping custom-class properties to C# types.