### PR TITLE
Story 40: A* tile pathfinding (internal component)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -221,6 +221,26 @@ so at `BaseSpeed == AnimationCycleSpeed == 2` (both in tiles/s, the defaults) on
 doubles the cycle rate; raising `AnimationCycleSpeed` (the reference speed) slows the animation
 relative to movement speed.
 
+## Pathfinding
+
+Click-to-move (next story) needs to walk a character from its current tile to a clicked tile. The
+engine's pathfinding is **tile-based** — it plans over integer tile coordinates, never
+pixel-by-pixel — so it stays cheap and independent of the renderer.
+
+`AStarPathfinder` (an **internal** static class in `RPGEngine`) exposes
+`FindPath(start, goal, isWalkable, width, height)`, which returns the ordered tiles from `start`
+(exclusive) to `goal` (inclusive), or an empty list when no path exists (including when start and
+goal coincide, or the start/goal is blocked or out of bounds). It is deliberately decoupled from
+`TileMap`: callers supply an `isWalkable(x, y)` predicate (the click-to-move story wires it to
+`TileMap` solidity), so the algorithm is unit-testable without rendering. It adds no public API.
+
+Movement is **8-direction** (cardinal + diagonal). A cardinal step costs `1`, a diagonal step costs
+`√2`, and **corner cutting is prevented**: a diagonal step `(±1, ±1)` is allowed only when both
+orthogonally adjacent cells are walkable. The heuristic is the **octile distance**
+(`max(|dx|, |dy|) + (√2 − 1) · min(|dx|, |dy|)`), which is consistent, so the returned path is
+optimal. The open set is a `PriorityQueue` keyed by `f = g + h`, and a tile is re-opened only when
+a strictly better `g` is found.
+
 ## Rendering
 
 `GameEngine.Render(canvas, dt)` draws a single frame in a fixed order:

