### PR TITLE
Story 37: Tile-based world coordinates and surface/world conversion

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -3,6 +3,18 @@
 The RPG Engine is built around a small composition model. This page explains how the pieces fit
 together and documents the fixed RPG Maker MZ part-composition order.
 
+## Coordinate system: tiles
+
+All world coordinates — `Character.Position`, `Player.Position`, camera origins and the
+`GameEngine.SurfaceToWorld` / `GameEngine.WorldToSurface` conversions — are expressed in
+**tiles** (double). Y grows downward. Pixels are produced only at the canvas boundary: the
+engine multiplies the tile positions by the map's tile size (`TileMap.TileWidth`, default 48
+when no map is set) when rendering. Movement speeds are in **tiles per second**.
+
+The tile size is fixed by the map (48 px for the fixture map and the RPG Maker MZ sheets), so a
+world position like `(8.5, 8.5)` tiles corresponds to the pixel position `(408, 408)` at
+48 px/tile.
+
 ## The composition model
 
 ### Player → Character
@@ -16,10 +28,11 @@ Player ── Character (Position, Direction, BaseSpeed, SpriteSheets, walk-cycl
 `Player` is a thin wrapper that forwards state access and movement to its `Character`. All of
 the in-world state lives on `Character`:
 
-- `Character.Position` — top-left world pixel position of the sprite (its size is the
-  configured sheet's derived cell size).
+- `Character.Position` — top-left world position of the sprite, in **tiles** (its size is the
+  configured sheet's derived cell size, in pixels, used only for clamping).
 - `Character.Direction` — the facing direction (8 directions: Down/Left/Right/Up plus the four diagonals).
-- `Character.BaseSpeed` — movement speed in pixels per second.
+- `Character.BaseSpeed` — movement speed in **tiles per second** (the player default is 2,
+  i.e. the tile-unit equivalent of 96 px/s at 48 px tiles).
 - `Character.SpriteSheets` — the list of `SpriteSheetRef`s (sheet name + 1..8 character index).
 - `Character.Update(dt)` — advances the walk-cycle animation (internal).
 
@@ -49,9 +62,41 @@ for each frame:
     engine.Render(canvas, dt)                // draw map + NPCs + player
 ```
 
-`GameEngine` never runs its own loop and never blocks. The camera is internal to the engine:
-`Render` follows the player and clamps the viewport inside the map. No public camera API exists
-in this epic.
+`GameEngine` never runs its own loop and never blocks.
+
+### The camera and surface ↔ world conversion
+
+The camera is internal to the engine: `Render` follows the player and clamps the viewport inside
+the map. The camera origin is computed in **tiles** by `ComputeCameraOrigin(canvasWidth,
+canvasHeight)` (internal, asserted by the tests):
+
+- `max = max(0, Map.Width - canvasWidth / ts)` per axis, where `ts` is the map's tile width —
+  the farthest the viewport may scroll while staying inside the map.
+- `desired = player.Position - (canvasWidth / (2*ts), canvasHeight / (2*ts))` — centers the player.
+- `origin = clamp(desired, 0, max) - max(0, (canvasSize - Map.PixelSize) / (2*ts))` per axis —
+  the centering offset when the map is smaller than the canvas (a negative origin).
+- No map → `(0, 0)`.
+
+`Render` turns the tile origin into a pixel viewport for the map (a pure pixel renderer) and
+into pixel screen positions for the characters. The map's `TileMap.Draw` / `DrawAbovePlayer`
+receive a pixel `SKRect` and blit their prerendered layer images; each character is drawn at
+screen position `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`.
+
+The engine exposes two public conversions that use the **same camera** (follow + clamp) for the
+given canvas size, so a host can translate between canvas pixels and world tiles without
+reimplementing the camera:
+
+- `Position SurfaceToWorld(double surfaceX, double surfaceY, double canvasWidth, double canvasHeight)`
+  — `world = (surfaceX / ts + origin.X, surfaceY / ts + origin.Y)`. This is the foundation of
+  the "click to move" feature: a mouse click at `(surfaceX, surfaceY)` becomes a world position.
+- `Position WorldToSurface(Position worldPosition, double canvasWidth, double canvasHeight)`
+  — `surface = ((world.X - origin.X) * ts, (world.Y - origin.Y) * ts)`. This is the foundation
+  of the "GUI around game objects" feature: a world position becomes a canvas position to draw
+  UI at.
+
+The two conversions are inverses of each other within floating-point tolerance. With no map the
+origin is `(0, 0)`, so `SurfaceToWorld(408, 408, 960, 960)` returns `(8.5, 8.5)` tiles at
+`ts = 48`.
 
 ### Tiled model
 
@@ -72,6 +117,7 @@ The map exposes a read-only view of everything the Tiled file declares:
   `TileMapObjectLayer` exposes its `Name`, `Visible`, `Opacity`, `Properties` and `Objects`;
   each `TileMapObject` exposes its `Id`, `Name`, `Type`, `Position`, `Width`/`Height`, `Shape`
   (`TileMapObjectShape`) and its own custom `Properties`. Object layers do not render tiles.
+  Object-layer positions stay in **pixels** (they come straight from the Tiled file).
 
 The read model wraps DotTiled, so no DotTiled types leak into the public API.
 
@@ -128,12 +174,13 @@ Hair (`Hair1` and `Hair2`) is shown unless a `Head` part sheet is present whose 
 The canonical sample scene (used by the desktop and WebAssembly hosts and by the end-to-end
 tests) configures:
 
-- **Player**: full sheet `hero`, character index **1**.
-- **Villager**: part sheets `body` + `face` + `hair1`, character index **2**.
-- **Guard**: part sheets `body` + `face` + `armour` + `head`, character index **3**.
+- **Player**: full sheet `hero`, character index **1**, at **(6, 6) tiles**.
+- **Villager**: part sheets `body` + `face` + `hair1`, character index **2**, at **(3, 4) tiles**.
+- **Guard**: part sheets `body` + `face` + `armour` + `head`, character index **3**, at **(11, 8) tiles**.
 
 ```csharp
 // Player — a single full sheet, character slot 1.
+engine.Player.Position = new Position(6, 6);
 engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
 // Villager — parts composed in the fixed order, character slot 2.
@@ -158,6 +205,9 @@ Opposite keys cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a d
 normalized, magnitude 1). When no bound key is held the player stops and the animation snaps back
 to the standing frame. The engine reads `GameConfig` at input time and never caches a snapshot.
 
+Movement speeds are in **tiles per second**; a move of one second at the default speed
+(`Player.DefaultBaseSpeed == 2`) travels exactly **2 tiles** (96 px with 48 px tiles).
+
 The walk-cycle animation is **time-based and speed-scaled**: `Character.Update(dt)` advances the
 walk cycle at a rate proportional to `BaseSpeed` and `AnimationCycleSpeed`. The walk cycle is the
 bounce `0 → 1 → 2 → 1` (4 frame steps), and the time per frame is
@@ -166,9 +216,10 @@ bounce `0 → 1 → 2 → 1` (4 frame steps), and the time per frame is
 secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)
 ```
 
-so at `BaseSpeed == AnimationCycleSpeed == 96` one frame lasts 0.25 s and the cycle completes
-exactly **once per second** (4 frames/s). Doubling `BaseSpeed` doubles the cycle rate; raising
-`AnimationCycleSpeed` (the reference speed) slows the animation relative to movement speed.
+so at `BaseSpeed == AnimationCycleSpeed == 2` (both in tiles/s, the defaults) one frame lasts
+0.25 s and the cycle completes exactly **once per second** (4 frames/s). Doubling `BaseSpeed`
+doubles the cycle rate; raising `AnimationCycleSpeed` (the reference speed) slows the animation
+relative to movement speed.
 
 ## Rendering
 
@@ -194,9 +245,13 @@ below-player layers → NPCs → player → above-player layers
   player (e.g. tree canopies the player walks under). Each blit draws the intersection of the
   viewport with the layer image bounds, so viewport culling is preserved and no per-tile work
   happens per frame.
-- The camera follows the player and clamps the viewport inside the map. When the map is
-  **smaller than the canvas** on an axis it is **centered** in the canvas and the area around
-  it stays black (`offset = max(0, (canvasSize − mapPixelSize) / 2)`), so a small map is never
-  letterboxed with transparent or leftover pixels. When the map fills (or exceeds) the canvas,
-  the behaviour is the classic follow-and-clamp camera. The canvas size is read from the
-  canvas clip bounds.
+- **The camera works in tiles and renders in pixels.** `Render` computes the camera origin in
+  tiles (follow + clamp, see above), derives a pixel viewport
+  `(origin.X*ts, origin.Y*ts, origin.X*ts + canvasWidth, origin.Y*ts + canvasHeight)` and passes
+  it to the map renderer (which stays a pure pixel renderer), and draws each character at the
+  screen position `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`. The canvas size is read
+  from the canvas clip bounds.
+- When the map is **smaller than the canvas** on an axis it is **centered** in the canvas and
+  the area around it stays black (`offset = max(0, (canvasSize − mapPixelSize) / (2*ts))` tiles),
+  so a small map is never letterboxed with transparent or leftover pixels. When the map fills
+  (or exceeds) the canvas, the behaviour is the classic follow-and-clamp camera.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,15 +48,16 @@ engine.Map = await TileMap.LoadAsync(
 using var heroStream = new MemoryStream(await http.GetByteArrayAsync("assets/characters/character_full.png"));
 await engine.LoadSpriteSheetAsync("hero", heroStream);
 
-// 3. Place the player and give it the "hero" sheet, character slot 1.
-engine.Player.Position = new Position(6 * 48, 6 * 48);
+// 3. Place the player (in tiles — the fixture map has 48 px tiles) and give it the "hero"
+//    sheet, character slot 1.
+engine.Player.Position = new Position(6, 6);
 engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
 // 4. Add an NPC built from part sheets (body + face + hair1, character slot 2). The other part
 //    sheets (face, hair1) are loaded the same way with LoadPartSpriteSheetAsync.
 using var bodyStream = new MemoryStream(await http.GetByteArrayAsync("assets/characters/character_part_body.png"));
 await engine.LoadPartSpriteSheetAsync("body", bodyStream, CharacterPartType.Body);
-var npc = new Character { Position = new Position(3 * 48, 4 * 48) };
+var npc = new Character { Position = new Position(3, 4) };
 npc.SpriteSheets.Add(new SpriteSheetRef("body", CharacterIndex: 2));
 engine.Characters.Add(npc);
 

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -2,8 +2,9 @@
 
 Namespace: `RPGEngine` — a character present in the game world (the player or an NPC).
 
-`Character` holds the position, facing direction (8 directions, cardinal + diagonal), movement
-speed, the walk-cycle animation state and the list of spritesheet references used to render it.
+`Character` holds the position (in **tiles**), facing direction (8 directions, cardinal +
+diagonal), movement speed (in tiles per second), the walk-cycle animation state and the list of
+spritesheet references used to render it.
 
 ## Remarks
 
@@ -14,15 +15,17 @@ speed, the walk-cycle animation state and the list of spritesheet references use
   in the fixed RPG Maker MZ order regardless of the order of entries in `SpriteSheets`; mixing
   full and part sheets (or using more than one full sheet) throws `InvalidOperationException` at
   draw time. A `SpriteSheetRef` whose `CharacterIndex` is outside 1..8 is rejected when used.
+- All world coordinates are in tiles. Pixels are produced only at the canvas boundary (the
+  engine multiplies by the map's tile size when rendering).
 
 ## Properties
 
 ### `Position Position`
 
-Gets or sets the top-left world position of the character's sprite, in pixels.
+Gets or sets the top-left world position of the character's sprite, in tiles.
 
 ```csharp
-var character = new Character { Position = new Position(144, 192) };
+var character = new Character { Position = new Position(3, 4) };
 ```
 
 ### `Direction Direction`
@@ -35,25 +38,25 @@ var character = new Character { Direction = Direction.Down };
 
 ### `double BaseSpeed`
 
-Gets or sets the movement speed of the character in pixels per second.
+Gets or sets the movement speed of the character in **tiles per second**.
 
 ```csharp
-var character = new Character { BaseSpeed = 96 };
+var character = new Character { BaseSpeed = 2 };
 ```
 
 ### `double AnimationCycleSpeed`
 
-Gets or sets the movement speed (px/s) at which the walk cycle completes exactly one full cycle
-per second. Defaults to 96 (matching the player's default `BaseSpeed`).
+Gets or sets the movement speed (tiles/s) at which the walk cycle completes exactly one full
+cycle per second. Defaults to **2** (matching the player's default `BaseSpeed`).
 
 The walk cycle is the bounce `0 → 1 → 2 → 1`, i.e. 4 frame steps. The time per frame is
 `secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)`, so at
-`BaseSpeed == AnimationCycleSpeed == 96` one frame lasts 0.25 s (4 frames/s = 1 cycle/s).
+`BaseSpeed == AnimationCycleSpeed == 2` one frame lasts 0.25 s (4 frames/s = 1 cycle/s).
 Doubling the movement speed doubles the cycle rate; halving it halves it. Raising this property
 (the reference speed) slows the animation relative to movement speed.
 
 ```csharp
