### PR TITLE
Story 39: prerender each tile layer to an SKImage on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Every public class, property and method is XML-documented (CS1591 enforced) and 
 `docs/api/` with commented, compilable examples (`DocsExamplesTests` runs them against the real
 API).
 
+A `TileMap` is `IDisposable` (it prerenders every visible tile layer into an `SKImage` on load
+and releases them on dispose). The engine owns the assigned map: replacing `GameEngine.Map`
+disposes the previous map, and disposing the engine disposes the current one.
+
 ## Samples
 
 - **Desktop** (`samples/RPGEngine.Sample.Desktop`) — a minimal WPF host that renders the

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -180,11 +180,20 @@ below-player layers → NPCs → player → above-player layers
 
 - When a `TileMap` is set, the canvas is **cleared to black first** — this is the black
   background behind and around the map.
-- `TileMap.Draw` renders the layers **below** the player (every layer whose
-  `TileMapLayer.AbovePlayer` is `false`), then each NPC and the player are drawn on top, and
-  finally `TileMap.DrawAbovePlayer` renders the layers whose `above_player` custom property is
-  `true` so those tiles appear **in front of** the player (e.g. tree canopies the player walks
-  under).
+- **Tile layers are prerendered once on load.** Each visible, non-empty tile layer is rasterized
+  into its own `SKImage` of the map's pixel size (`TileMap.PixelWidth × PixelHeight`) when the
+  map is loaded: the tiles are drawn at their world pixel positions with the flip transforms
+  applied and the layer opacity baked into the layer alpha. Invisible and empty layers are not
+  prerendered (a `null` slot). A `TileMap` is `IDisposable` and releases these prerendered
+  images; the engine disposes the previous map when `GameEngine.Map` is replaced and when the
+  engine itself is disposed.
+- **Drawing is a per-layer image blit.** `TileMap.Draw` blits the prerendered images of the
+  layers **below** the player (every layer whose `TileMapLayer.AbovePlayer` is `false`), each
+  NPC and the player are drawn on top, and finally `TileMap.DrawAbovePlayer` blits the layers
+  whose `above_player` custom property is `true` so those tiles appear **in front of** the
+  player (e.g. tree canopies the player walks under). Each blit draws the intersection of the
+  viewport with the layer image bounds, so viewport culling is preserved and no per-tile work
+  happens per frame.
 - The camera follows the player and clamps the viewport inside the map. When the map is
   **smaller than the canvas** on an axis it is **centered** in the canvas and the area around
   it stays black (`offset = max(0, (canvasSize − mapPixelSize) / 2)`), so a small map is never

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,17 +91,22 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > The synchronous, file-system based equivalents (`TileMap.Load(path)`, `LoadSpriteSheet(name,
 > path)`) are what the desktop sample host uses; both loading styles exercise the same rendering
 > pipeline.