--- a/src/RPGEngine/Core/AStarPathfinder.cs
+++ b/src/RPGEngine/Core/AStarPathfinder.cs
@@ -1,0 +1,186 @@
+namespace RPGEngine;
+
+/// <summary>
+/// Tile-based A* pathfinding over a caller-supplied walkability predicate.
+/// </summary>
+/// <remarks>
+/// The engine moves tile-by-tile, never pixel-by-pixel, so pathfinding operates purely on
+/// integer tile coordinates. The class is <c>internal</c> and has no dependencies on
+/// <c>TileMap</c> or SkiaSharp: the click-to-move story wires the <c>isWalkable</c> predicate to
+/// <c>TileMap</c> solidity. Movement is 8-direction (cardinal cost 1, diagonal cost √2) with
+/// corner cutting prevented, and the octile heuristic is consistent, so returned paths are
+/// optimal.
+/// </remarks>
+internal static class AStarPathfinder
+{
+    /// <summary>Cost of a cardinal (orthogonal) step.</summary>
+    private const double CardinalCost = 1.0;
+
+    /// <summary>Cost of a diagonal step (√2).</summary>
+    private static readonly double DiagonalCost = Math.Sqrt(2);
+
+    /// <summary>
+    /// The eight neighbor deltas in a fixed order (cardinal then diagonal) so that expansion is
+    /// deterministic and results are stable across runs.
+    /// </summary>
+    private static readonly (int DX, int DY)[] NeighborDeltas =
+    {
+        (1, 0), (-1, 0), (0, 1), (0, -1),
+        (1, 1), (1, -1), (-1, 1), (-1, -1),
+    };
+
+    /// <summary>
+    /// Finds an optimal 8-direction path from <paramref name="start"/> (exclusive) to
+    /// <paramref name="goal"/> (inclusive) on a <paramref name="width"/> ×
+    /// <paramref name="height"/> tile grid.
+    /// </summary>
+    /// <param name="start">The starting tile (not included in the result).</param>
+    /// <param name="goal">The goal tile (included in the result).</param>
+    /// <param name="isWalkable">
+    /// Predicate deciding whether a tile is passable; out-of-bounds tiles are always treated as
+    /// not walkable regardless of the predicate.
+    /// </param>
+    /// <param name="width">Grid width in tiles.</param>
+    /// <param name="height">Grid height in tiles.</param>
+    /// <returns>
+    /// The ordered list of tiles from <paramref name="start"/> (exclusive) to <paramref name="goal"/>
+    /// (inclusive), or an empty list when no movement is needed, the start or goal is not walkable
+    /// (including out of bounds), or no path exists.
+    /// </returns>
+    internal static IReadOnlyList<(int X, int Y)> FindPath(
+        (int X, int Y) start,
+        (int X, int Y) goal,
+        Func<int, int, bool> isWalkable,
+        int width,
+        int height)
+    {
+        // No movement is needed when start and goal coincide.
+        if (start == goal)
+        {
+            return Array.Empty<(int X, int Y)>();
+        }
+
+        // A path can neither begin nor end on a tile that cannot be stood on (out-of-bounds tiles
+        // are never walkable).
+        if (!IsWalkable(goal.X, goal.Y, isWalkable, width, height) ||
+            !IsWalkable(start.X, start.Y, isWalkable, width, height))
+        {
+            return Array.Empty<(int X, int Y)>();
+        }
+
+        // gScore[tile] is the best known cost from start to tile.
+        var gScore = new Dictionary<(int X, int Y), double> { [start] = 0.0 };
+
+        // cameFrom[tile] is the predecessor on the best known path; used to reconstruct the result.
+        var cameFrom = new Dictionary<(int X, int Y), (int X, int Y)>();
+
+        // Open set ordered by f = g + h (octile). A tile may be enqueued more than once: it is only
+        // re-enqueued when a strictly better g is found. Because the heuristic is consistent, the
+        // first time a tile is dequeued its g is optimal, so the closed set below simply skips stale
+        // duplicate entries that carry an equal-or-worse g.
+        var open = new PriorityQueue<(int X, int Y), double>();
+        var closed = new HashSet<(int X, int Y)>();
+        open.Enqueue(start, Heuristic(start, goal));
+
+        while (open.Count > 0)
+        {
+            var current = open.Dequeue();
+
+            if (current == goal)
+            {
+                return ReconstructPath(cameFrom, start, goal);
+            }
+
+            if (!closed.Add(current))
+            {
+                // Stale duplicate entry; this tile was already expanded with its optimal g.
+                continue;
+            }
+
+            double currentG = gScore[current];
+            foreach ((int DX, int DY) in NeighborDeltas)
+            {
+                (int X, int Y) neighbor = (current.X + DX, current.Y + DY);
+
+                // Blocked and out-of-bounds tiles are not walkable.
+                if (!IsWalkable(neighbor.X, neighbor.Y, isWalkable, width, height))
+                {
+                    continue;
+                }
+
+                // Prevent corner cutting: a diagonal step may only pass through the corner when both
+                // orthogonally adjacent cells are walkable.
+                if (DX != 0 && DY != 0 &&
+                    (!IsWalkable(current.X + DX, current.Y, isWalkable, width, height) ||
+                     !IsWalkable(current.X, current.Y + DY, isWalkable, width, height)))
+                {
+                    continue;
+                }
+
+                double stepCost = DX != 0 && DY != 0 ? DiagonalCost : CardinalCost;
+                double tentativeG = currentG + stepCost;
+
+                // Re-open a tile only when a strictly better g is found.
+                if (gScore.TryGetValue(neighbor, out double knownG) && tentativeG >= knownG)
+                {
+                    continue;
+                }
+
+                gScore[neighbor] = tentativeG;
+                cameFrom[neighbor] = current;
+                open.Enqueue(neighbor, tentativeG + Heuristic(neighbor, goal));
+            }
+        }
+
+        // The open set was exhausted without reaching the goal: no path exists.
+        return Array.Empty<(int X, int Y)>();
+    }
+
+    /// <summary>
+    /// Reconstructs the path by walking parents from <paramref name="goal"/> back to
+    /// <paramref name="start"/> (exclusive), then reversing so the result is
+    /// start-exclusive → goal-inclusive.
+    /// </summary>
+    private static IReadOnlyList<(int X, int Y)> ReconstructPath(
+        Dictionary<(int X, int Y), (int X, int Y)> cameFrom,
+        (int X, int Y) start,
+        (int X, int Y) goal)
+    {
+        var path = new List<(int X, int Y)>();
+        var current = goal;
+        while (current != start)
+        {
+            path.Add(current);
+            current = cameFrom[current];
+        }
+
+        path.Reverse();
+        return path;
+    }
+
+    /// <summary>
+    /// Returns whether the tile is passable according to <paramref name="isWalkable"/>;
+    /// out-of-bounds tiles are never walkable.
+    /// </summary>
+    private static bool IsWalkable(int x, int y, Func<int, int, bool> isWalkable, int width, int height)
+    {
+        if (x < 0 || y < 0 || x >= width || y >= height)
+        {
+            return false;
+        }
+
+        return isWalkable(x, y);
+    }
+
+    /// <summary>
+    /// Octile distance: <c>max(|dx|, |dy|) + (√2 − 1) · min(|dx|, |dy|)</c>. This is the exact
+    /// movement cost on an unobstructed 8-direction grid and is consistent, so A* returns optimal
+    /// paths.
+    /// </summary>
+    private static double Heuristic((int X, int Y) from, (int X, int Y) to)
+    {
+        int dx = Math.Abs(from.X - to.X);
+        int dy = Math.Abs(from.Y - to.Y);
+        return Math.Max(dx, dy) + (DiagonalCost - CardinalCost) * Math.Min(dx, dy);
+    }
+}