-var character = new Character { BaseSpeed = 96, AnimationCycleSpeed = 96 };
+var character = new Character { BaseSpeed = 2, AnimationCycleSpeed = 2 };
 // One full walk cycle (0 → 1 → 2 → 1) completes every second.
 ```
 
@@ -73,14 +76,14 @@ character.SpriteSheets.Add(new SpriteSheetRef("cape", CharacterIndex: 4));
 
 ### `void Move(Direction direction, double speedFactor = 1, double dt = 1)`
 
-Moves the character in `direction` by `BaseSpeed * speedFactor * dt` pixels and sets the facing
+Moves the character in `direction` by `BaseSpeed * speedFactor * dt` tiles and sets the facing
 direction. When `speedFactor` is zero the character only turns to face the direction without
-moving. `dt` defaults to 1, so `Move(d, factor)` moves `BaseSpeed * factor` pixels (per-second
+moving. `dt` defaults to 1, so `Move(d, factor)` moves `BaseSpeed * factor` tiles (per-second
 semantics).
 
 ```csharp
-var character = new Character { BaseSpeed = 96 };
-character.Move(Direction.Right, speedFactor: 1, dt: 0.5); // 48 px right
+var character = new Character { BaseSpeed = 2 };
+character.Move(Direction.Right, speedFactor: 1, dt: 0.5); // 1 tile right
 ```
 
 ### `void Move(double speedFactor = 1, double dt = 1)`
@@ -88,8 +91,8 @@ character.Move(Direction.Right, speedFactor: 1, dt: 0.5); // 48 px right
 Moves the character in its current facing direction. See the overload above for semantics.
 
 ```csharp
-var character = new Character { Direction = Direction.Up, BaseSpeed = 48 };
-character.Move(dt: 1); // 48 px up
+var character = new Character { Direction = Direction.Up, BaseSpeed = 1 };
+character.Move(dt: 1); // 1 tile up
 ```
 
 ## Example: configuring a character with a sheet name + index
@@ -97,9 +100,9 @@ character.Move(dt: 1); // 48 px up
 ```csharp
 var character = new Character
 {
-    Position = new Position(96, 96),
+    Position = new Position(2, 2),
     Direction = Direction.Down,
-    BaseSpeed = 96,
+    BaseSpeed = 2,
 };
 
 character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -15,9 +15,17 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   output to a CPU bitmap. When the host passes a GPU-backed `SKCanvas` (e.g. the surface of a
   SkiaSharp GL view or a WebAssembly `SKSurface` created from a `GRContext`), the drawing is
   hardware accelerated. The engine has **zero platform-specific dependencies**.
+- **All world coordinates are in tiles** (double): `Player.Position`, `Character.Position`,
+  camera origins and the `SurfaceToWorld`/`WorldToSurface` conversions. Pixels are produced only
+  at the canvas boundary — `Render` multiplies the tile positions by the map's tile size to
+  place sprites and the camera viewport (the tile size is read from `TileMap.TileWidth`, with a
+  default of 48 when no map is set).
 - The camera is internal: `Render` follows the player and clamps the viewport inside the map.
   When the map is smaller than the canvas on an axis it is centered and the area around it is
   filled with black, so the map is never letterboxed with transparent or leftover pixels.
+  `SurfaceToWorld` and `WorldToSurface` expose the same follow + clamp camera for the given
+  canvas size — the foundation the "click to move" and "GUI around game objects" features will
+  build on.
 - When a map is set, `Render` clears the whole canvas to black first, then draws the map's
   below-player layers, then every NPC, then the player, and finally the map's `above_player`
   layers (tile layers declaring the Tiled `above_player` custom property) so those tiles appear
@@ -51,7 +59,7 @@ Gets the player character. The camera always follows the player.
 
 ```csharp
 var engine = new GameEngine();
-engine.Player.Position = new Position(96, 96);
+engine.Player.Position = new Position(2, 2);
 engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 ```
 
@@ -61,7 +69,7 @@ Gets the mutable list of NPC characters present in the game world. The player is
 list (it is rendered separately, on top).
 
 ```csharp
-var npc = new Character { Position = new Position(144, 192) };
+var npc = new Character { Position = new Position(3, 4) };
 npc.SpriteSheets.Add(new SpriteSheetRef("villager_body", CharacterIndex: 2));
 engine.Characters.Add(npc);
 ```
@@ -105,8 +113,8 @@ engine.Input(Key.D, isPressed: false);  // key-up
 ### `void Update(double dt)`
 
 Advances the simulation by `dt` seconds: resolves the movement direction from the currently
-pressed keys, moves the player, clamps it inside the map, and advances the walk-cycle animation
-of the player and every NPC.
+pressed keys, moves the player (in tiles), clamps it inside the map, and advances the
+walk-cycle animation of the player and every NPC.
 
 ```csharp
 engine.Update(dt: 1.0 / 60);
@@ -119,7 +127,8 @@ black background behind/around a map smaller than the canvas), then the map's be
 layers are drawn, then every NPC, then the player on top, and finally the map's `above_player`
 layers so those tiles appear above the player. The camera follows the player, centers a map
 smaller than the canvas, and is clamped so the viewport stays inside the map; the canvas size is
-read from the canvas clip bounds.
+read from the canvas clip bounds. The camera origin is computed in tiles and converted to a
+pixel viewport for the map and to pixel screen positions for the characters.
 
 ```csharp
 using var bitmap = new SKBitmap(640, 480);
@@ -128,6 +137,34 @@ using (var canvas = new SKCanvas(bitmap))
     canvas.Clear(SKColors.Transparent);
     engine.Render(canvas, dt: 1.0 / 60);
 }
+```
+
+### `Position SurfaceToWorld(double surfaceX, double surfaceY, double canvasWidth, double canvasHeight)`
+
+Translates a host-surface (canvas) coordinate, in pixels, to a world coordinate, in tiles, using
+the same camera as `Render` (follow + clamp) for the given canvas size:
+`world = (surfaceX / ts + origin.X, surfaceY / ts + origin.Y)`, where `ts` is the map's tile
+width (48 when no map is set) and `origin` is the camera origin for that canvas size. This is
+the inverse of `WorldToSurface` within floating-point tolerance. Hosts use it to translate mouse
+clicks into world coordinates for "click to move".
+
+```csharp
+// With no map the camera origin is (0,0): a surface point of (408, 408) on a 960×960 canvas is
+// world (8.5, 8.5) tiles at ts = 48.
+var world = engine.SurfaceToWorld(408, 408, 960, 960); // (8.5, 8.5)
+```
+
+### `Position WorldToSurface(Position worldPosition, double canvasWidth, double canvasHeight)`
+
+Translates a world coordinate, in tiles, to a host-surface (canvas) coordinate, in pixels, using
+the same camera as `Render` (follow + clamp) for the given canvas size:
+`surface = ((world.X - origin.X) * ts, (world.Y - origin.Y) * ts)`, where `ts` is the map's tile
+width (48 when no map is set) and `origin` is the camera origin for that canvas size. This is
+the inverse of `SurfaceToWorld` within floating-point tolerance. Hosts use it to position GUI
+elements around game objects.
+
+```csharp
+var surface = engine.WorldToSurface(new Position(8.5, 8.5), 960, 960); // (408, 408)
 ```
 
 ### `void Dispose()`
@@ -210,11 +247,11 @@ await engine.LoadPartSpriteSheetAsync("villager_body", stream, CharacterPartType
 var engine = new GameEngine();
 engine.Map = TileMap.Load("assets/map.tmx");
 engine.LoadSpriteSheet("hero", "assets/characters/character_full.png");
-engine.Player.Position = new Position(6 * 48, 6 * 48);
+engine.Player.Position = new Position(6, 6);
 engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
 engine.LoadPartSpriteSheet("body", "assets/characters/character_part_body.png", CharacterPartType.Body);
-var npc = new Character { Position = new Position(3 * 48, 4 * 48) };
+var npc = new Character { Position = new Position(3, 4) };
 npc.SpriteSheets.Add(new SpriteSheetRef("body", CharacterIndex: 2));
 engine.Characters.Add(npc);
 

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -5,20 +5,21 @@ Namespace: `RPGEngine` — represents the player character controlled by the use
 ## Remarks
 
 The player is **composed** of a `Character` (composition, no inheritance) which carries all of
-the in-world state: position, facing direction, movement speed and the list of spritesheet
-references. `Player` is a thin wrapper that forwards state access and movement to that character,
-so configuring `SpriteSheets` or moving the player is exactly equivalent to configuring/moving
-the underlying `Character`.
+the in-world state: position (in tiles), facing direction, movement speed (in tiles per second)
+and the list of spritesheet references. `Player` is a thin wrapper that forwards state access
+and movement to that character, so configuring `SpriteSheets` or moving the player is exactly
+equivalent to configuring/moving the underlying `Character`.
 
 The player does not listen to input itself. The engine (`GameEngine`) owns the pressed-keys
 state and calls `Move(direction, 1, dt)` in its update loop.
 
 ## Fields
 
-### `const double DefaultBaseSpeed = 96`
+### `const double DefaultBaseSpeed = 2`
 
-The default movement speed in pixels per second of a player created by the parameterless
-constructor (96 px/s, i.e. two 48px map tiles every second).
+The default movement speed in **tiles per second** of a player created by the parameterless
+constructor (2 tiles/s, the tile-unit equivalent of the previous 96 px/s with 48 px tiles: two
+48px map tiles every second).
 
 ## Constructors
 
@@ -31,7 +32,7 @@ var player = new Player();
 ### `Player(Character character)` — wraps the provided character
 
 ```csharp
-var character = new Character { BaseSpeed = 64 };
+var character = new Character { BaseSpeed = 1 };
 var player = new Player(character);
 ```
 
@@ -45,16 +46,16 @@ speed and spritesheets as well.
 
 ```csharp
 var player = new Player();
-player.Character.Position = new Position(10, 20);
+player.Character.Position = new Position(6, 6);
 ```
 
 ### `Position Position`
 
-Gets or sets the top-left world position of the player's sprite, in pixels. Forwards to
+Gets or sets the top-left world position of the player's sprite, in tiles. Forwards to
 `Character.Position`.
 
 ```csharp
-player.Position = new Position(6 * 48, 6 * 48);
+player.Position = new Position(6, 6);
 ```
 
 ### `Direction Direction`
@@ -80,7 +81,7 @@ player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
 ### `void Move(Direction direction, double speedFactor = 1, double dt = 1)`
 
-Moves the player in `direction` by `BaseSpeed * speedFactor * dt` pixels and sets the facing
+Moves the player in `direction` by `BaseSpeed * speedFactor * dt` tiles and sets the facing
 direction. Forwards to `Character.Move`.
 
 ```csharp

--- a/docs/api/Position.md
+++ b/docs/api/Position.md
@@ -1,22 +1,25 @@
 # Position
 
-Namespace: `RPGEngine` — a position in 2D screen space with double-precision coordinates.
+Namespace: `RPGEngine` — a position in the game world with double-precision coordinates
+measured in **tiles**.
 
-Y grows downward, so increasing `Y` moves the position down the screen.
+Y grows downward, so increasing `Y` moves the position down the map. Positions are stored in
+tile units; pixels are produced only at the canvas boundary (rendering and the `ToPixels`
+conversion).
 
 ```csharp
-var position = new Position(10, 20);
+var position = new Position(8.5, 8.5); // eight and a half tiles to the right and down
 ```
 
 ## Members
 
 ### `double X` / `double Y`
 
-The horizontal (x) and vertical (y) coordinates.
+The horizontal (x) and vertical (y) coordinates, in tiles.
 
 ### `static Position operator +(Position position, Vector2 offset)`
 
-Returns a new position offset from this one by `offset`.
+Returns a new position offset from this one by `offset` (in tiles).
 
 ```csharp
 var position = new Position(10, 20);
@@ -25,34 +28,47 @@ var moved = position + new Vector2(3, -4); // (13, 16)
 
 ### `static Position operator -(Position position, Vector2 offset)`
 
-Returns a new position offset from this one by `offset`.
+Returns a new position offset from this one by `offset` (in tiles).
 
 ### `static Vector2 operator -(Position left, Position right)`
 
-Returns the vector from `right` to `left`.
+Returns the vector from `right` to `left` (in tiles).
 
 ### `Position WithOffset(double dx, double dy)`
 
-Returns a new position offset from this one by `dx` and `dy`.
+Returns a new position offset from this one by `dx` and `dy` (in tiles).
 
 ```csharp
 var position = new Position(10, 20);
 var offset = position.WithOffset(3, -4); // (13, 16)
 ```
 
-### `(int TileX, int TileY) ToTile(int tileSize)`
+### `(int TileX, int TileY) ToTile()`
 
-Converts the pixel position to tile coordinates using floor division. Throws
+Floors the tile-unit position to the coordinates of the containing cell. Because positions are
+already expressed in tiles, this simply floors each component: `(8.5, 8.5)` lies in cell
+`(8, 8)`, and `(-1.5, -1.5)` lies in cell `(-2, -2)` (floor division, so negatives round toward
+negative infinity).
+
+```csharp
+var tile = new Position(8.5, 8.5).ToTile();  // (8, 8)
+var negative = new Position(-1.5, -1.5).ToTile(); // (-2, -2)
+```
+
+### `Position ToPixels(int tileSize)`
+
+Converts the tile-unit position to pixel coordinates: `(X * tileSize, Y * tileSize)`. Used by
+rendering (to place sprites and the camera viewport on the canvas) and by the
+`GameEngine.SurfaceToWorld` / `GameEngine.WorldToSurface` conversions. Throws
 `ArgumentOutOfRangeException` when `tileSize` is zero or negative.
 
 ```csharp