+>
+> **Map ownership:** a `TileMap` is `IDisposable` — it prerenders every visible tile layer into
+> an `SKImage` on load. The engine owns the assigned map: replacing `engine.Map` disposes the
+> previous map, and disposing the engine (`using var engine = ...` or `engine.Dispose()`) disposes
+> the current one.
 
 ### Reading order
 
 | Page | What it covers |
 | --- | --- |
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering, rendering order and the Tiled read model. |
-| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async), camera, black background / map centering. |
+| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async), camera, black background / map centering, map ownership (`IDisposable`). |
 | [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references and the speed-scaled walk-cycle animation (`AnimationCycleSpeed`). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |
-| [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading (sync + async) and rendering; map custom properties, object layers and the `above_player` flag. |
+| [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading (sync + async); prerendered layer images, viewport-culled image-blit rendering and `IDisposable`; map custom properties, object layers and the `above_player` flag. |
 | [api/TileMapLayer.md](api/TileMapLayer.md) | Tile-layer data and the `AbovePlayer` flag. |
 | [api/MapProperty.md](api/MapProperty.md) / [api/MapPropertyType.md](api/MapPropertyType.md) | Typed map/layer/object custom properties. |
 | [api/TileMapObject.md](api/TileMapObject.md) / [api/TileMapObjectShape.md](api/TileMapObjectShape.md) / [api/TileMapObjectLayer.md](api/TileMapObjectLayer.md) | The object-layer read model. |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -26,6 +26,9 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
 - Movement input combines every held bound key into a single 8-direction vector: opposite keys
   cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
   at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
+- The engine is **`IDisposable`**: it owns the assigned map and disposes it when `Map` is
+  replaced or when the engine itself is disposed (a `TileMap` is disposable because it
+  prerenders each tile layer into an `SKImage` on load).
 - Tile sets are not loaded through the engine: a `TileMap` owns the tilesets its layers
   reference. Standalone tilesets are loaded directly through the `TileSet.Load` factories.
 
@@ -66,10 +69,12 @@ engine.Characters.Add(npc);
 ### `TileMap? Map`
 
 Gets or sets the tile map to be displayed, or `null` when no map is loaded. When changed, the
-next `Render` uses the new map immediately.
+next `Render` uses the new map immediately. The engine **owns** the assigned map: replacing the
+value disposes the previous map, and `Dispose()` releases the current one.
 
 ```csharp
 engine.Map = TileMap.Load("assets/map.tmx");
+engine.Map = TileMap.Load("assets/other.tmx"); // the first map is disposed here
 ```
 
 ### `GameConfig Config`
@@ -123,6 +128,19 @@ using (var canvas = new SKCanvas(bitmap))
     canvas.Clear(SKColors.Transparent);
     engine.Render(canvas, dt: 1.0 / 60);
 }
+```
+
+### `void Dispose()`
+
+Releases the engine's resources: the current map (if any) is disposed, which releases its
+prerendered layer images. Replacing the map through `Map` already disposes the previous map, so
+hosts only need to call this when the engine itself is being torn down. Safe to call more than
+once.
+
+```csharp
+using var engine = new GameEngine { Map = TileMap.Load("assets/map.tmx") };
+// ... game loop ...
+// engine.Dispose() runs at the end of the using block and disposes the map.
 ```
 
 ### `void LoadSpriteSheet(string name, string path)`

--- a/docs/api/TileMap.md
+++ b/docs/api/TileMap.md
@@ -9,6 +9,16 @@ Namespace: `RPGEngine.Tiled` — a tile map loaded from a Tiled `.tmx` file (and
   are not registered anywhere globally. Loading a map never touches the engine's tilesets.
 - Tile coordinates are 0-based. Layer data is stored row-major. Only the orthogonal map layout
   is supported by this epic.
+- **Layers are prerendered on load.** Every visible, non-empty tile layer is rasterized once
+  into its own `SKImage` of the map's pixel size (`PixelWidth × PixelHeight`) when the map is
+  loaded: the tiles are drawn at their world pixel positions with the flip transforms applied,
+  and the layer's `Opacity` is baked into the layer alpha. Invisible layers and empty layers
+  (no non-zero GID) are not prerendered. `Draw` and `DrawAbovePlayer` then only **blit** the
+  cached layer images that intersect the viewport, so a frame never re-draws tiles.
+- A `TileMap` is **`IDisposable`**: disposing it releases the prerendered layer images.
+  Replacing `GameEngine.Map` disposes the previous map, and disposing the `GameEngine` disposes
+  the current map; hosts that load maps directly are responsible for disposing them when they
+  are replaced or no longer needed.
 - Rendering happens in **two passes**: the layers **below** the player (every layer whose
   `TileMapLayer.AbovePlayer` is `false`) are drawn first, and the layers **above** the player
   (those declaring the Tiled `above_player` custom property set to `true`) are drawn afterwards,
@@ -115,6 +125,21 @@ returns `false`; collision data will be added by a later story.
 
 ```csharp
 Console.WriteLine(map.IsSolid(1, 1)); // False
+```
+
+### `void Dispose()`
+
+Releases the prerendered layer images owned by the map. This method is **idempotent** (calling
+it more than once is a no-op). After disposal, `Draw` and `DrawAbovePlayer` throw
+`ObjectDisposedException`. The engine disposes the previous map when `GameEngine.Map` is
+replaced and when the engine itself is disposed, so hosts usually do not call `Dispose`
+directly.
+
+```csharp
+// The engine owns the map: replacing it (or disposing the engine) disposes it automatically.
+var engine = new GameEngine { Map = TileMap.Load("assets/map.tmx") };
+engine.Map = TileMap.Load("assets/other.tmx"); // the first map is disposed here
+engine.Dispose();                              // the current map is disposed here
 ```
 
 ## Example

--- a/samples/RPGEngine.Sample.Desktop/MainWindow.xaml.cs
+++ b/samples/RPGEngine.Sample.Desktop/MainWindow.xaml.cs
@@ -29,7 +29,13 @@ public partial class MainWindow : Window
         _engine = SampleScene.Create(fixtures.Root);
 
         CompositionTarget.Rendering += OnRendering;
-        Closed += (_, _) => CompositionTarget.Rendering -= OnRendering;
+        Closed += (_, _) =>
+        {
+            // The engine owns the map (a TileMap is IDisposable: it holds the prerendered
+            // layer images), so releasing the engine releases the map too.
+            CompositionTarget.Rendering -= OnRendering;
+            _engine.Dispose();
+        };
     }
 
     /// <summary>Runs the engine's update step on the UI thread at the compositor's frame rate.</summary>

--- a/samples/RPGEngine.Sample.Wasm/Pages/Index.razor
+++ b/samples/RPGEngine.Sample.Wasm/Pages/Index.razor
@@ -132,5 +132,8 @@
 
     public void Dispose()
     {
+        // The engine owns the map (a TileMap is IDisposable: it holds the prerendered layer
+        // images), so disposing the engine releases the map too.
+        _engine?.Dispose();
     }
 }

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -46,16 +46,22 @@ namespace RPGEngine;
 /// animation snaps back to the standing frame.
 /// </para>
 /// <para>
+/// The engine is <see cref="IDisposable"/>: it owns the assigned map and disposes it when
+/// <see cref="Map"/> is replaced or when the engine itself is disposed (a <see cref="TileMap"/>
+/// is disposable because it prerenders each tile layer into an <see cref="SKImage"/> on load).
+/// </para>
+/// <para>
 /// Tile sets are not loaded through the engine: a <see cref="TileMap"/> owns the tilesets that
 /// its layers reference (they are created when the map is loaded). Standalone tilesets can be
 /// loaded directly through the <c>TileSet.Load</c> factories in <c>RPGEngine.Tiled</c>.
 /// </para>
 /// </remarks>
-public sealed class GameEngine
+public sealed class GameEngine : IDisposable
 {
     private readonly SpriteSheetManager _spriteSheetManager = new();
     private readonly List<Character> _characters = [];
     private readonly HashSet<Key> _pressedKeys = [];
+    private TileMap? _map;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameEngine"/> class with default state: a
@@ -83,7 +89,24 @@ public sealed class GameEngine
     /// Gets or sets the tile map to be displayed, or <see langword="null"/> when no map is loaded.
     /// When the value is changed, the next <see cref="Render"/> uses the new map immediately.
     /// </summary>
-    public TileMap? Map { get; set; }
+    /// <remarks>
+    /// The engine owns the assigned map: replacing the value disposes the previous map (a
+    /// <see cref="TileMap"/> is <see cref="IDisposable"/>), and <see cref="Dispose"/> releases
+    /// the current map. Hosts that load maps directly and never assign them through this property
+    /// are responsible for disposing those maps themselves.
+    /// </remarks>
+    public TileMap? Map
+    {
+        get => _map;
+        set
+        {
+            if (!ReferenceEquals(_map, value))
+            {
+                _map?.Dispose();
+                _map = value;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets or sets the configuration values used by the engine. The engine reads the
@@ -207,6 +230,18 @@ public sealed class GameEngine
         {
             canvas.Restore();
         }
+    }
+
+    /// <summary>
+    /// Releases the resources owned by the engine: the current map (if any) is disposed, which
+    /// releases its prerendered layer images. Replacing the map through <see cref="Map"/> already
+    /// disposes the previous map, so hosts only need to call this when the engine itself is being
+    /// torn down. This method is safe to call more than once.
+    /// </summary>
+    public void Dispose()
+    {
+        // Assigning null through the setter disposes the current map and clears the reference.
+        Map = null;
     }
 
     /// <summary>

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -21,6 +21,22 @@ namespace RPGEngine.Tiled;
 /// layout is supported by this story; collision, pathfinding and <c>.tmj</c> are out of scope.
 /// </para>
 /// <para>
+/// Rendering is a per-layer image blit. When the map is loaded, every visible, non-empty tile
+/// layer is prerendered once into its own <see cref="SKImage"/> of the map's pixel size: the
+/// tiles are drawn at their world pixel positions with the flip transforms from
+/// <see cref="TileFlags"/> applied, and the layer's <see cref="TileMapLayer.Opacity"/> is baked
+/// into the layer alpha. <see cref="Draw"/> and <see cref="DrawAbovePlayer"/> then only blit the
+/// cached layer images that intersect the viewport, so drawing a frame no longer touches the
+/// per-tile data (tiles are drawn exactly once, at load time).
+/// </para>
+/// <para>
+/// A <see cref="TileMap"/> is <see cref="IDisposable"/>: disposing it releases the prerendered
+/// layer images (and any surfaces kept during their creation). The engine disposes the previous
+/// map when <c>GameEngine.Map</c> is replaced and when the engine itself is disposed; hosts that
+/// load maps directly are responsible for disposing them when they are replaced or no longer
+/// needed.
+/// </para>
+/// <para>
 /// Rendering happens in two passes. <see cref="Draw"/> draws the layers below the player
 /// (every layer whose <see cref="TileMapLayer.AbovePlayer"/> is <see langword="false"/>), and
 /// <see cref="DrawAbovePlayer"/> draws the layers above the player (those marked with the
@@ -29,10 +45,18 @@ namespace RPGEngine.Tiled;
 /// tiles appear in front of the player.
 /// </para>
 /// </remarks>
-public sealed class TileMap
+public sealed class TileMap : IDisposable
 {
     private readonly IReadOnlyList<TileSet> _tileSets;
     private readonly Dictionary<string, TileMapLayer> _layersByName;
+
+    /// <summary>
+    /// The prerendered layer images, one slot per <see cref="Layers"/> entry in file order.
+    /// A slot is <see langword="null"/> when the layer was not prerendered (invisible or empty).
+    /// </summary>
+    private readonly SKImage?[] _prerenderedImages;
+
+    private bool _disposed;
 
     private TileMap(
         int width,
@@ -58,6 +82,10 @@ public sealed class TileMap
         {
             _layersByName.TryAdd(layer.Name, layer);
         }
+
+        // Every visible, non-empty tile layer is rasterized once into an SKImage at load time.
+        // The prerendered images are the source of every later render call.
+        _prerenderedImages = PrerenderLayers();
     }
 
     /// <summary>Gets the width of the map in tiles.</summary>
@@ -98,6 +126,21 @@ public sealed class TileMap
     /// image/group layers are ignored for now.
     /// </summary>
     public IReadOnlyList<TileMapObjectLayer> ObjectLayers { get; }
+
+    /// <summary>
+    /// Gets the prerendered layer images, one slot per <see cref="Layers"/> entry in file order.
+    /// Each non-<see langword="null"/> image is the full pixel-size raster of its layer with the
+    /// flip transforms and layer opacity baked in; a <see langword="null"/> slot means the layer
+    /// was not prerendered (it is invisible or empty).
+    /// </summary>
+    /// <remarks>
+    /// Internal so the test project can assert the prerender contract (acceptance criterion 5).
+    /// The caller must not dispose these images; <see cref="Dispose"/> owns them.
+    /// </remarks>
+    internal IReadOnlyList<SKImage?> PrerenderedLayerImages => _prerenderedImages;
+
+    /// <summary>Gets whether this map has been disposed. Internal for tests.</summary>
+    internal bool IsDisposed => _disposed;
 
     /// <summary>
     /// Returns the map property named <paramref name="name"/> using a case-sensitive comparison,
@@ -250,93 +293,151 @@ public sealed class TileMap
     /// <summary>
     /// Draws the visible part of the map to <paramref name="canvas"/>, rendering only the
     /// layers that belong <em>below</em> the player (those whose
-    /// <see cref="TileMapLayer.AbovePlayer"/> is <see langword="false"/>). Only tiles
-    /// intersecting <paramref name="viewport"/> are drawn; the viewport is in the same
-    /// (world) coordinate space that tiles are drawn into, so callers that apply a camera
-    /// transform must pass the corresponding viewport rectangle.
+    /// <see cref="TileMapLayer.AbovePlayer"/> is <see langword="false"/>). Only the region of
+    /// each prerendered layer image that intersects <paramref name="viewport"/> is blitted; the
+    /// viewport is in the same (world) coordinate space that tiles are drawn into, so callers
+    /// that apply a camera transform must pass the corresponding viewport rectangle.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
-    /// <param name="viewport">The visible world-space rectangle used to cull tiles.</param>
+    /// <param name="viewport">The visible world-space rectangle used to cull layers.</param>
+    /// <exception cref="ObjectDisposedException">The map has been disposed.</exception>
     /// <remarks>
     /// This is the first render pass: the engine calls it before drawing the characters, then
     /// calls <see cref="DrawAbovePlayer"/> afterwards so <c>above_player</c> layers appear on
-    /// top of the player.
+    /// top of the player. Each layer is a prerendered image blit; no per-tile work happens here.
     /// </remarks>
     internal void Draw(SKCanvas canvas, SKRect viewport)
-        => DrawLayers(canvas, viewport, abovePlayerOnly: false);
+        => DrawLayerImages(canvas, viewport, abovePlayerOnly: false);
 
     /// <summary>
     /// Draws the visible part of the map to <paramref name="canvas"/>, rendering only the
     /// layers that belong <em>above</em> the player (those whose
-    /// <see cref="TileMapLayer.AbovePlayer"/> is <see langword="true"/>). The culling,
-    /// opacity and flip handling are identical to <see cref="Draw"/>; only the layer
-    /// selection differs.
+    /// <see cref="TileMapLayer.AbovePlayer"/> is <see langword="true"/>). The culling and image
+    /// blitting are identical to <see cref="Draw"/>; only the layer selection differs.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
-    /// <param name="viewport">The visible world-space rectangle used to cull tiles.</param>
+    /// <param name="viewport">The visible world-space rectangle used to cull layers.</param>
+    /// <exception cref="ObjectDisposedException">The map has been disposed.</exception>
     /// <remarks>
     /// This is the second render pass: the engine calls it after the NPCs and the player have
     /// been drawn, so the tiles of <c>above_player</c> layers appear in front of the player.
     /// </remarks>
     internal void DrawAbovePlayer(SKCanvas canvas, SKRect viewport)
-        => DrawLayers(canvas, viewport, abovePlayerOnly: true);
+        => DrawLayerImages(canvas, viewport, abovePlayerOnly: true);
+
+    /// <summary>
+    /// Releases the prerendered layer images owned by this map. This method is idempotent:
+    /// calling it more than once, or after the engine has already replaced/disposed the map, is
+    /// a no-op.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        foreach (var image in _prerenderedImages)
+        {
+            image?.Dispose();
+        }
+    }
 
     /// <summary>
     /// Shared implementation of the two map render passes. When
     /// <paramref name="abovePlayerOnly"/> is <see langword="false"/> only layers below the
     /// player are drawn (see <see cref="Draw"/>); when <see langword="true"/> only layers
     /// above the player are drawn (see <see cref="DrawAbovePlayer"/>). In both cases the
-    /// visible layers are culled to <paramref name="viewport"/> and drawn in file order with
-    /// their opacity and flip flags applied.
+    /// prerendered layer images are iterated in file order and each image's intersection with
+    /// <paramref name="viewport"/> is blitted with a plain, non-antialiased image draw. Layers
+    /// that were not prerendered (invisible or empty) have a <see langword="null"/> slot and are
+    /// skipped. Opacity and flip transforms were baked in at load time, so the draw path is a
+    /// pure image blit.
     /// </summary>
-    private void DrawLayers(SKCanvas canvas, SKRect viewport, bool abovePlayerOnly)
+    private void DrawLayerImages(SKCanvas canvas, SKRect viewport, bool abovePlayerOnly)
     {
-        var startX = Math.Max(0, (int)MathF.Floor(viewport.Left / TileWidth));
-        var endX = Math.Min(Width - 1, (int)MathF.Ceiling(viewport.Right / TileWidth) - 1);
-        var startY = Math.Max(0, (int)MathF.Floor(viewport.Top / TileHeight));
-        var endY = Math.Min(Height - 1, (int)MathF.Ceiling(viewport.Bottom / TileHeight) - 1);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        // Cull: intersect the viewport with the map's pixel bounds (each prerendered layer image
+        // spans exactly (0, 0, PixelWidth, PixelHeight)). When the viewport does not overlap the
+        // map nothing is drawn, so pixels outside the viewport are never touched.
+        var left = Math.Max(viewport.Left, 0f);
+        var top = Math.Max(viewport.Top, 0f);
+        var right = Math.Min(viewport.Right, (float)PixelWidth);
+        var bottom = Math.Min(viewport.Bottom, (float)PixelHeight);
+        if (left >= right || top >= bottom)
+        {
+            return;
+        }
+
+        var visible = new SKRect(left, top, right, bottom);
+
+        using var paint = new SKPaint { IsAntialias = false };
 
         for (var layerIndex = 0; layerIndex < Layers.Count; layerIndex++)
         {
-            var layer = Layers[layerIndex];
-            if (!layer.Visible || layer.AbovePlayer != abovePlayerOnly)
+            if (Layers[layerIndex].AbovePlayer != abovePlayerOnly)
             {
                 continue;
             }
 
-            using var tilePaint = new SKPaint { IsAntialias = false };
-            var applyOpacity = layer.Opacity < 1f;
-            if (applyOpacity)
+            var image = _prerenderedImages[layerIndex];
+            if (image is null)
             {
-                // Apply the layer opacity by drawing the whole layer into a temporary layer
-                // whose alpha is controlled by a dedicated paint. The tile paint keeps its
-                // full alpha so the opacity is not applied twice.
-                using var layerPaint = new SKPaint
-                {
-                    Color = SKColors.White.WithAlpha((byte)Math.Round(layer.Opacity * 255f)),
-                };
-                canvas.SaveLayer(layerPaint);
-                try
-                {
-                    DrawLayer(canvas, layer, startX, endX, startY, endY, tilePaint);
-                }
-                finally
-                {
-                    canvas.Restore();
-                }
+                continue;
             }
-            else
-            {
-                DrawLayer(canvas, layer, startX, endX, startY, endY, tilePaint);
-            }
+
+            // The source and destination rects are the same world-pixel rect: the visible part
+            // of the prerendered image is blitted in place, which preserves viewport culling.
+            canvas.DrawImage(image, visible, visible, paint);
         }
     }
 
-    private void DrawLayer(SKCanvas canvas, TileMapLayer layer, int startX, int endX, int startY, int endY, SKPaint paint)
+    /// <summary>
+    /// Prerenders every visible, non-empty tile layer into an <see cref="SKImage"/> of the map's
+    /// pixel size. Invisible layers and empty layers (no non-zero GID) produce a
+    /// <see langword="null"/> slot. Each returned image is owned by this map and released by
+    /// <see cref="Dispose"/>.
+    /// </summary>
+    private SKImage?[] PrerenderLayers()
     {
-        for (var y = startY; y <= endY; y++)
+        var images = new SKImage?[Layers.Count];
+
+        for (var layerIndex = 0; layerIndex < Layers.Count; layerIndex++)
         {
-            for (var x = startX; x <= endX; x++)
+            var layer = Layers[layerIndex];
+            if (!layer.Visible || !HasAnyTile(layer))
+            {
+                continue;
+            }
+
+            images[layerIndex] = PrerenderLayer(layer);
+        }
+
+        return images;
+    }
+
+    /// <summary>
+    /// Rasterizes one tile layer into a full map-size <see cref="SKImage"/>. The tiles are drawn
+    /// at their world pixel positions with the flip transforms from <see cref="DrawTile"/>
+    /// applied; when the layer has an opacity below 1 the whole layer is faded afterwards, so the
+    /// opacity is baked into the stored image and the draw path stays a plain image blit.
+    /// </summary>
+    private SKImage PrerenderLayer(TileMapLayer layer)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(PixelWidth, PixelHeight))
+            ?? throw new InvalidOperationException("Failed to create the raster surface used to prerender the map layers.");
+
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+
+        using var tilePaint = new SKPaint { IsAntialias = false };
+
+        for (var y = 0; y < Height; y++)
+        {
+            for (var x = 0; x < Width; x++)
             {
                 var gid = layer.GetTileId(x, y);
                 if (gid == 0)
@@ -361,9 +462,44 @@ public sealed class TileMap
                     (x + 1) * TileWidth,
                     (y + 1) * TileHeight);
 
-                DrawTile(canvas, tileImage, dest, flags, paint);
+                DrawTile(canvas, tileImage, dest, flags, tilePaint);
             }
         }
+
+        if (layer.Opacity < 1f)
+        {
+            // Bake the layer opacity into the whole layer: the tiles are composited at full
+            // alpha first and the resulting layer is then faded, matching the previous
+            // SaveLayer-based behavior. Drawing the full-alpha snapshot back onto the surface
+            // with an alpha-modulated paint produces exactly that faded layer.
+            using var fullAlphaLayer = surface.Snapshot();
+            canvas.Clear(SKColors.Transparent);
+
+            using var opacityPaint = new SKPaint
+            {
+                Color = SKColors.White.WithAlpha((byte)Math.Round(layer.Opacity * 255f)),
+                IsAntialias = false,
+            };
+            canvas.DrawImage(fullAlphaLayer, 0, 0, opacityPaint);
+        }
+
+        // The snapshot keeps the surface's pixels alive after the surface is disposed, so the
+        // surface can be released as soon as the image has been taken.
+        return surface.Snapshot();
+    }
+
+    /// <summary>Returns whether the layer contains at least one non-zero (non-empty) tile GID.</summary>
+    private static bool HasAnyTile(TileMapLayer layer)
+    {
+        foreach (var tileId in layer.TileIds)
+        {
+            if (tileId != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void DrawTile(SKCanvas canvas, SKImage image, SKRect dest, TileFlags flags, SKPaint paint)

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -536,6 +536,47 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 39: the engine owns the assigned map. Replacing GameEngine.Map
+    // disposes the previous map and disposing the engine disposes the current
+    // map; rendering through a disposed map is guarded.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies replacing GameEngine.Map disposes the previous map without error, and disposing the engine disposes the current map.</summary>
+    [Fact]
+    public void Map_ReplacementAndEngineDispose_DisposeMaps()
+    {
+        using var firstFixture = CreateFilledMapFixture(2, 2);
+        var firstMap = TileMap.Load(firstFixture.MapPath);
+        var engine = new GameEngine { Map = firstMap };
+        Assert.False(firstMap.IsDisposed);
+
+        // Replacing the map disposes the previous map.
+        using var secondFixture = CreateFilledMapFixture(3, 3);
+        var secondMap = TileMap.Load(secondFixture.MapPath);
+        engine.Map = secondMap;
+        Assert.True(firstMap.IsDisposed);
+        Assert.False(secondMap.IsDisposed);
+
+        // Disposing the engine disposes the current map; it is safe to call again.
+        engine.Dispose();
+        Assert.True(secondMap.IsDisposed);
+        engine.Dispose();
+    }
+
+    /// <summary>Verifies rendering through the engine after the map was disposed is guarded (throws ObjectDisposedException).</summary>
+    [Fact]
+    public void Render_AfterMapDisposed_ThrowsObjectDisposedException()
+    {
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var map = TileMap.Load(fixture.MapPath);
+        var engine = new GameEngine { Map = map };
+        map.Dispose(); // e.g. a host that disposed the map it had loaded directly.
+
+        using var bitmap = new SKBitmap(96, 96);
+        using var canvas = new SKCanvas(bitmap);
+        Assert.Throws<ObjectDisposedException>(() => engine.Render(canvas, FrameDt));
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 

--- a/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
+++ b/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
@@ -478,6 +478,91 @@ public class TileMapTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 39: prerendered layer images + viewport culling + IDisposable.
+    // Every visible, non-empty tile layer is rasterized once into a full
+    // pixel-size SKImage at load time; Draw/DrawAbovePlayer blit those images
+    // (culled to the viewport) and a disposed map is guarded.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies every visible non-empty layer is prerendered into a full pixel-size image, and that invisible and empty layers get a null slot.</summary>
+    [Fact]
+    public void Prerender_VisibleNonEmptyLayers_ProducePixelSizedImages()
+    {
+        var ground = new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 });
+        var decor = new TileLayerSpec("decor", new uint[4]); // empty layer
+        var hidden = new TileLayerSpec("hidden", new uint[] { 1, 0, 0, 0 }, Visible: false);
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { ground, decor, hidden });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.Equal(3, map.PrerenderedLayerImages.Count);
+
+        // ground is visible and non-empty -> a full map-size image.
+        var groundImage = map.PrerenderedLayerImages[0];
+        Assert.NotNull(groundImage);
+        Assert.Equal(map.PixelWidth, groundImage.Width);
+        Assert.Equal(map.PixelHeight, groundImage.Height);
+
+        // decor is empty -> not prerendered.
+        Assert.Null(map.PrerenderedLayerImages[1]);
+
+        // hidden is invisible -> not prerendered.
+        Assert.Null(map.PrerenderedLayerImages[2]);
+
+        map.Dispose();
+    }
+
+    /// <summary>Verifies a viewport covering only a sub-region of the map draws only that region; pixels outside the viewport stay untouched.</summary>
+    [Fact]
+    public void Draw_WithSubregionViewport_CullsToViewport()
+    {
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 }) });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // The viewport covers only the top-left tile (0,0,tile,tile) of the 96×96 map.
+        using var bitmap = new SKBitmap(map.PixelWidth, map.PixelHeight);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            map.Draw(canvas, new SKRect(0, 0, map.TileWidth, map.TileHeight));
+        }
+
+        // Inside the viewport: the top-left tile is drawn (opaque).
+        Assert.NotEqual(0, bitmap.GetPixel(map.TileWidth / 2, map.TileHeight / 2).Alpha);
+
+        // Outside the viewport (the other three tiles): untouched (transparent).
+        Assert.Equal(0, bitmap.GetPixel(map.TileWidth + (map.TileWidth / 2), map.TileHeight / 2).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(map.TileWidth / 2, map.TileHeight + (map.TileHeight / 2)).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(map.TileWidth + (map.TileWidth / 2), map.TileHeight + (map.TileHeight / 2)).Alpha);
+
+        map.Dispose();
+    }
+
+    /// <summary>Verifies Dispose is idempotent and that Draw/DrawAbovePlayer are guarded (throw ObjectDisposedException) after disposal.</summary>
+    [Fact]
+    public void Dispose_IsIdempotent_AndRenderingIsGuarded()
+    {
+        using var fixture = new TiledTestFixture(
+            1,
+            1,
+            new[] { new TileLayerSpec("ground", new uint[] { 1 }) });
+        var map = TileMap.Load(fixture.MapPath);
+
+        map.Dispose();
+        map.Dispose(); // idempotent: the second call must not throw.
+
+        Assert.True(map.IsDisposed);
+
+        using var bitmap = new SKBitmap(map.PixelWidth, map.PixelHeight);
+        using var canvas = new SKCanvas(bitmap);
+        var viewport = new SKRect(0, 0, map.PixelWidth, map.PixelHeight);
+        Assert.Throws<ObjectDisposedException>(() => map.Draw(canvas, viewport));
+        Assert.Throws<ObjectDisposedException>(() => map.DrawAbovePlayer(canvas, viewport));
+    }
+
+    // ---------------------------------------------------------------------
     // TileSet factories (replacing the removed TileSetManager): standalone
     // tilesets are loaded directly, from the file system or from a stream
     // resolved over HTTP (the WebAssembly-compatible path).


### PR DESCRIPTION
Closes #39

## Summary

Rewrites `TileMap` rendering so tiles are drawn exactly once — at load time. Every visible, non-empty tile layer is prerendered into its own `SKImage` of the map's pixel size (`PixelWidth × PixelHeight`) using a raster `SKSurface` (portable to WASM), with the existing flip transforms applied and the layer `Opacity` baked into the layer alpha. `Draw`/`DrawAbovePlayer` keep their signatures and semantics but now blit the cached layer images: the viewport is intersected with the layer image bounds and that sub-rect is drawn with `canvas.DrawImage(image, sourceRect, destRect, paint)`, so culling is preserved and per-frame work is a plain image blit.

## What changed

- **`TileMap`** (`src/RPGEngine/Tiled/TileMap.cs`)
  - On load, `PrerenderLayers()` rasterizes every visible, non-empty tile layer into a full map-size `SKImage` (flip transforms via the existing `DrawTile` logic; opacity baked by fading the whole layer after compositing tiles at full alpha, matching the previous `SaveLayer` behavior). Invisible and empty layers get a `null` slot.
  - `Draw`/`DrawAbovePlayer` now iterate the prerendered images in file order, compute the viewport∩image-bounds intersection, and blit that sub-rect (source and dest rects are the same world-pixel rect).
  - Implements `IDisposable`: releases the prerendered `SKImage`s, idempotent, and rendering after disposal throws `ObjectDisposedException`.
  - Internal accessors `PrerenderedLayerImages` / `IsDisposed` for tests (via `InternalsVisibleTo`).
- **`GameEngine`** (`src/RPGEngine/GameEngine.cs`) — implements `IDisposable`; the `Map` setter disposes the previous map when replaced and `Dispose()` disposes the current map (map ownership documented).
- **Samples** — desktop host disposes the engine on window close; WASM component disposes the engine in `Dispose()`.
- **Tests** — new coverage for prerendered image existence/size (and null slots for invisible/empty layers), viewport culling (only the viewport region is drawn), disposal (replacing `Map` disposes the previous map, engine disposal disposes the current map, `TileMap.Dispose()` is idempotent, rendering after disposal is guarded). All existing pixel-equivalence tests (solid layer, flip flags with `TilePattern.Marker`, layer opacity < 1, above_player layers, multi-layer maps) pass unchanged.
- **Docs** — `docs/api/TileMap.md`, `docs/api/GameEngine.md`, `docs/Architecture.md`, `docs/README.md`, `README.md` document the prerendering model, image-blit rendering, and `IDisposable`/map ownership.

## Acceptance criteria

- `dotnet build -c Release`: **0 warnings / 0 errors**
- `dotnet test tests/RPGEngine.Tests -c Release`: **259 passed**
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~TileMapTests|FullyQualifiedName~GameEngineTests|FullyQualifiedName~SampleSceneTests"`: **62 passed**

Out of scope (per story): minimap rendering, collision/pathfinding, changing public `Draw` signatures, chunked/infinite maps, GPU-only surface allocation, `.tmj`.