--- a/tests/RPGEngine.Tests/Core/AStarPathfinderTests.cs
+++ b/tests/RPGEngine.Tests/Core/AStarPathfinderTests.cs
@@ -1,0 +1,332 @@
+using RPGEngine;
+using Xunit;
+
+namespace RPGEngine.Tests.Core;
+
+/// <summary>
+/// Acceptance tests for <see cref="AStarPathfinder"/> (story 40: A* tile pathfinding, internal).
+/// </summary>
+public class AStarPathfinderTests
+{
+    // ---------------------------------------------------------------------
+    // Acceptance 1: straight line on an open grid.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies a straight horizontal run on an open 10×10 grid returns the expected tiles,
+    /// excluding the start and including the goal.
+    /// </summary>
+    [Fact]
+    public void FindPath_OpenGrid_StraightLine_ReturnsExpectedPath()
+    {
+        var path = AStarPathfinder.FindPath((0, 0), (3, 0), AlwaysWalkable, 10, 10);
+
+        Assert.Equal(new[] { (1, 0), (2, 0), (3, 0) }, path);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 2: an L-shaped wall forces a valid detour.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies an L-shaped wall blocks the direct route and the returned path is valid (every
+    /// step walkable, adjacent by the 8-neighborhood, no corner cutting) and ends at the goal.
+    /// </summary>
+    [Fact]
+    public void FindPath_LShapedWall_DetoursAroundWall()
+    {
+        // Wall cells: (2,0), (3,0), (2,1), (2,2) — an L that blocks the direct row-0 route.
+        string[] map =
+        {
+            "..##.",
+            "..#..",
+            "..#..",
+            ".....",
+            ".....",
+        };
+        var start = (0, 0);
+        var goal = (4, 0);
+        var isWalkable = MapWalkability(map);
+
+        var path = AStarPathfinder.FindPath(start, goal, isWalkable, width: 5, height: 5);
+
+        AssertValidPath(path, start, goal, isWalkable, 5, 5);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 3: a U-shaped (fully enclosing) obstacle makes the goal unreachable.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies a wall ring with no opening enclosing the goal yields an empty path.
+    /// </summary>
+    [Fact]
+    public void FindPath_EnclosedGoal_ReturnsEmpty()
+    {
+        // The goal (3,3) sits inside a closed wall ring; there is no opening to reach it.
+        string[] map =
+        {
+            ".......",
+            ".#####.",
+            ".#...#.",
+            ".#...#.",
+            ".#...#.",
+            ".#####.",
+            ".......",
+        };
+        var start = (0, 0);
+        var goal = (3, 3);
+
+        var path = AStarPathfinder.FindPath(start, goal, MapWalkability(map), width: 7, height: 7);
+
+        Assert.Empty(path);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 4: start == goal needs no movement.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a zero-length request returns an empty path.</summary>
+    [Fact]
+    public void FindPath_StartEqualsGoal_ReturnsEmpty()
+    {
+        var path = AStarPathfinder.FindPath((2, 2), (2, 2), AlwaysWalkable, 10, 10);
+
+        Assert.Empty(path);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5: a solid (or out-of-bounds) goal has no path.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a blocked goal tile yields an empty path.</summary>
+    [Fact]
+    public void FindPath_GoalBlocked_ReturnsEmpty()
+    {
+        // (2,1) is a wall tile and is the requested goal.
+        string[] map =
+        {
+            ".....",
+            "..#..",
+            ".....",
+            ".....",
+            ".....",
+        };
+
+        var path = AStarPathfinder.FindPath((0, 0), (2, 1), MapWalkability(map), width: 5, height: 5);
+
+        Assert.Empty(path);
+    }
+
+    /// <summary>Verifies an out-of-bounds goal yields an empty path (never throws).</summary>
+    [Theory]
+    [InlineData(10, 0)]
+    [InlineData(0, 10)]
+    [InlineData(-1, 0)]
+    [InlineData(0, -1)]
+    public void FindPath_GoalOutOfBounds_ReturnsEmpty(int goalX, int goalY)
+    {
+        var path = AStarPathfinder.FindPath((0, 0), (goalX, goalY), AlwaysWalkable, 10, 10);
+
+        Assert.Empty(path);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 6: a direct diagonal on an open grid.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies (0,0) → (2,2) on an open grid walks straight diagonally.</summary>
+    [Fact]
+    public void FindPath_OpenGrid_Diagonal_ReturnsDirectDiagonalPath()
+    {
+        var path = AStarPathfinder.FindPath((0, 0), (2, 2), AlwaysWalkable, 10, 10);
+
+        Assert.Equal(new[] { (1, 1), (2, 2) }, path);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 7: corner cutting around a blocked tile is prevented.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies that with (1,1) blocked the path from (0,0) to (2,2) detours orthogonally instead
+    /// of cutting the corner — no diagonal step is possible without passing the blocked cell.
+    /// </summary>
+    [Fact]
+    public void FindPath_BlockedCorner_PreventsCornerCutting()
+    {
+        string[] map =
+        {
+            "...",
+            ".#.",
+            "...",
+        };
+        var start = (0, 0);
+        var goal = (2, 2);
+        var isWalkable = MapWalkability(map);
+
+        var path = AStarPathfinder.FindPath(start, goal, isWalkable, width: 3, height: 3);
+
+        AssertValidPath(path, start, goal, isWalkable, 3, 3);
+        Assert.DoesNotContain((1, 1), path);
+        AssertNoDiagonalSteps(path, start);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 8: determinism and optimality on a grid with two equal-length routes.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies that with (1,1) blocked there are two equal-length routes of cost 4, that running
+    /// the search twice returns the exact same list, and that the returned path is minimal.
+    /// </summary>
+    [Fact]
+    public void FindPath_TwoEqualLengthRoutes_IsDeterministicAndOptimal()
+    {
+        string[] map =
+        {
+            "...",
+            ".#.",
+            "...",
+        };
+        var start = (0, 0);
+        var goal = (2, 2);
+        var isWalkable = MapWalkability(map);
+
+        var first = AStarPathfinder.FindPath(start, goal, isWalkable, width: 3, height: 3);
+        var second = AStarPathfinder.FindPath(start, goal, isWalkable, width: 3, height: 3);
+
+        // Deterministic: both runs return the exact same list.
+        Assert.Equal(first, second);
+        AssertValidPath(first, start, goal, isWalkable, 3, 3);
+
+        // Optimal: every route around the blocked corner costs exactly 4 (all cardinal steps).
+        Assert.Equal(4.0, PathCost(first, start), precision: 6);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 9: out-of-bounds start/goal handling never throws.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies an out-of-bounds start yields an empty path (never throws).</summary>
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, -1)]
+    [InlineData(10, 0)]
+    [InlineData(0, 10)]
+    public void FindPath_StartOutOfBounds_ReturnsEmpty(int startX, int startY)
+    {
+        var path = AStarPathfinder.FindPath((startX, startY), (5, 5), AlwaysWalkable, 10, 10);
+
+        Assert.Empty(path);
+    }
+
+    /// <summary>Verifies wildly out-of-bounds start and goal return empty without throwing.</summary>
+    [Fact]
+    public void FindPath_OutOfBoundsStartAndGoal_ReturnsEmptyWithoutThrowing()
+    {
+        var path = AStarPathfinder.FindPath((-5, -5), (99, 99), AlwaysWalkable, 10, 10);
+
+        Assert.Empty(path);
+    }
+
+    /// <summary>Verifies an out-of-bounds start equal to an out-of-bounds goal returns empty.</summary>
+    [Fact]
+    public void FindPath_StartEqualsGoalOutOfBounds_ReturnsEmptyWithoutThrowing()
+    {
+        var path = AStarPathfinder.FindPath((99, 99), (99, 99), AlwaysWalkable, 10, 10);
+
+        Assert.Empty(path);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// <summary>A walkability predicate over a fully open grid.</summary>
+    private static bool AlwaysWalkable(int x, int y) => true;
+
+    /// <summary>
+    /// Builds a walkability predicate from a string map where <c>'.'</c> is walkable and any other
+    /// character is blocked. Row 0 is y = 0, so <c>map[y][x]</c> is the tile at (x, y).
+    /// </summary>
+    private static Func<int, int, bool> MapWalkability(string[] map) =>
+        (x, y) => map[y][x] == '.';
+
+    /// <summary>
+    /// Asserts <paramref name="path"/> is a valid start-exclusive → goal-inclusive route: every
+    /// tile is walkable and in bounds, each step is an 8-neighbor move, and no diagonal step cuts a
+    /// corner (both orthogonally adjacent cells are walkable).
+    /// </summary>
+    private static void AssertValidPath(
+        IReadOnlyList<(int X, int Y)> path,
+        (int X, int Y) start,
+        (int X, int Y) goal,
+        Func<int, int, bool> isWalkable,
+        int width,
+        int height)
+    {
+        Assert.NotEmpty(path);
+        Assert.Equal(goal, path[^1]);
+
+        var previous = start;
+        foreach (var tile in path)
+        {
+            Assert.True(IsWalkable(tile, isWalkable, width, height), $"tile ({tile.X}, {tile.Y}) must be walkable");
+
+            int dx = tile.X - previous.X;
+            int dy = tile.Y - previous.Y;
+            int adx = Math.Abs(dx);
+            int ady = Math.Abs(dy);
+
+            // Each step must be a single 8-neighbor move (never a jump or a self-loop).
+            Assert.True(
+                adx <= 1 && ady <= 1 && adx + ady >= 1,
+                $"step from ({previous.X}, {previous.Y}) to ({tile.X}, {tile.Y}) is not an 8-neighbor move");
+
+            // Diagonal steps must not cut corners.
+            if (adx == 1 && ady == 1)
+            {
+                Assert.True(
+                    IsWalkable((previous.X + dx, previous.Y), isWalkable, width, height) &&
+                    IsWalkable((previous.X, previous.Y + dy), isWalkable, width, height),
+                    $"diagonal step to ({tile.X}, {tile.Y}) cuts a corner");
+            }
+
+            previous = tile;
+        }
+    }
+
+    /// <summary>Asserts the path uses only cardinal steps (no diagonals) from the given start.</summary>
+    private static void AssertNoDiagonalSteps(IReadOnlyList<(int X, int Y)> path, (int X, int Y) start)
+    {
+        var previous = start;
+        foreach (var tile in path)
+        {
+            int dx = Math.Abs(tile.X - previous.X);
+            int dy = Math.Abs(tile.Y - previous.Y);
+            Assert.True(
+                dx + dy == 1,
+                $"path uses a diagonal step to ({tile.X}, {tile.Y}) instead of detouring orthogonally");
+            previous = tile;
+        }
+    }
+
+    /// <summary>Computes the sum of step costs (1 cardinal, √2 diagonal) from start through path.</summary>
+    private static double PathCost(IReadOnlyList<(int X, int Y)> path, (int X, int Y) start)
+    {
+        double cost = 0;
+        var previous = start;
+        foreach (var tile in path)
+        {
+            int dx = Math.Abs(tile.X - previous.X);
+            int dy = Math.Abs(tile.Y - previous.Y);
+            cost += dx == 1 && dy == 1 ? Math.Sqrt(2) : 1.0;
+            previous = tile;
+        }
+
+        return cost;
+    }
+
+    /// <summary>Returns whether the tile is in bounds and walkable.</summary>
+    private static bool IsWalkable((int X, int Y) tile, Func<int, int, bool> isWalkable, int width, int height)
+    {
+        if (tile.X < 0 || tile.Y < 0 || tile.X >= width || tile.Y >= height)
+        {
+            return false;
+        }
+
+        return isWalkable(tile.X, tile.Y);
+    }
+}


### PR DESCRIPTION
Closes #40

## Summary

Implements the A* tile pathfinding algorithm as a small, internal, unit-testable component for the click-to-move story.

### What changed

- **`src/RPGEngine/Core/AStarPathfinder.cs`** — new `internal static class AStarPathfinder` with `FindPath(start, goal, isWalkable, width, height)`:
  - Tile-by-tile planning (never pixel-by-pixel); takes a generic `isWalkable(x, y)` predicate so it is independent of `TileMap`/SkiaSharp and trivially testable.
  - Out-of-bounds tiles are always treated as not walkable.
  - `start == goal` → empty; unreachable/non-walkable/out-of-bounds goal (or start) → empty; no path → empty; otherwise returns start-exclusive → goal-inclusive tiles.
  - 8-direction movement: cardinal cost 1, diagonal cost √2, no corner cutting (diagonals require both orthogonal cells walkable).
  - Octile-distance heuristic (consistent → optimal results).
  - `PriorityQueue<(int X, int Y), double>` open set + `Dictionary` g-score + parent map; tiles are re-opened only on a strictly better `g`. Fixed neighbor order and no per-neighbor closures keep it deterministic and allocation-light.
  - No public API added (internal + existing `InternalsVisibleTo`).

- **`tests/RPGEngine.Tests/Core/AStarPathfinderTests.cs`** — new acceptance tests covering all 9 automatable criteria:
  1. Straight line `(0,0)→(3,0)` returns `[(1,0),(2,0),(3,0)]`.
  2. L-shaped wall forces a valid detour (every step walkable, 8-adjacent, no corner cutting, ends at goal).
  3. Fully enclosed (U-shaped) goal → empty.
  4. `start == goal` → empty.
  5. Blocked / out-of-bounds goal → empty.
  6. Open-grid diagonal `(0,0)→(2,2)` returns `[(1,1),(2,2)]`.
  7. Corner cutting prevented with `(1,1)` blocked — path detours orthogonally, no diagonal steps.
  8. Determinism (two equal-length routes, run twice → same list) and optimality (path cost is minimal for the hand-verified maze).
  9. Out-of-bounds start/goal never throws and returns empty where appropriate.

- **`docs/Architecture.md`** — added a short "Pathfinding" section describing the tile-based A* model (8-direction, no corner cutting, octile heuristic) and that it is internal to the engine.

### Verification

```
dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~AStarPathfinderTests"
```
→ 18 passed. Full suite: 287 passed, 0 failed. Release build: 0 warnings / 0 errors.

Click-to-move integration, `TileMap.IsSolid` wiring, path smoothing, and exposing A* as public API are intentionally out of scope (next stories).