-var position = new Position(100, 100);
-var tile = position.ToTile(tileSize: 48); // (2, 2)
+var pixels = new Position(8.5, 8.5).ToPixels(48); // (408, 408)
 ```
 
 ### `double DistanceTo(Position other)`
 
-Returns the Euclidean distance between this position and `other`.
+Returns the Euclidean distance between this position and `other` (in tiles).
 
 ```csharp
 var a = new Position(0, 0);

--- a/docs/api/Vector2.md
+++ b/docs/api/Vector2.md
@@ -32,7 +32,7 @@ a direction delta by a distance.
 
 ```csharp
 var delta = Direction.Up.Delta();         // (0, -1)
-var step = delta * (96 * 1 * 0.5);        // (0, -48) — 48 px up at 96 px/s for 0.5 s
+var step = delta * (2 * 1 * 0.5);         // (0, -1) — 1 tile up at 2 tiles/s for 0.5 s
 ```
 
 ## Example
@@ -41,5 +41,6 @@ var step = delta * (96 * 1 * 0.5);        // (0, -48) — 48 px up at 96 px/s fo
 var position = new Position(10, 20);
 var offset = new Vector2(3, -4);
 var moved = position + offset;            // (13, 16)
-var tile = moved.ToTile(tileSize: 48);    // (0, 0)
+var tile = moved.ToTile();                // (13, 16) — the containing cell
+var pixels = moved.ToPixels(48);          // (624, 768) — pixels at 48 px/tile
 ```

--- a/samples/RPGEngine.Sample.Desktop/SampleScene.cs
+++ b/samples/RPGEngine.Sample.Desktop/SampleScene.cs
@@ -15,14 +15,14 @@ internal static class SampleScene
     /// <summary>Tile size in pixels of the fixture map and the RPG Maker MZ sheets.</summary>
     public const int TileSize = 48;
 
-    /// <summary>Player world position (on the sand path of the fixture map).</summary>
-    public static readonly Position PlayerPosition = new(6 * TileSize, 6 * TileSize);
+    /// <summary>Player world position in tiles (on the sand path of the fixture map).</summary>
+    public static readonly Position PlayerPosition = new(6, 6);
 
-    /// <summary>First NPC world position (a villager made of body/face/hair1 parts).</summary>
-    public static readonly Position VillagerPosition = new(3 * TileSize, 4 * TileSize);
+    /// <summary>First NPC world position in tiles (a villager made of body/face/hair1 parts).</summary>
+    public static readonly Position VillagerPosition = new(3, 4);
 
-    /// <summary>Second NPC world position (a guard made of body/face/armour/head parts).</summary>
-    public static readonly Position GuardPosition = new(11 * TileSize, 8 * TileSize);
+    /// <summary>Second NPC world position in tiles (a guard made of body/face/armour/head parts).</summary>
+    public static readonly Position GuardPosition = new(11, 8);
 
     /// <summary>
     /// Builds the engine for the sample scene from a directory that contains the materialized
@@ -42,10 +42,11 @@ internal static class SampleScene
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
         // NPC 1 "villager": body + face + hair1 part sheets, character slot 2.
+        // NPC speed is 1 tile/s (the tile-unit equivalent of the previous 48 px/s at 48px tiles).
         var villager = new Character
         {
             Position = VillagerPosition,
-            BaseSpeed = 48,
+            BaseSpeed = 1,
         };
         engine.LoadPartSpriteSheet("villager_body", Path.Combine(assetsRoot, FixtureAssets.PartBody), CharacterPartType.Body);
         engine.LoadPartSpriteSheet("villager_face", Path.Combine(assetsRoot, FixtureAssets.PartFace), CharacterPartType.Face);
@@ -56,10 +57,11 @@ internal static class SampleScene
         engine.Characters.Add(villager);
 
         // NPC 2 "guard": body + face + armour + head part sheets, character slot 3.
+        // NPC speed is 1 tile/s (the tile-unit equivalent of the previous 48 px/s at 48px tiles).
         var guard = new Character
         {
             Position = GuardPosition,
-            BaseSpeed = 48,
+            BaseSpeed = 1,
         };
         engine.LoadPartSpriteSheet("guard_body", Path.Combine(assetsRoot, FixtureAssets.PartBody), CharacterPartType.Body);
         engine.LoadPartSpriteSheet("guard_face", Path.Combine(assetsRoot, FixtureAssets.PartFace), CharacterPartType.Face);

--- a/samples/RPGEngine.Sample.Wasm/GameScene.cs
+++ b/samples/RPGEngine.Sample.Wasm/GameScene.cs
@@ -25,14 +25,14 @@ public sealed class GameScene
     /// <summary>Tile size in pixels of the fixture map and the RPG Maker MZ sheets.</summary>
     public const int TileSize = 48;
 
-    /// <summary>Player world position (on the sand path of the fixture map).</summary>
-    public static readonly Position PlayerPosition = new(6 * TileSize, 6 * TileSize);
+    /// <summary>Player world position in tiles (on the sand path of the fixture map).</summary>
+    public static readonly Position PlayerPosition = new(6, 6);
 
-    /// <summary>First NPC world position (a villager made of body/face/hair1 parts).</summary>
-    public static readonly Position VillagerPosition = new(3 * TileSize, 4 * TileSize);
+    /// <summary>First NPC world position in tiles (a villager made of body/face/hair1 parts).</summary>
+    public static readonly Position VillagerPosition = new(3, 4);
 
-    /// <summary>Second NPC world position (a guard made of body/face/armour/head parts).</summary>
-    public static readonly Position GuardPosition = new(11 * TileSize, 8 * TileSize);
+    /// <summary>Second NPC world position in tiles (a guard made of body/face/armour/head parts).</summary>
+    public static readonly Position GuardPosition = new(11, 8);
 
     private readonly GameEngine _engine;
 
@@ -85,10 +85,11 @@ public sealed class GameScene
         await engine.LoadPartSpriteSheetAsync("villager_body", await FetchPngStreamAsync(http, baseUrl, "characters/character_part_body.png.b64").ConfigureAwait(false), CharacterPartType.Body).ConfigureAwait(false);
         await engine.LoadPartSpriteSheetAsync("villager_face", await FetchPngStreamAsync(http, baseUrl, "characters/character_part_face.png.b64").ConfigureAwait(false), CharacterPartType.Face).ConfigureAwait(false);
         await engine.LoadPartSpriteSheetAsync("villager_hair1", await FetchPngStreamAsync(http, baseUrl, "characters/character_part_hair1.png.b64").ConfigureAwait(false), CharacterPartType.Hair1).ConfigureAwait(false);
+        // NPC speed is 1 tile/s (the tile-unit equivalent of the previous 48 px/s at 48px tiles).
         var villager = new Character
         {
             Position = VillagerPosition,
-            BaseSpeed = 48,
+            BaseSpeed = 1,
         };
         villager.SpriteSheets.Add(new SpriteSheetRef("villager_body", CharacterIndex: 2));
         villager.SpriteSheets.Add(new SpriteSheetRef("villager_face", CharacterIndex: 2));
@@ -100,10 +101,11 @@ public sealed class GameScene
         await engine.LoadPartSpriteSheetAsync("guard_face", await FetchPngStreamAsync(http, baseUrl, "characters/character_part_face.png.b64").ConfigureAwait(false), CharacterPartType.Face).ConfigureAwait(false);
         await engine.LoadPartSpriteSheetAsync("guard_armour", await FetchPngStreamAsync(http, baseUrl, "characters/character_part_armour.png.b64").ConfigureAwait(false), CharacterPartType.Armour).ConfigureAwait(false);
         await engine.LoadPartSpriteSheetAsync("guard_head", await FetchPngStreamAsync(http, baseUrl, "characters/character_part_head.png.b64").ConfigureAwait(false), CharacterPartType.Head).ConfigureAwait(false);
+        // NPC speed is 1 tile/s (the tile-unit equivalent of the previous 48 px/s at 48px tiles).
         var guard = new Character
         {
             Position = GuardPosition,
-            BaseSpeed = 48,
+            BaseSpeed = 1,
         };
         guard.SpriteSheets.Add(new SpriteSheetRef("guard_body", CharacterIndex: 3));
         guard.SpriteSheets.Add(new SpriteSheetRef("guard_face", CharacterIndex: 3));

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -46,28 +46,28 @@ public sealed class Character
     // the first step goes toward 0, then the bounce alternates direction at each end.
     private int _frameStep = -1;
 
-    /// <summary>Gets or sets the top-left world position of the character's sprite, in pixels.</summary>
+    /// <summary>Gets or sets the top-left world position of the character's sprite, in tiles.</summary>
     public Position Position { get; set; }
 
     /// <summary>Gets or sets the direction the character is facing.</summary>
     public Direction Direction { get; set; }
 
-    /// <summary>Gets or sets the movement speed of the character in pixels per second.</summary>
+    /// <summary>Gets or sets the movement speed of the character in tiles per second.</summary>
     public double BaseSpeed { get; set; }
 
     /// <summary>
-    /// Gets or sets the movement speed (px/s) at which the walk cycle completes exactly one full
-    /// cycle per second. Defaults to 96, matching <see cref="Player.DefaultBaseSpeed"/>.
+    /// Gets or sets the movement speed (tiles/s) at which the walk cycle completes exactly one full
+    /// cycle per second. Defaults to 2, matching <see cref="Player.DefaultBaseSpeed"/>.
     /// </summary>
     /// <remarks>
     /// The walk cycle is the bounce <c>0 &#8594; 1 &#8594; 2 &#8594; 1</c>, i.e.
     /// <see cref="FramesPerCycle"/> frame steps. The time per frame is
     /// <c>secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)</c>, so at
-    /// <c>BaseSpeed == AnimationCycleSpeed == 96</c> one frame lasts 0.25 s (4 frames/s =
+    /// <c>BaseSpeed == AnimationCycleSpeed == 2</c> one frame lasts 0.25 s (4 frames/s =
     /// 1 cycle/s). Doubling the movement speed doubles the cycle rate; halving it halves it.
     /// Raising this property (the reference speed) slows the animation relative to movement speed.
     /// </remarks>
-    public double AnimationCycleSpeed { get; set; } = 96;
+    public double AnimationCycleSpeed { get; set; } = 2;
 
     /// <summary>
     /// Gets the mutable list of spritesheet references used to render the character. Each entry
@@ -92,13 +92,13 @@ public sealed class Character
 
     /// <summary>
     /// Moves the character in <paramref name="direction"/> by <c>BaseSpeed * speedFactor * dt</c>
-    /// pixels and sets the facing direction.
+    /// tiles and sets the facing direction.
     /// </summary>
     /// <param name="direction">The direction to face and move towards.</param>
     /// <param name="speedFactor">A multiplier applied to <see cref="BaseSpeed"/>. When zero the
     /// character only turns to face <paramref name="direction"/> without moving.</param>
     /// <param name="dt">The elapsed time in seconds (defaults to 1, so calling
-    /// <c>Move(d, factor)</c> moves <c>BaseSpeed * factor</c> pixels, i.e. per-second semantics).</param>
+    /// <c>Move(d, factor)</c> moves <c>BaseSpeed * factor</c> tiles, i.e. per-second semantics).</param>
     public void Move(Direction direction, double speedFactor = 1, double dt = 1)
     {
         Direction = direction;
@@ -149,7 +149,7 @@ public sealed class Character
         _animationAccumulator += dt;
 
         // secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle). At
-        // BaseSpeed == AnimationCycleSpeed == 96 this is 0.25 s/frame, i.e. 4 frames/s = 1 cycle/s.
+        // BaseSpeed == AnimationCycleSpeed == 2 this is 0.25 s/frame, i.e. 4 frames/s = 1 cycle/s.
         var secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle);
         var framesToAdvance = (int)Math.Floor(_animationAccumulator / secondsPerFrame);
         _animationAccumulator -= framesToAdvance * secondsPerFrame;
@@ -192,7 +192,9 @@ public sealed class Character
     /// <returns>The sprite size <c>(width, height)</c> in pixels.</returns>
     /// <remarks>
     /// Used by the engine to clamp a character (notably the player) inside the map bounds using
-    /// its actual rendered size, whatever the sheet's derived cell size is.
+    /// its actual rendered size, whatever the sheet's derived cell size is. The value stays in
+    /// pixels because it reads the sheet's cell size; the engine converts it to tiles (dividing
+    /// by the map's tile size) when clamping.
     /// </remarks>
     internal (int Width, int Height) GetSpriteSize(SpriteSheetManager manager)
     {

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -12,6 +12,13 @@ namespace RPGEngine;
 /// </summary>
 /// <remarks>
 /// <para>
+/// All world coordinates (<see cref="Player.Position"/>, <see cref="Character.Position"/>,
+/// camera origins and <see cref="SurfaceToWorld"/>/<see cref="WorldToSurface"/>) are expressed
+/// in <em>tiles</em> (double). Pixels are produced only at the canvas boundary: <see cref="Render"/>
+/// multiplies the tile positions by the map's tile size to place sprites and the camera viewport,
+/// and the tile size of a map is read from <c>TileMap.TileWidth</c> (48 when no map is set).
+/// </para>
+/// <para>
 /// The game loop is written by the host: each frame the host calls <see cref="Update"/> with its
 /// own elapsed time (<c>dt</c>, in seconds) to advance the simulation, then <see cref="Render"/>
 /// with the same <c>dt</c> to draw the frame onto its canvas. The engine never runs its own loop
@@ -28,8 +35,10 @@ namespace RPGEngine;
 /// The camera is internal to the engine: <see cref="Render"/> follows the player and clamps the
 /// viewport inside the map. When the map is smaller than the canvas on an axis it is centered
 /// in that axis and the area around it is filled with black (the map background), so the map is
-/// never letterboxed with transparent or leftover pixels. If a public camera API becomes
-/// necessary later it can be extracted without breaking this class's API.
+/// never letterboxed with transparent or leftover pixels. <see cref="SurfaceToWorld"/> and
+/// <see cref="WorldToSurface"/> expose the same follow + clamp camera for the given canvas size,
+/// translating host-surface (canvas) coordinates to world coordinates and back — the foundation
+/// the "click to move" and "GUI around game objects" features will build on.
 /// </para>
 /// <para>
 /// When a map is set, <see cref="Render"/> clears the whole canvas to black first, then draws
@@ -62,6 +71,12 @@ public sealed class GameEngine : IDisposable
     private readonly List<Character> _characters = [];
     private readonly HashSet<Key> _pressedKeys = [];
     private TileMap? _map;
+
+    // The canvas size (in pixels) of the most recent Render call, stored so the future
+    // click-to-move story can translate host-surface coordinates with the same camera without
+    // further API churn.
+    private double _lastCanvasWidth;
+    private double _lastCanvasHeight;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameEngine"/> class with default state: a
@@ -114,6 +129,20 @@ public sealed class GameEngine : IDisposable
     /// immediately.
     /// </summary>
     public GameConfig Config { get; set; }
+
+    /// <summary>
+    /// Gets the width in pixels of the canvas from the most recent <see cref="Render"/> call
+    /// (0 before the first render). Internal so the future click-to-move story can translate
+    /// host-surface coordinates without further API churn.
+    /// </summary>
+    internal double LastCanvasWidth => _lastCanvasWidth;
+
+    /// <summary>
+    /// Gets the height in pixels of the canvas from the most recent <see cref="Render"/> call
+    /// (0 before the first render). Internal so the future click-to-move story can translate
+    /// host-surface coordinates without further API churn.
+    /// </summary>
+    internal double LastCanvasHeight => _lastCanvasHeight;
 
     /// <summary>
     /// Reports a key event to the engine. A value of <see langword="true"/> for
@@ -173,7 +202,9 @@ public sealed class GameEngine : IDisposable
     /// the map's <c>above_player</c> layers so those tiles appear above the player. The camera
     /// follows the player, centers a map smaller than the canvas, and is clamped so the viewport
     /// stays inside the map; the canvas size is read from the canvas clip bounds so the view
-    /// adapts to the current surface size automatically.
+    /// adapts to the current surface size automatically. The camera origin is computed in tiles
+    /// and converted to a pixel viewport for the map (a pure pixel renderer) and to pixel screen
+    /// positions for the characters.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto (CPU or GPU backed; see the class remarks).</param>
     /// <param name="dt">The elapsed time in seconds since the previous frame (reserved for future animation timing).</param>
@@ -185,12 +216,21 @@ public sealed class GameEngine : IDisposable
         var canvasWidth = Math.Max(0, (int)Math.Ceiling(bounds.Width));
         var canvasHeight = Math.Max(0, (int)Math.Ceiling(bounds.Height));
 
+        // Record the canvas size so the future click-to-move story can translate host-surface
+        // coordinates with the same camera used here, without further API churn.
+        _lastCanvasWidth = canvasWidth;
+        _lastCanvasHeight = canvasHeight;
+
+        var ts = Map?.TileWidth ?? 48;
         var origin = ComputeCameraOrigin(canvasWidth, canvasHeight);
+
+        // The pixel viewport of the camera, derived from the tile origin. TileMap.Draw /
+        // DrawAbovePlayer stay pure pixel renderers and receive this pixel rect.
         var viewport = new SKRect(
-            (float)origin.X,
-            (float)origin.Y,
-            (float)(origin.X + canvasWidth),
-            (float)(origin.Y + canvasHeight));
+            (float)(origin.X * ts),
+            (float)(origin.Y * ts),
+            (float)(origin.X * ts + canvasWidth),
+            (float)(origin.Y * ts + canvasHeight));
 
         // When a map is set the whole canvas is cleared to black first: this is the black
         // background behind/around a map that is smaller than the canvas. Without a map the
@@ -200,14 +240,16 @@ public sealed class GameEngine : IDisposable
             canvas.Clear(SKColors.Black);
         }
 
-        // Draw everything in world coordinates and let the translate apply the camera: the map
-        // draws its tiles at world positions, and each character is drawn at its world position.
+        // Draw everything through a single camera translation in pixels (origin * ts): the map
+        // blits its prerendered pixel layers in world pixels, and each character is drawn at its
+        // world pixel position (pos * ts). The net screen position of a character is therefore
+        // (pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts).
         // Draw order is: below-player map layers -> each NPC -> the player -> above-player map
         // layers, so tiles marked with the Tiled above_player property appear on top of the player.
         canvas.Save();
         try
         {
-            canvas.Translate((float)-origin.X, (float)-origin.Y);
+            canvas.Translate((float)(-origin.X * ts), (float)(-origin.Y * ts));
 
             if (Map is not null)
             {
@@ -216,10 +258,10 @@ public sealed class GameEngine : IDisposable
 
             foreach (var character in _characters)
             {
-                character.Draw(canvas, character.Position, dt, _spriteSheetManager);
+                character.Draw(canvas, character.Position.ToPixels(ts), dt, _spriteSheetManager);
             }
 
-            Player.Character.Draw(canvas, Player.Position, dt, _spriteSheetManager);
+            Player.Character.Draw(canvas, Player.Position.ToPixels(ts), dt, _spriteSheetManager);
 
             if (Map is not null)
             {
@@ -230,6 +272,51 @@ public sealed class GameEngine : IDisposable
         {
             canvas.Restore();
         }
+    }
+
+    /// <summary>
+    /// Translates a host-surface (canvas) coordinate, in pixels, to a world coordinate, in
+    /// tiles, using the same camera as <see cref="Render"/> (follow + clamp) for the given
+    /// canvas size: <c>world = (surfaceX / ts + origin.X, surfaceY / ts + origin.Y)</c>, where
+    /// <c>ts</c> is the map's tile width (48 when no map is set) and <c>origin</c> is the camera
+    /// origin computed by <see cref="ComputeCameraOrigin"/>.
+    /// </summary>
+    /// <param name="surfaceX">The horizontal surface coordinate in pixels.</param>
+    /// <param name="surfaceY">The vertical surface coordinate in pixels.</param>
+    /// <param name="canvasWidth">The width of the canvas in pixels.</param>
+    /// <param name="canvasHeight">The height of the canvas in pixels.</param>
+    /// <returns>The world position in tiles under the given surface point.</returns>
+    /// <remarks>
+    /// This is the inverse of <see cref="WorldToSurface"/> within floating-point tolerance.
+    /// Hosts use it to translate mouse clicks into world coordinates for "click to move".
+    /// </remarks>
+    public Position SurfaceToWorld(double surfaceX, double surfaceY, double canvasWidth, double canvasHeight)
+    {
+        var ts = Map?.TileWidth ?? 48;
+        var origin = ComputeCameraOrigin((int)canvasWidth, (int)canvasHeight);
+        return new Position(surfaceX / ts + origin.X, surfaceY / ts + origin.Y);
+    }
+
+    /// <summary>
+    /// Translates a world coordinate, in tiles, to a host-surface (canvas) coordinate, in
+    /// pixels, using the same camera as <see cref="Render"/> (follow + clamp) for the given
+    /// canvas size: <c>surface = ((world.X - origin.X) * ts, (world.Y - origin.Y) * ts)</c>,
+    /// where <c>ts</c> is the map's tile width (48 when no map is set) and <c>origin</c> is the
+    /// camera origin computed by <see cref="ComputeCameraOrigin"/>.
+    /// </summary>
+    /// <param name="worldPosition">The world position in tiles.</param>
+    /// <param name="canvasWidth">The width of the canvas in pixels.</param>
+    /// <param name="canvasHeight">The height of the canvas in pixels.</param>
+    /// <returns>The surface position in pixels where the world position appears.</returns>
+    /// <remarks>
+    /// This is the inverse of <see cref="SurfaceToWorld"/> within floating-point tolerance.
+    /// Hosts use it to position GUI elements around game objects.
+    /// </remarks>
+    public Position WorldToSurface(Position worldPosition, double canvasWidth, double canvasHeight)
+    {
+        var ts = Map?.TileWidth ?? 48;
+        var origin = ComputeCameraOrigin((int)canvasWidth, (int)canvasHeight);
+        return new Position((worldPosition.X - origin.X) * ts, (worldPosition.Y - origin.Y) * ts);
     }
 
     /// <summary>
@@ -358,16 +445,19 @@ public sealed class GameEngine : IDisposable
         => _spriteSheetManager.LoadPartAsync(name, stream, partType);
 
     /// <summary>
-    /// Computes the camera origin: the world pixel position that maps to the canvas' top-left
-    /// corner. The desired origin centers the player; it is then clamped so the viewport stays
-    /// inside the map (<c>origin ∈ [0, max(0, PixelSize - canvasSize)]</c> per axis). When the
-    /// map is smaller than the canvas on an axis, half the difference is subtracted so the map is
-    /// centered and the origin becomes negative (<c>origin = clamp(desired, 0, max) - max(0,
-    /// (canvasSize - PixelSize) / 2)</c> per axis). When no map is set the origin is <c>(0, 0)</c>.
+    /// Computes the camera origin: the world position (in tiles) that maps to the canvas' top-left
+    /// corner. Let <c>ts</c> be the map's tile width. The desired origin centers the player
+    /// (<c>desired = player.Position - (canvasWidth / (2*ts), canvasHeight / (2*ts))</c>); it is
+    /// then clamped so the viewport stays inside the map
+    /// (<c>origin ∈ [0, max(0, Map.Width - canvasWidth / ts)]</c> per axis). When the map is
+    /// smaller than the canvas on an axis, half the difference is subtracted so the map is
+    /// centered and the origin becomes negative (<c>origin = clamp(desired, 0, max) -
+    /// max(0, (canvasSize - Map.PixelSize) / (2*ts))</c> per axis). When no map is set the origin
+    /// is <c>(0, 0)</c>.
     /// </summary>
     /// <param name="canvasWidth">The width of the canvas in pixels.</param>
     /// <param name="canvasHeight">The height of the canvas in pixels.</param>
-    /// <returns>The camera origin in world pixel coordinates.</returns>
+    /// <returns>The camera origin in world tile coordinates.</returns>
     /// <remarks>
     /// Internal so the test project can assert the camera contract directly; the camera is not
     /// part of the public API of this story.
@@ -379,21 +469,23 @@ public sealed class GameEngine : IDisposable
             return new Position(0, 0);
         }
 
-        // The maximum viewport origin keeps the view inside the map: 0 when the map is smaller
-        // than the canvas on an axis (the map cannot scroll on that axis), otherwise
-        // PixelSize - canvasSize.
-        var maxX = Math.Max(0, Map.PixelWidth - canvasWidth);
-        var maxY = Math.Max(0, Map.PixelHeight - canvasHeight);
+        var ts = Map.TileWidth;
+
+        // The maximum viewport origin (in tiles) keeps the view inside the map: 0 when the map
+        // is smaller than the canvas on an axis (the map cannot scroll on that axis), otherwise
+        // Map.Width - canvasWidth / ts.
+        var maxX = Math.Max(0, Map.Width - canvasWidth / (double)ts);
+        var maxY = Math.Max(0, Map.Height - canvasHeight / (double)ts);
 
         // When the map is smaller than the canvas on an axis it is centered by shifting the
-        // origin by half the difference, producing a negative origin. When the map fills (or
-        // exceeds) the canvas the offset is 0 and the behavior is exactly the follow + clamp
-        // described above.
-        var offsetX = Math.Max(0, (canvasWidth - Map.PixelWidth) / 2.0);
-        var offsetY = Math.Max(0, (canvasHeight - Map.PixelHeight) / 2.0);
+        // origin by half the difference (in tiles), producing a negative origin. When the map
+        // fills (or exceeds) the canvas the offset is 0 and the behavior is exactly the
+        // follow + clamp described above.
+        var offsetX = Math.Max(0, (canvasWidth - Map.PixelWidth) / (2.0 * ts));
+        var offsetY = Math.Max(0, (canvasHeight - Map.PixelHeight) / (2.0 * ts));
 
-        var desiredX = Player.Position.X - (canvasWidth / 2.0);
-        var desiredY = Player.Position.Y - (canvasHeight / 2.0);
+        var desiredX = Player.Position.X - (canvasWidth / (2.0 * ts));
+        var desiredY = Player.Position.Y - (canvasHeight / (2.0 * ts));
 
         return new Position(
             Math.Clamp(desiredX, 0, maxX) - offsetX,
@@ -402,16 +494,19 @@ public sealed class GameEngine : IDisposable
 
     /// <summary>
     /// Clamps the player's top-left position so its sprite stays inside the map bounds. The
-    /// sprite size is resolved from the player's configured spritesheet (see
-    /// <see cref="Character.GetSpriteSize"/>); when no sheet is configured it falls back to the
-    /// 48×48 default. <c>x ∈ [0, PixelWidth - spriteWidth]</c>, <c>y ∈ [0, PixelHeight - spriteHeight]</c>.
+    /// sprite size is resolved in pixels from the player's configured spritesheet (see
+    /// <see cref="Character.GetSpriteSize"/>) and converted to tiles using the map's tile width;
+    /// when no sheet is configured it falls back to the 48×48 default.
+    /// <c>x ∈ [0, max(0, Map.Width - spriteWidth / ts)]</c>,
+    /// <c>y ∈ [0, max(0, Map.Height - spriteHeight / ts)]</c>, all in tiles.
     /// Called after every move while a map is set.
     /// </summary>
     private void ClampPlayerToMap()
     {
+        var ts = Map!.TileWidth;
         var (spriteWidth, spriteHeight) = Player.Character.GetSpriteSize(_spriteSheetManager);
-        var maxX = Math.Max(0, Map!.PixelWidth - spriteWidth);
-        var maxY = Math.Max(0, Map!.PixelHeight - spriteHeight);
+        var maxX = Math.Max(0, Map.Width - spriteWidth / (double)ts);
+        var maxY = Math.Max(0, Map.Height - spriteHeight / (double)ts);
 
         var position = Player.Position;
         Player.Position = new Position(

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -23,12 +23,12 @@ namespace RPGEngine;
 public sealed class Player
 {
     /// <summary>
-    /// The default movement speed, in pixels per second, of a player created by the parameterless
-    /// constructor: 96 px/s, i.e. two 48px map tiles every second (the tile grid is fixed at
-    /// 48px regardless of the sprite's derived cell size). This is a gameplay tuning
-    /// constant and is expected to be adjusted later.
+    /// The default movement speed, in tiles per second, of a player created by the parameterless
+    /// constructor: 2 tiles/s, i.e. the tile-unit equivalent of the previous 96 px/s with 48 px
+    /// tiles (two 48px map tiles every second). This is a gameplay tuning constant and is
+    /// expected to be adjusted later.
     /// </summary>
-    public const double DefaultBaseSpeed = 96;
+    public const double DefaultBaseSpeed = 2;
 
     /// <summary>Gets or sets the <see cref="Character"/> that represents the player in the game world.</summary>
     /// <remarks>
@@ -57,7 +57,7 @@ public sealed class Player
     }
 
     /// <summary>
-    /// Gets or sets the top-left world position of the player's sprite, in pixels. Forwards to
+    /// Gets or sets the top-left world position of the player's sprite, in tiles. Forwards to
     /// <see cref="Character.Position"/>.
     /// </summary>
     public Position Position
@@ -87,7 +87,7 @@ public sealed class Player
 
     /// <summary>
     /// Moves the player in <paramref name="direction"/> by <c>BaseSpeed * speedFactor * dt</c>
-    /// pixels and sets the facing direction. Forwards to
+    /// tiles and sets the facing direction. Forwards to
     /// <see cref="Character.Move(Direction, double, double)"/>.
     /// </summary>
     /// <param name="direction">The direction to face and move towards.</param>

--- a/src/RPGEngine/Position.cs
+++ b/src/RPGEngine/Position.cs
@@ -1,11 +1,13 @@
 namespace RPGEngine;
 
 /// <summary>
-/// A position in 2D screen space with double-precision coordinates. Y grows downward, so
-/// increasing <see cref="Y"/> moves the position down the screen.
+/// A position in the game world with double-precision coordinates measured in <em>tiles</em>.
+/// Y grows downward, so increasing <see cref="Y"/> moves the position down the map. Positions
+/// are stored in tile units; pixels are produced only at the canvas boundary (rendering and the
+/// <see cref="ToPixels"/> conversion).
 /// </summary>
-/// <param name="X">The horizontal (x) coordinate.</param>
-/// <param name="Y">The vertical (y) coordinate.</param>
+/// <param name="X">The horizontal (x) coordinate, in tiles.</param>
+/// <param name="Y">The vertical (y) coordinate, in tiles.</param>
 public readonly record struct Position(double X, double Y)
 {
     /// <summary>Returns a new position offset from this one by <paramref name="offset"/>.</summary>
@@ -21,25 +23,37 @@ public readonly record struct Position(double X, double Y)
         => new(left.X - right.X, left.Y - right.Y);
 
     /// <summary>Returns a new position offset from this one by <paramref name="dx"/> and <paramref name="dy"/>.</summary>
-    /// <param name="dx">The horizontal offset to apply.</param>
-    /// <param name="dy">The vertical offset to apply.</param>
+    /// <param name="dx">The horizontal offset to apply, in tiles.</param>
+    /// <param name="dy">The vertical offset to apply, in tiles.</param>
     /// <returns>The offset position.</returns>
     public Position WithOffset(double dx, double dy) => new(X + dx, Y + dy);
 
     /// <summary>
-    /// Converts the pixel position to tile coordinates using floor division.
+    /// Floors the tile-unit position to the coordinates of the containing cell. Because
+    /// positions are already expressed in tiles, this simply floors each component: a position
+    /// of <c>(8.5, 8.5)</c> lies in cell <c>(8, 8)</c>, and a position of <c>(-1.5, -1.5)</c>
+    /// lies in cell <c>(-2, -2)</c> (floor division, so negatives round toward negative infinity).
+    /// </summary>
+    /// <returns>The 0-based tile cell containing this position.</returns>
+    public (int TileX, int TileY) ToTile()
+        => ((int)Math.Floor(X), (int)Math.Floor(Y));
+
+    /// <summary>
+    /// Converts the tile-unit position to pixel coordinates: <c>(X * tileSize, Y * tileSize)</c>.
+    /// Used by rendering (to place sprites and the camera viewport on the canvas) and by the
+    /// <c>GameEngine.SurfaceToWorld</c>/<c>WorldToSurface</c> conversions.
     /// </summary>
     /// <param name="tileSize">The size of a tile in pixels; must be greater than zero.</param>
-    /// <returns>The tile coordinates containing this position.</returns>
+    /// <returns>The equivalent pixel position.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="tileSize"/> is zero or negative.</exception>
-    public (int TileX, int TileY) ToTile(int tileSize)
+    public Position ToPixels(int tileSize)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(tileSize);
 
-        return ((int)Math.Floor(X / tileSize), (int)Math.Floor(Y / tileSize));
+        return new Position(X * tileSize, Y * tileSize);
     }
 
-    /// <summary>Returns the Euclidean distance between this position and <paramref name="other"/>.</summary>
+    /// <summary>Returns the Euclidean distance between this position and <paramref name="other"/> (in tiles).</summary>
     /// <param name="other">The other position.</param>
     /// <returns>The non-negative distance.</returns>
     public double DistanceTo(Position other)

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -42,9 +42,9 @@ public class CharacterTests
 
     // ---------------------------------------------------------------------
     // Acceptance 2: Move(direction, factor, dt) moves exactly
-    // BaseSpeed * factor * dt pixels in the right axis/direction and sets Direction.
+    // BaseSpeed * factor * dt tiles in the right axis/direction and sets Direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies Move(direction, factor, dt) moves exactly BaseSpeed × factor × dt pixels along the correct axis and direction, and sets Direction.</summary>
+    /// <summary>Verifies Move(direction, factor, dt) moves exactly BaseSpeed × factor × dt tiles along the correct axis and direction, and sets Direction.</summary>
     [Theory]
     [InlineData(Direction.Down, 0.0, 100.0)]
     [InlineData(Direction.Up, 0.0, -100.0)]
@@ -57,7 +57,7 @@ public class CharacterTests
     {
         var character = new Character { BaseSpeed = 100, Position = new Position(0, 0) };
 
-        // BaseSpeed * factor * dt = 100 * 2 * 0.5 = 100 pixels.
+        // BaseSpeed * factor * dt = 100 * 2 * 0.5 = 100 tiles.
         character.Move(direction, speedFactor: 2, dt: 0.5);
 
         Assert.Equal(expectedX, character.Position.X);
@@ -84,7 +84,7 @@ public class CharacterTests
     // Acceptance 2b (story 21): diagonal movement moves the normalized distance
     // (magnitude 1, not √2) and sets the diagonal Direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies Move(DownRight, 1, 1) at BaseSpeed 100 moves exactly (100·√½, 100·√½) and sets Direction to DownRight.</summary>
+    /// <summary>Verifies Move(DownRight, 1, 1) at BaseSpeed 100 moves exactly (100·√½, 100·√½) tiles and sets Direction to DownRight.</summary>
     [Fact]
     public void Move_Diagonal_MovesNormalizedDistance_AndSetsDirection()
     {
@@ -92,7 +92,7 @@ public class CharacterTests
 
         character.Move(Direction.DownRight, speedFactor: 1, dt: 1);
 
-        // DownRight = (+√½, +√½); 100 px of travel split evenly across the two axes.
+        // DownRight = (+√½, +√½); 100 tiles of travel split evenly across the two axes.
         var component = 100 * Math.Sqrt(0.5);
         Assert.Equal(component, character.Position.X, precision: 9);
         Assert.Equal(component, character.Position.Y, precision: 9);
@@ -104,14 +104,15 @@ public class CharacterTests
     // ---------------------------------------------------------------------
     /// <summary>
     /// Verifies the walk-cycle animation is time-based and speed-scaled: at
-    /// BaseSpeed == AnimationCycleSpeed == 96 the cycle completes one full 4-frame cycle
-    /// (<c>0 → 1 → 2 → 1</c>) per second. A single one-second <see cref="Character.Update(double)"/>
-    /// after moving advances exactly 4 frames and lands back on the standing frame.
+    /// BaseSpeed == AnimationCycleSpeed == 2 (tiles/s, the new defaults) the cycle completes
+    /// one full 4-frame cycle (<c>0 → 1 → 2 → 1</c>) per second. A single one-second
+    /// <see cref="Character.Update(double)"/> after moving advances exactly 4 frames and lands
+    /// back on the standing frame.
     /// </summary>
     [Fact]
-    public void Update_AtBaseSpeed96_MoveOnceThenOneSecondUpdate_CompletesOneCycle()
+    public void Update_AtDefaultSpeed_MoveOnceThenOneSecondUpdate_CompletesOneCycle()
     {
-        var character = new Character { BaseSpeed = 96 };
+        var character = new Character { BaseSpeed = 2 };
 
         // A fresh character stands on the middle (standing) frame and stays there when idle.
         Assert.Equal(StandingFrame, character.AnimationFrame);
@@ -126,13 +127,14 @@ public class CharacterTests
     }
 
     /// <summary>
-    /// Verifies the walk-cycle advances frames per second proportionally to BaseSpeed: the frame
-    /// sequence over one second is revealed by moving + updating at the exact per-frame duration.
+    /// Verifies the walk-cycle advances frames per second proportionally to BaseSpeed (tiles/s):
+    /// the frame sequence over one second is revealed by moving + updating at the exact per-frame
+    /// duration. 2 tiles/s is the new default equivalent of the previous 96 px/s at 48px tiles.
     /// </summary>
     [Theory]
-    [InlineData(96, new[] { 0, 1, 2, 1 })]                 // 0.25 s/frame → 4 frames/s → 1 cycle/s
-    [InlineData(192, new[] { 0, 1, 2, 1, 0, 1, 2, 1 })]    // 0.125 s/frame → 8 frames/s → 2 cycles/s
-    [InlineData(48, new[] { 0, 1 })]                       // 0.5 s/frame → 2 frames/s → 1/2 cycle/s
+    [InlineData(2, new[] { 0, 1, 2, 1 })]                 // 0.25 s/frame → 4 frames/s → 1 cycle/s
+    [InlineData(4, new[] { 0, 1, 2, 1, 0, 1, 2, 1 })]    // 0.125 s/frame → 8 frames/s → 2 cycles/s
+    [InlineData(1, new[] { 0, 1 })]                       // 0.5 s/frame → 2 frames/s → 1/2 cycle/s
     public void Update_WalkCycle_AdvancesFramesPerSecondScaledByBaseSpeed(double baseSpeed, int[] expectedFrames)
     {
         var character = new Character { BaseSpeed = baseSpeed };
@@ -152,7 +154,7 @@ public class CharacterTests
     [Fact]
     public void Update_WhenNotMoving_SnapsToStandingFrame()
     {
-        var character = new Character { BaseSpeed = 96 };
+        var character = new Character { BaseSpeed = 2 };
 
         // Advance the cycle while moving.
         MoveAndUpdate(character, Direction.Down, dt: 0.25);
@@ -168,8 +170,8 @@ public class CharacterTests
     public void Update_AnimationCycleSpeed_IsConfigurable()
     {
         // secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)
-        //                 = 192 / (96 * 4) = 0.5 s/frame → only 2 frames per second.
-        var character = new Character { BaseSpeed = 96, AnimationCycleSpeed = 192 };
+        //                 = 4 / (2 * 4) = 0.5 s/frame → only 2 frames per second.
+        var character = new Character { BaseSpeed = 2, AnimationCycleSpeed = 4 };
 
         MoveAndUpdate(character, Direction.Down, dt: 0.5);
         Assert.Equal(0, character.AnimationFrame);

--- a/tests/RPGEngine.Tests/Core/PositionTests.cs
+++ b/tests/RPGEngine.Tests/Core/PositionTests.cs
@@ -4,7 +4,8 @@ using Xunit;
 namespace RPGEngine.Tests.Core;
 
 /// <summary>
-/// Acceptance tests for <see cref="Position"/> (story 4: core primitives — Direction and Position).
+/// Acceptance tests for <see cref="Position"/> (story 4: core primitives — Direction and Position,
+/// updated by story 37: tile-based world coordinates).
 /// </summary>
 public class PositionTests
 {
@@ -55,21 +56,53 @@ public class PositionTests
         Assert.Equal(new Position(12.5, 16.5), offset);
     }
 
-    /// <summary>Verifies <see cref="Position.ToTile"/> floors correctly for positive and negative pixel positions.</summary>
+    /// <summary>
+    /// Verifies <see cref="Position.ToTile"/> floors the tile-unit position to the containing
+    /// cell. Positions are already in tiles, so the floor is applied directly; negative values
+    /// round toward negative infinity (acceptance criterion 3: (8.5, 8.5) → (8, 8) and
+    /// (-1.5, -1.5) → (-2, -2)).
+    /// </summary>
     [Theory]
-    [InlineData(95, 95, 48, 1, 1)]
-    [InlineData(0, 0, 48, 0, 0)]
-    [InlineData(47, 47, 48, 0, 0)]
-    [InlineData(48, 48, 48, 1, 1)]
-    [InlineData(-1, -1, 48, -1, -1)]
-    [InlineData(-48, -48, 48, -1, -1)]
-    [InlineData(-49, -49, 48, -2, -2)]
-    public void ToTile_FloorsCorrectly(double x, double y, int tileSize, int expectedTileX, int expectedTileY)
+    [InlineData(8.5, 8.5, 8, 8)]
+    [InlineData(0, 0, 0, 0)]
+    [InlineData(0.9, 0.9, 0, 0)]
+    [InlineData(1, 1, 1, 1)]
+    [InlineData(1.5, 1.5, 1, 1)]
+    [InlineData(-1, -1, -1, -1)]
+    [InlineData(-1.5, -1.5, -2, -2)]
+    [InlineData(-0.1, -0.1, -1, -1)]
+    public void ToTile_FloorsToContainingCell(double x, double y, int expectedTileX, int expectedTileY)
     {
-        var (tileX, tileY) = new Position(x, y).ToTile(tileSize);
+        var (tileX, tileY) = new Position(x, y).ToTile();
 
         Assert.Equal(expectedTileX, tileX);
         Assert.Equal(expectedTileY, tileY);
+    }
+
+    /// <summary>
+    /// Verifies <see cref="Position.ToPixels"/> converts tile coordinates to pixels by
+    /// multiplying by the tile size (acceptance criterion 3: (8.5, 8.5).ToPixels(48) →
+    /// (408, 408)).
+    /// </summary>
+    [Theory]
+    [InlineData(8.5, 8.5, 48, 408, 408)]
+    [InlineData(0, 0, 48, 0, 0)]
+    [InlineData(1, 2, 32, 32, 64)]
+    [InlineData(-1.5, 2.5, 48, -72, 120)]
+    public void ToPixels_MultipliesByTileSize(double x, double y, int tileSize, double expectedX, double expectedY)
+    {
+        var pixels = new Position(x, y).ToPixels(tileSize);
+
+        Assert.Equal(expectedX, pixels.X);
+        Assert.Equal(expectedY, pixels.Y);
+    }
+
+    /// <summary>Verifies <see cref="Position.ToPixels"/> rejects a non-positive tile size.</summary>
+    [Fact]
+    public void ToPixels_NonPositiveTileSize_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Position(1, 1).ToPixels(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Position(1, 1).ToPixels(-1));
     }
 
     /// <summary>Verifies <see cref="Position.DistanceTo"/> computes the Euclidean distance.</summary>

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -180,9 +180,9 @@ public class DocsExamplesTests
     {
         var character = new Character
         {
-            Position = new Position(96, 96),
+            Position = new Position(2, 2),
             Direction = Direction.Down,
-            BaseSpeed = 96,
+            BaseSpeed = 2,
         };
 
         character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
@@ -212,16 +212,16 @@ public class DocsExamplesTests
     [Fact]
     public void Character_AnimationCycleSpeed_TunesWalkCycle()
     {
-        // At BaseSpeed == AnimationCycleSpeed == 96 the 4-frame walk cycle (0 -> 1 -> 2 -> 1)
-        // completes once per second: secondsPerFrame = 96 / (96 * 4) = 0.25 s/frame.
-        var character = new Character { BaseSpeed = 96, AnimationCycleSpeed = 96 };
+        // At BaseSpeed == AnimationCycleSpeed == 2 (tiles/s) the 4-frame walk cycle
+        // (0 -> 1 -> 2 -> 1) completes once per second: secondsPerFrame = 2 / (2 * 4) = 0.25 s/frame.
+        var character = new Character { BaseSpeed = 2, AnimationCycleSpeed = 2 };
         character.Move(Direction.Down, speedFactor: 1, dt: 0.25);
         character.Update(dt: 0.25);
         Assert.Equal(0, character.AnimationFrame); // advanced one frame step (1 -> 0)
 
         // Doubling AnimationCycleSpeed (the reference speed) halves the cycle rate: the same
         // 0.25 s only accumulates half a frame, so the standing frame (1) is kept.
-        var slow = new Character { BaseSpeed = 96, AnimationCycleSpeed = 192 };
+        var slow = new Character { BaseSpeed = 2, AnimationCycleSpeed = 4 };
         slow.Move(Direction.Down, speedFactor: 1, dt: 0.25);
         slow.Update(dt: 0.25);
         Assert.Equal(1, slow.AnimationFrame); // still the standing frame
@@ -306,8 +306,11 @@ public class DocsExamplesTests
         var moved = position + offset;
         Assert.Equal(new Position(13, 16), moved);
 
-        var tile = moved.ToTile(tileSize: 48);
-        Assert.Equal((0, 0), tile);
+        // Positions are in tiles: ToTile() floors to the containing cell, ToPixels(ts)
+        // converts to pixels at the given tile size.
+        var cell = moved.ToTile();
+        Assert.Equal((13, 16), cell);
+        Assert.Equal(new Position(624, 768), moved.ToPixels(tileSize: 48));
 
         var distance = position.DistanceTo(new Position(13, 16));
         Assert.Equal(5, distance, precision: 10);

--- a/tests/RPGEngine.Tests/Fixtures/SampleScene.cs
+++ b/tests/RPGEngine.Tests/Fixtures/SampleScene.cs
@@ -16,9 +16,9 @@ namespace RPGEngine.Tests.Fixtures;
 /// </para>
 /// <list type="bullet">
 /// <item>Map: the committed 16×12 orthogonal map (48px tiles, 768×576 px world).</item>
-/// <item>Player: <c>hero</c> full sheet, character index 1, at (288, 288) — on the sand path.</item>
-/// <item>NPC "villager": <c>body</c> + <c>face</c> + <c>hair1</c> part sheets, character index 2, at (144, 192).</item>
-/// <item>NPC "guard": <c>body</c> + <c>face</c> + <c>armour</c> + <c>head</c> part sheets, character index 3, at (528, 384).</item>
+/// <item>Player: <c>hero</c> full sheet, character index 1, at (6, 6) tiles — on the sand path.</item>
+/// <item>NPC "villager": <c>body</c> + <c>face</c> + <c>hair1</c> part sheets, character index 2, at (3, 4) tiles.</item>
+/// <item>NPC "guard": <c>body</c> + <c>face</c> + <c>armour</c> + <c>head</c> part sheets, character index 3, at (11, 8) tiles.</item>
 /// </list>
 /// </remarks>
 internal static class SampleScene
@@ -26,14 +26,14 @@ internal static class SampleScene
     /// <summary>Tile size in pixels of the fixture map and the RPG Maker MZ sheets.</summary>
     public const int TileSize = 48;
 
-    /// <summary>Player world position (on the sand path of the fixture map).</summary>
-    public static readonly Position PlayerPosition = new(6 * TileSize, 6 * TileSize);
+    /// <summary>Player world position in tiles (on the sand path of the fixture map).</summary>
+    public static readonly Position PlayerPosition = new(6, 6);
 
-    /// <summary>First NPC world position (a villager made of body/face/hair1 parts).</summary>
-    public static readonly Position VillagerPosition = new(3 * TileSize, 4 * TileSize);
+    /// <summary>First NPC world position in tiles (a villager made of body/face/hair1 parts).</summary>
+    public static readonly Position VillagerPosition = new(3, 4);
 
-    /// <summary>Second NPC world position (a guard made of body/face/armour/head parts).</summary>
-    public static readonly Position GuardPosition = new(11 * TileSize, 8 * TileSize);
+    /// <summary>Second NPC world position in tiles (a guard made of body/face/armour/head parts).</summary>
+    public static readonly Position GuardPosition = new(11, 8);
 
     /// <summary>
     /// Builds the engine for the sample scene from a directory that contains the materialized
@@ -54,11 +54,12 @@ internal static class SampleScene
         engine.Player.Position = PlayerPosition;
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
-        // NPC 1 "villager": body + face + hair1 part sheets, character slot 2.
+        // NPC 1 "villager": body + face + hair1 part sheets, character slot 2. The NPC speed is
+        // 1 tile/s (the tile-unit equivalent of the previous 48 px/s at 48px tiles).
         var villager = new Character
         {
             Position = VillagerPosition,
-            BaseSpeed = 48,
+            BaseSpeed = 1,
         };
         engine.LoadPartSpriteSheet("villager_body", Path.Combine(assetsRoot, FixtureAssets.PartBody), CharacterPartType.Body);
         engine.LoadPartSpriteSheet("villager_face", Path.Combine(assetsRoot, FixtureAssets.PartFace), CharacterPartType.Face);
@@ -68,11 +69,12 @@ internal static class SampleScene
         villager.SpriteSheets.Add(new SpriteSheetRef("villager_hair1", CharacterIndex: 2));
         engine.Characters.Add(villager);
 
-        // NPC 2 "guard": body + face + armour + head part sheets, character slot 3.
+        // NPC 2 "guard": body + face + armour + head part sheets, character slot 3. The NPC
+        // speed is 1 tile/s (the tile-unit equivalent of the previous 48 px/s at 48px tiles).
         var guard = new Character
         {
             Position = GuardPosition,
-            BaseSpeed = 48,
+            BaseSpeed = 1,
         };
         engine.LoadPartSpriteSheet("guard_body", Path.Combine(assetsRoot, FixtureAssets.PartBody), CharacterPartType.Body);
         engine.LoadPartSpriteSheet("guard_face", Path.Combine(assetsRoot, FixtureAssets.PartFace), CharacterPartType.Face);

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -7,11 +7,11 @@ using Xunit;
 namespace RPGEngine.Tests;
 
 /// <summary>
-/// Acceptance tests for <see cref="GameEngine"/> (story 3): the root object that owns the
-/// player, NPCs, map, configuration and spritesheet registry, and exposes the
-/// <c>Update</c>/<c>Render</c>/<c>Input</c>/<c>LoadSpriteSheet</c> API used by the host game
-/// loop. Tile sets are loaded by the <c>TileMap</c> itself and are not part of the engine's
-/// public API.
+/// Acceptance tests for <see cref="GameEngine"/> (story 3, updated by story 37: tile-based
+/// world coordinates): the root object that owns the player, NPCs, map, configuration and
+/// spritesheet registry, and exposes the <c>Update</c>/<c>Render</c>/<c>Input</c>/
+/// <c>LoadSpriteSheet</c> API used by the host game loop. All world coordinates are in tiles;
+/// pixels are produced only at the canvas boundary.
 /// </summary>
 public class GameEngineTests
 {
@@ -21,15 +21,15 @@ public class GameEngineTests
 
     // ---------------------------------------------------------------------
     // Acceptance 1: Input → movement. Pressing W and calling Update(1/60)
-    // for 60 frames with BaseSpeed = 96 moves the player up ~96 px; releasing
+    // for 60 frames with BaseSpeed = 2 moves the player up ~2 tiles; releasing
     // the key stops the movement.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies holding W for one second at 96 px/s moves the player up ~96 px, and releasing the key stops the movement.</summary>
+    /// <summary>Verifies holding W for one second at the default 2 tiles/s moves the player up 2 tiles, and releasing the key stops the movement.</summary>
     [Fact]
     public void Input_UpKeyForOneSecond_MovesPlayerUpByBaseSpeed()
     {
         var engine = new GameEngine();
-        engine.Player.Character.BaseSpeed = 96;
+        engine.Player.Character.BaseSpeed = 2;
         engine.Player.Position = new Position(200, 200);
 
         engine.Input(Key.W, true);
@@ -38,9 +38,9 @@ public class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // Moved straight up for one second: -96 px on Y, X unchanged.
+        // Moved straight up for one second: -2 tiles on Y, X unchanged.
         Assert.Equal(200, engine.Player.Position.X, precision: 6);
-        Assert.Equal(200 - 96, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(200 - 2, engine.Player.Position.Y, precision: 6);
         Assert.Equal(Direction.Up, engine.Player.Direction);
 
         // Releasing the key stops the movement on the next update.
@@ -77,12 +77,15 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
-    // Acceptance 3: the camera follows the player and clamps inside the map.
-    // With a 10×10 (48px) map and a 240×240 canvas the origin is (0,0) at the
-    // top-left corner, (PixelWidth - 240, PixelHeight - 240) at the bottom-right
-    // corner, and centers the player in the middle. Verified via rendering.
+    // Acceptance 3 (story 37): the camera follows the player and clamps inside
+    // the map, in tile units. With a 10×10 (48px) map and a 240×240 canvas the
+    // origin is (0,0) tiles at the top-left corner, (5,5) tiles at the
+    // bottom-right corner (previously (240,240) px), and (2,2) tiles for the
+    // player at (4.5,4.5) tiles (previously (216,216) px) — the camera contract
+    // is unchanged when re-expressed in tiles. Verified via ComputeCameraOrigin
+    // and rendered output.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies the camera origin clamps to the map bounds and centers the player, asserted through rendered output.</summary>
+    /// <summary>Verifies the camera origin clamps to the map bounds and centers the player, in tile units, asserted through rendered output.</summary>
     [Fact]
     public void Camera_ClampsToMapBounds_AndCentersPlayer()
     {
@@ -101,17 +104,18 @@ public class GameEngineTests
             Assert.NotEqual(0, bitmap.GetPixel(200, 200).Alpha);
         }
 
-        // Bottom-right corner: origin clamped to (PixelWidth - 240, PixelHeight - 240).
-        engine.Player.Position = new Position(480 - CellSize, 480 - CellSize);
-        Assert.Equal(new Position(240, 240), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+        // Bottom-right corner: origin clamped to (Map.Width - canvas/ts, Map.Height - canvas/ts)
+        // = (10 - 5, 10 - 5) = (5, 5) tiles (previously (240, 240) px).
+        engine.Player.Position = new Position(9, 9); // 432 px
+        Assert.Equal(new Position(5, 5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
         using (var bitmap = Render(engine, canvasSize, canvasSize))
         {
             AssertSpriteColor(bitmap, topLeftX: 192, topLeftY: 192, seed: 1, characterIndex: 1);
         }
 
-        // Middle: origin = player - canvas/2 (no clamping), so the player is centered.
-        engine.Player.Position = new Position(216, 216);
-        Assert.Equal(new Position(96, 96), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+        // Middle: origin = player - canvas/(2*ts) (no clamping), so the player is centered.
+        engine.Player.Position = new Position(4.5, 4.5); // 216 px
+        Assert.Equal(new Position(2, 2), engine.ComputeCameraOrigin(canvasSize, canvasSize));
         using (var bitmap = Render(engine, canvasSize, canvasSize))
         {
             AssertSpriteColor(bitmap, topLeftX: 120, topLeftY: 120, seed: 1, characterIndex: 1);
@@ -134,7 +138,7 @@ public class GameEngineTests
         ConfigurePlayerSprite(engine, seed: 1);
         engine.Player.Position = new Position(0, 0);
 
-        var npc = new Character { Position = new Position(96, 96) };
+        var npc = new Character { Position = new Position(2, 2) }; // 96 px
         using (var npcStream = CharacterTestHelper.CreateSheetStream(2))
         {
             engine.LoadSpriteSheet("npc", npcStream);
@@ -152,9 +156,10 @@ public class GameEngineTests
         Assert.Equal(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), bitmap.GetPixel(120, 120));
 
         // Replacing the map changes the output: the 2×2 (96×96) map is now centered on the
-        // 240×240 canvas (origin -72,-72), so the player/NPC move to screen (72,72)/(168,168)
-        // and the pixel at (200,100) is outside the map and every sprite: it is black (the black
-        // background around a smaller map), instead of the red tile of the 10×10 map.
+        // 240×240 canvas (origin -1.5,-1.5 tiles), so the player/NPC move to screen
+        // (72,72)/(168,168) and the pixel at (200,100) is outside the map and every sprite: it
+        // is black (the black background around a smaller map), instead of the red tile of the
+        // 10×10 map.
         using (var smallFixture = CreateFilledMapFixture(2, 2))
         {
             engine.Map = TileMap.Load(smallFixture.MapPath);
@@ -164,7 +169,7 @@ public class GameEngineTests
         }
 
         // Removing the NPC removes its pixels; re-adding restores them. On the centered 2×2
-        // map the NPC (world 96,96) is at screen (168,168); its centre pixel is (192,192).
+        // map the NPC (world 2,2) is at screen (168,168); its centre pixel is (192,192).
         engine.Characters.Remove(npc);
         using (var withoutNpc = Render(engine, canvasSize, canvasSize))
         {
@@ -310,12 +315,12 @@ public class GameEngineTests
     // diagonally, opposite keys cancel, and releasing one key of a held
     // diagonal pair reverts to the remaining cardinal direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies holding W+D for one second at 96 px/s moves diagonally up-right (~±67.88 px per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
+    /// <summary>Verifies holding W+D for one second at 2 tiles/s moves diagonally up-right (~±1.414 tiles per axis) and sets Direction to UpRight; releasing D then moves straight up.</summary>
     [Fact]
     public void Update_HoldingDiagonalPair_MovesDiagonallyAndRevertsOnRelease()
     {
         var engine = new GameEngine();
-        engine.Player.Character.BaseSpeed = 96;
+        engine.Player.Character.BaseSpeed = 2;
         engine.Player.Position = new Position(200, 200);
 
         engine.Input(Key.W, true);
@@ -325,8 +330,8 @@ public class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // UpRight = (+√½, -√½); one second at 96 px/s → (±96·√½) ≈ (±67.88) per axis.
-        var component = 96 * Math.Sqrt(0.5);
+        // UpRight = (+√½, -√½); one second at 2 tiles/s → (±2·√½) ≈ (±1.414) per axis.
+        var component = 2 * Math.Sqrt(0.5);
         Assert.Equal(200 + component, engine.Player.Position.X, precision: 6);
         Assert.Equal(200 - component, engine.Player.Position.Y, precision: 6);
         Assert.Equal(Direction.UpRight, engine.Player.Direction);
@@ -373,10 +378,9 @@ public class GameEngineTests
 
     // ---------------------------------------------------------------------
     // Acceptance (story 23): the player is clamped inside the map using its
-    // actual sprite size (78×108 for a 936×864 sheet), verified through
-    // ComputeCameraOrigin/rendering.
+    // actual sprite size (78×108 for a 936×864 sheet), converted to tiles.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies ClampPlayerToMap uses the player's derived 78×108 sprite size (maxX = PixelWidth - 78, maxY = PixelHeight - 108).</summary>
+    /// <summary>Verifies ClampPlayerToMap uses the player's derived 78×108 sprite size converted to tiles (maxX = 10 - 78/48, maxY = 10 - 108/48).</summary>
     [Fact]
     public void ClampPlayerToMap_UsesPlayerSpriteSize()
     {
@@ -389,11 +393,12 @@ public class GameEngineTests
         }
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
-        // Beyond the bottom-right corner: clamps to (480 - 78, 480 - 108) = (402, 372).
+        // Beyond the bottom-right corner: clamps to (10 - 78/48, 10 - 108/48) = (8.375, 7.75)
+        // tiles (the previous (402, 372) px).
         engine.Player.Position = new Position(1000, 1000);
         engine.Update(FrameDt);
-        Assert.Equal(480 - 78, engine.Player.Position.X, precision: 6);
-        Assert.Equal(480 - 108, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(10 - (78 / (double)CellSize), engine.Player.Position.X, precision: 6);
+        Assert.Equal(10 - (108 / (double)CellSize), engine.Player.Position.Y, precision: 6);
 
         // Negative position clamps to (0, 0).
         engine.Player.Position = new Position(-100, -100);
@@ -417,12 +422,12 @@ public class GameEngineTests
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
         engine.Player.Position = new Position(1000, 1000);
-        engine.Update(FrameDt); // clamps to (402, 372)
+        engine.Update(FrameDt); // clamps to (8.375, 7.75)
 
-        // The camera origin clamps to the map: maxX = maxY = 480 - 240 = 240.
-        Assert.Equal(new Position(240, 240), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+        // The camera origin clamps to the map: maxX = maxY = 10 - 240/48 = 5 tiles.
+        Assert.Equal(new Position(5, 5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
 
-        // The 78×108 sprite renders at screen (402 - 240, 372 - 240) = (162, 132).
+        // The 78×108 sprite renders at screen ((8.375 - 5)*48, (7.75 - 5)*48) = (162, 132).
         using var bitmap = Render(engine, canvasSize, canvasSize);
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
         Assert.Equal(expected, bitmap.GetPixel(162 + 39, 132 + 54));
@@ -434,7 +439,7 @@ public class GameEngineTests
     // map is centered, and Render clears the surrounding area to black. Tile layers
     // declaring the Tiled above_player property are drawn after the player.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies a map smaller than the canvas is centered (negative origin) and the surrounding pixels are black.</summary>
+    /// <summary>Verifies a map smaller than the canvas is centered (negative origin, in tiles) and the surrounding pixels are black.</summary>
     [Fact]
     public void Camera_MapSmallerThanCanvas_CentersMapWithBlackBackground()
     {
@@ -443,8 +448,8 @@ public class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         engine.Player.Position = new Position(0, 0);
 
-        // offset = (240 - 96) / 2 = 72 on each axis; the origin is the negative offset.
-        Assert.Equal(new Position(-72, -72), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+        // offset = (240 - 96) / (2 * 48) = 1.5 on each axis; the origin is the negative offset.
+        Assert.Equal(new Position(-1.5, -1.5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
 
         using var bitmap = Render(engine, canvasSize, canvasSize);
 
@@ -463,7 +468,7 @@ public class GameEngineTests
         Assert.Equal(black, bitmap.GetPixel(120, 220)); // below the map
     }
 
-    /// <summary>Verifies a map that fills (or exceeds) the canvas keeps the previous follow + clamp camera behavior (offset == 0).</summary>
+    /// <summary>Verifies a map that fills (or exceeds) the canvas keeps the previous follow + clamp camera behavior (offset == 0), in tiles.</summary>
     [Fact]
     public void Camera_MapFillsCanvas_KeepsFollowAndClampBehavior()
     {
@@ -475,13 +480,13 @@ public class GameEngineTests
         engine.Player.Position = new Position(0, 0);
         Assert.Equal(new Position(0, 0), engine.ComputeCameraOrigin(canvasSize, canvasSize));
 
-        // Bottom-right: origin clamped to PixelSize - canvasSize.
-        engine.Player.Position = new Position(480 - CellSize, 480 - CellSize);
-        Assert.Equal(new Position(240, 240), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+        // Bottom-right: origin clamped to (Map.Width - canvas/ts, Map.Height - canvas/ts) = (5, 5).
+        engine.Player.Position = new Position(9, 9);
+        Assert.Equal(new Position(5, 5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
 
-        // Middle: origin = player - canvas/2 (follow, no clamping).
-        engine.Player.Position = new Position(216, 216);
-        Assert.Equal(new Position(96, 96), engine.ComputeCameraOrigin(canvasSize, canvasSize));
+        // Middle: origin = player - canvas/(2*ts) (follow, no clamping).
+        engine.Player.Position = new Position(4.5, 4.5);
+        Assert.Equal(new Position(2, 2), engine.ComputeCameraOrigin(canvasSize, canvasSize));
     }
 
     /// <summary>Verifies a tile on an above_player layer is drawn on top of the player, and without the flag the player is on top.</summary>
@@ -532,6 +537,124 @@ public class GameEngineTests
             using var bitmap = Render(engine, canvasSize, canvasSize);
             var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
             Assert.Equal(expected, bitmap.GetPixel(24, 24));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Story 37 acceptance 4: SurfaceToWorld / WorldToSurface are camera-aware
+    // and inverses within floating-point tolerance. With no map the origin is
+    // (0,0), so SurfaceToWorld(408, 408, 960, 960) == (8.5, 8.5) tiles.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies SurfaceToWorld and WorldToSurface are inverses within 1e-9, and the documented origin-(0,0) round trip.</summary>
+    [Fact]
+    public void SurfaceToWorld_WorldToSurface_AreInversesWithinTolerance()
+    {
+        var engine = new GameEngine(); // no map -> camera origin (0,0), ts 48
+
+        // With origin (0,0) and ts 48, SurfaceToWorld(408, 408, 960, 960) == (8.5, 8.5).
+        var world = engine.SurfaceToWorld(408, 408, 960, 960);
+        Assert.Equal(8.5, world.X, precision: 9);
+        Assert.Equal(8.5, world.Y, precision: 9);
+
+        // Round-trip: WorldToSurface(SurfaceToWorld(p)) == p within floating-point tolerance.
+        var surface = engine.WorldToSurface(world, 960, 960);
+        Assert.Equal(408, surface.X, precision: 9);
+        Assert.Equal(408, surface.Y, precision: 9);
+
+        // Inverses across a spread of surface points.
+        foreach (var (sx, sy) in new[] { (0.0, 0.0), (123.0, 456.0), (959.0, 1.0), (408.0, 408.0) })
+        {
+            var roundTripped = engine.WorldToSurface(engine.SurfaceToWorld(sx, sy, 960, 960), 960, 960);
+            Assert.Equal(sx, roundTripped.X, precision: 9);
+            Assert.Equal(sy, roundTripped.Y, precision: 9);
+        }
+    }
+
+    /// <summary>Verifies SurfaceToWorld / WorldToSurface use the same follow + clamp camera as Render for a given canvas size.</summary>
+    [Fact]
+    public void SurfaceToWorld_WorldToSurface_RespectCameraOffset()
+    {
+        const int canvasSize = 240;
+        using var fixture = CreateFilledMapFixture(10, 10); // 480×480 px
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Player at (4.5, 4.5) tiles -> camera origin (2, 2) tiles, so the player's world
+        // position maps to the canvas centre (120, 120) px.
+        engine.Player.Position = new Position(4.5, 4.5);
+        var surface = engine.WorldToSurface(new Position(4.5, 4.5), canvasSize, canvasSize);
+        Assert.Equal(120, surface.X, precision: 9);
+        Assert.Equal(120, surface.Y, precision: 9);
+
+        // And the canvas centre maps back to the player's world position.
+        var world = engine.SurfaceToWorld(120, 120, canvasSize, canvasSize);
+        Assert.Equal(4.5, world.X, precision: 9);
+        Assert.Equal(4.5, world.Y, precision: 9);
+
+        // The conversions are inverses within floating-point tolerance.
+        var roundTripped = engine.WorldToSurface(engine.SurfaceToWorld(80, 160, canvasSize, canvasSize), canvasSize, canvasSize);
+        Assert.Equal(80, roundTripped.X, precision: 9);
+        Assert.Equal(160, roundTripped.Y, precision: 9);
+    }
+
+    // ---------------------------------------------------------------------
+    // Story 37 acceptance 5: rendering reproduces the previous pixel output.
+    // Player.Position = (8.5, 8.5) tiles with camera origin (0,0) draws the
+    // sprite at 408 px.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a player at (8.5, 8.5) tiles with origin (0,0) renders its sprite at screen position 408 px (pixel assertion).</summary>
+    [Fact]
+    public void Render_PlayerAt8_5_WithOriginZero_DrawsSpriteAt408Px()
+    {
+        // A 21×21 map (1008×1008 px) on a 960×960 canvas: Render derives the canvas size
+        // from the clip bounds (962×962), for which the camera origin is exactly (0,0) tiles —
+        // the player's desired origin (8.5 - 962/96 < 0) clamps to 0 and the map is larger than
+        // the canvas, so there is no centering offset.
+        using var fixture = CreateFilledMapFixture(21, 21);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(8.5, 8.5);
+
+        using var bitmap = new SKBitmap(960, 960);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.Render(canvas, FrameDt);
+
+            // Assert the camera origin used inside Render is exactly (0,0) tiles.
+            var canvasWidth = (int)Math.Ceiling(canvas.LocalClipBounds.Width);
+            var canvasHeight = (int)Math.Ceiling(canvas.LocalClipBounds.Height);
+            Assert.Equal(new Position(0, 0), engine.ComputeCameraOrigin(canvasWidth, canvasHeight));
+        }
+
+        // The 48×48 sprite is drawn at screen top-left (408, 408); its centre is (432, 432).
+        var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(408 + (CellSize / 2), 408 + (CellSize / 2)));
+        Assert.Equal(expected, bitmap.GetPixel(408, 408));
+        Assert.Equal(expected, bitmap.GetPixel(408 + CellSize - 1, 408 + CellSize - 1));
+    }
+
+    // ---------------------------------------------------------------------
+    // Story 37: Render records the canvas size from the clip bounds (internal
+    // state the click-to-move story will consume).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies Render records the canvas size derived from the clip bounds for the future click-to-move story.</summary>
+    [Fact]
+    public void Render_RecordsCanvasSize()
+    {
+        var engine = new GameEngine();
+        Assert.Equal(0, engine.LastCanvasWidth);
+        Assert.Equal(0, engine.LastCanvasHeight);
+
+        using var bitmap = new SKBitmap(240, 160);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.Render(canvas, FrameDt);
+
+            // Render stores the same clip-derived size it uses for the camera.
+            Assert.Equal(Math.Max(0, (int)Math.Ceiling(canvas.LocalClipBounds.Width)), engine.LastCanvasWidth);
+            Assert.Equal(Math.Max(0, (int)Math.Ceiling(canvas.LocalClipBounds.Height)), engine.LastCanvasHeight);
         }
     }
 

--- a/tests/RPGEngine.Tests/PlayerTests.cs
+++ b/tests/RPGEngine.Tests/PlayerTests.cs
@@ -94,7 +94,7 @@ public class PlayerTests
     // Acceptance 4: Move(direction, factor, dt) moves the underlying Character
     // by BaseSpeed * factor * dt and updates its Direction.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies Move(direction, factor, dt) moves the underlying Character exactly BaseSpeed × factor × dt pixels along the right axis and updates its Direction.</summary>
+    /// <summary>Verifies Move(direction, factor, dt) moves the underlying Character exactly BaseSpeed × factor × dt tiles along the right axis and updates its Direction.</summary>
     [Theory]
     [InlineData(Direction.Down, 0.0, 100.0)]
     [InlineData(Direction.Up, 0.0, -100.0)]
@@ -108,7 +108,7 @@ public class PlayerTests
         var player = new Player { Position = new Position(0, 0) };
         player.Character.BaseSpeed = 100;
 
-        // BaseSpeed * factor * dt = 100 * 2 * 0.5 = 100 pixels.
+        // BaseSpeed * factor * dt = 100 * 2 * 0.5 = 100 tiles.
         player.Move(direction, speedFactor: 2, dt: 0.5);
 
         Assert.Equal(expectedX, player.Position.X);
@@ -150,22 +150,23 @@ public class PlayerTests
         var right = config.GetDirection(Key.D)!.Value;
         var down = config.GetDirection(Key.S)!.Value;
 
-        // Move right for one second (60 frames at 1/60 s) → 96 px to the right.
+        // Move right for one second (60 frames at 1/60 s) → 2 tiles to the right (the new
+        // default BaseSpeed of 2 tiles/s, the tile-unit equivalent of the previous 96 px/s).
         for (var frame = 0; frame < 60; frame++)
         {
             player.Move(right, speedFactor: 1, dt);
         }
 
-        Assert.Equal(96, player.Position.X, precision: 6);
+        Assert.Equal(2, player.Position.X, precision: 6);
         Assert.Equal(0, player.Position.Y, precision: 6);
 
-        // Then move down for half a second (30 frames) → 48 px down.
+        // Then move down for half a second (30 frames) → 1 tile down.
         for (var frame = 0; frame < 30; frame++)
         {
             player.Move(down, speedFactor: 1, dt);
         }
 
-        Assert.Equal(96, player.Position.X, precision: 6);
-        Assert.Equal(48, player.Position.Y, precision: 6);
+        Assert.Equal(2, player.Position.X, precision: 6);
+        Assert.Equal(1, player.Position.Y, precision: 6);
     }
 }

--- a/tests/RPGEngine.Tests/SampleSceneTests.cs
+++ b/tests/RPGEngine.Tests/SampleSceneTests.cs
@@ -68,7 +68,9 @@ public class SampleSceneTests
 
         var spawn = objects.Objects.Single(obj => obj.Name == "spawn");
         Assert.Equal(TileMapObjectShape.Point, spawn.Shape);
-        Assert.Equal(SampleScene.PlayerPosition, spawn.Position);
+        // The spawn object is a Tiled object-layer position, which stays in pixels: (6, 6)
+        // tiles = (288, 288) px (the tile-unit equivalent of SampleScene.PlayerPosition).
+        Assert.Equal(new Position(288, 288), spawn.Position);
 
         var chest = objects.Objects.Single(obj => obj.Name == "chest");
         Assert.Equal(true, chest.Properties.Single(p => p.Name == "locked").Value);
@@ -116,8 +118,8 @@ public class SampleSceneTests
         using var fixtures = FixtureAssets.MaterializeToTempDirectory();
         var engine = SampleScene.Create(fixtures.Root);
 
-        // Camera origin for a 640×480 view with the player at (288, 288): (0, 48).
-        // Player screen top-left = (288, 240); centre = (312, 264).
+        // The player is at (6, 6) tiles (= 288 px). The camera origin for a 640×480 view is
+        // (0, 1) tiles (= 48 px), so the player screen top-left = (288, 240); centre = (312, 264).
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, frame: 1);
@@ -131,7 +133,7 @@ public class SampleSceneTests
         using var fixtures = FixtureAssets.MaterializeToTempDirectory();
         var engine = SampleScene.Create(fixtures.Root);
 
-        // Villager world (144, 192) → screen (144, 144); centre (168, 168).
+        // Villager world (3, 4) tiles = (144, 192) px → screen (144, 144); centre (168, 168).
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
         // Parts drawn: hair2 (absent), face (seed 3), body (seed 2), hair1 (seed 4, on top).
@@ -146,7 +148,7 @@ public class SampleSceneTests
         using var fixtures = FixtureAssets.MaterializeToTempDirectory();
         var engine = SampleScene.Create(fixtures.Root);
 
-        // Guard world (528, 384) → screen (528, 336); centre (552, 360).
+        // Guard world (11, 8) tiles = (528, 384) px → screen (528, 336); centre (552, 360).
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
         // Parts drawn: face (seed 3), body (seed 2), armour (seed 7), head (seed 8, on top).


### PR DESCRIPTION
Closes #37

## Summary

Switches the engine's world-coordinate unit from pixels to **tiles** (double), as mandated by the epic. A pixel position like 408 becomes **8.5** tiles at the 48 px tile size. Character speeds, camera math, clamping, movement and rendering were adapted, and the engine now exposes functions translating host-surface (canvas) coordinates to game world coordinates and back.

## Changes

### `Position`
- `X`/`Y` are now tile coordinates (double); XML docs updated.
- `ToTile(int tileSize)` → `ToTile()` — floors the tile-unit position to the containing cell (`(8.5, 8.5) → (8, 8)`, `(-1.5, -1.5) → (-2, -2)`).
- New `ToPixels(int tileSize)` — `(X * tileSize, Y * tileSize)`, throws `ArgumentOutOfRangeException` when `tileSize <= 0`.

### `Character`
- `BaseSpeed` is now in tiles per second; `AnimationCycleSpeed` default is **2** (matches `Player.DefaultBaseSpeed`), so `BaseSpeed == AnimationCycleSpeed == 2` keeps 1 cycle/s.
- `GetSpriteSize` still returns pixels; the engine converts to tiles when clamping.

### `Player`
- `DefaultBaseSpeed` is now **2** (tiles/s), the tile-unit equivalent of the previous 96 px/s with 48 px tiles.

### `GameEngine`
- `ComputeCameraOrigin` returns the camera origin in **tiles** (formulas per spec, `ts = Map.TileWidth`, default 48).
- `ClampPlayerToMap` clamps in tile units (sprite size converted from pixels).
- `Render` builds the pixel viewport from the tile origin (`origin * ts`), draws characters at screen `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`, and records `_lastCanvasWidth`/`_lastCanvasHeight` from the canvas clip bounds for the future click-to-move story.
- New public `SurfaceToWorld` / `WorldToSurface` (camera-aware, inverses within floating-point tolerance).

### Tests, samples & docs
- Updated `PositionTests`, `CharacterTests`, `PlayerTests`, `GameEngineTests`, `DocsExamplesTests`, `SampleSceneTests` and both sample hosts to tile units, with new acceptance-criteria tests:
  - `Player.DefaultBaseSpeed == 2`, holding W for 1 s moves up 2 tiles.
  - Camera origins `(0,0)/(5,5)/(2,2)` for the 10×10 map / 240×240 canvas contract.
  - `ToTile()`/`ToPixels(48)` floor/multiply correctly.
  - `SurfaceToWorld`/`WorldToSurface` are inverses within 1e-9 (`SurfaceToWorld(408, 408, 960, 960) == (8.5, 8.5)`).
  - `Player.Position = (8.5, 8.5)` with origin `(0,0)` renders the sprite at 408 px (pixel assertion).
- Updated `docs/api/Position.md`, `Character.md`, `Player.md`, `GameEngine.md` (and `Vector2.md`), `docs/Architecture.md` and `docs/README.md` to tile units with the new members documented.

## Verification
- `dotnet build -c Release`: 0 warnings, 0 errors (CS1591 enforced).
- `dotnet test tests/RPGEngine.Tests -c Release`: 269/269 green.
- Acceptance filter (`PositionTests|CharacterTests|PlayerTests|GameEngineTests|DocsExamplesTests`): 103/103 green.