### PR TITLE
Story 34: SpriteSheetExists on GameEngine

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,9 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 
 > The synchronous, file-system based equivalents (`TileMap.Load(path)`, `LoadSpriteSheet(name,
 > path)`) are what the desktop sample host uses; both loading styles exercise the same rendering
-> pipeline.
+> pipeline. Before loading, hosts can check whether a name is already registered with
+> `SpriteSheetExists(name)` — it covers both full and part sheets and is case-sensitive and
+> trimmed.
 >
 > **Map ownership:** a `TileMap` is `IDisposable` — it prerenders every visible tile layer into
 > an `SKImage` on load. The engine owns the assigned map: replacing `engine.Map` disposes the
@@ -103,7 +105,7 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 | Page | What it covers |
 | --- | --- |
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering, rendering order and the Tiled read model. |
-| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async), camera, black background / map centering, map ownership (`IDisposable`). |
+| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, map ownership (`IDisposable`). |
 | [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references and the speed-scaled walk-cycle animation (`AnimationCycleSpeed`). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -241,6 +241,33 @@ using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/charact
 await engine.LoadPartSpriteSheetAsync("villager_body", stream, CharacterPartType.Body);
 ```
 
+### `bool SpriteSheetExists(string name)`
+
+Returns whether a spritesheet is registered under `name`. Full sheets (loaded with
+`LoadSpriteSheet`) and part sheets (loaded with `LoadPartSpriteSheet`) share one registry, so
+both are visible to this check — it is the safe way to test whether a name is already in use
+without catching the `KeyNotFoundException` thrown by the render path. The check is
+case-sensitive and trims surrounding whitespace from `name` before the lookup, matching how
+sheets are registered; a `null` name throws `ArgumentNullException`.
+
+```csharp
+// false before loading, true after: full sheets are visible to the check.
+engine.LoadSpriteSheet("hero", "assets/characters/character_full.png");
+var hasHero = engine.SpriteSheetExists("hero"); // true
+var hasVillager = engine.SpriteSheetExists("villager"); // false
+
+// Part sheets are visible too: a "hair" part sheet registers under "hair".
+engine.LoadPartSpriteSheet("hair", "assets/characters/character_part_hair1.png", CharacterPartType.Hair1);
+var hasHair = engine.SpriteSheetExists("hair"); // true
+
+// Case-sensitive and trimmed: "Hero" is not "hero", but " hero " is.
+var hasHeroDifferentCase = engine.SpriteSheetExists("Hero"); // false
+var hasHeroTrimmed = engine.SpriteSheetExists(" hero ");     // true
+
+// null throws ArgumentNullException.
+engine.SpriteSheetExists(null); // ArgumentNullException
+```
+
 ## Full example ("hello world")
 
 ```csharp

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -445,6 +445,25 @@ public sealed class GameEngine : IDisposable
         => _spriteSheetManager.LoadPartAsync(name, stream, partType);
 
     /// <summary>
+    /// Returns whether a spritesheet is registered under <paramref name="name"/>. Full sheets
+    /// (loaded with <see cref="LoadSpriteSheet(string, Stream)"/>) and part sheets (loaded with
+    /// <see cref="LoadPartSpriteSheet(string, Stream, CharacterPartType)"/>) share one registry,
+    /// so both are visible to this check. This is the safe way to test whether a name is already
+    /// in use without catching the <see cref="KeyNotFoundException"/> thrown by the render path.
+    /// </summary>
+    /// <param name="name">The name of the sheet to look up.</param>
+    /// <returns>
+    /// <see langword="true"/> if a full or part sheet is registered under <paramref name="name"/>;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// The check is case-sensitive and trims surrounding whitespace from <paramref name="name"/>
+    /// before the lookup, matching how sheets are registered.
+    /// </remarks>
+    public bool SpriteSheetExists(string name) => _spriteSheetManager.Contains(name);
+
+    /// <summary>
     /// Computes the camera origin: the world position (in tiles) that maps to the canvas' top-left
     /// corner. Let <c>ts</c> be the map's tile width. The desired origin centers the player
     /// (<c>desired = player.Position - (canvasWidth / (2*ts), canvasHeight / (2*ts))</c>); it is

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -255,6 +255,88 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 34: SpriteSheetExists reports whether a full or part sheet is
+    // registered under a name, without touching the render path. The check
+    // is case-sensitive, trims surrounding whitespace, and a null name
+    // throws ArgumentNullException.
+    // ---------------------------------------------------------------------
+
+    /// <summary>Verifies SpriteSheetExists returns false before a full sheet is loaded and true after LoadSpriteSheet.</summary>
+    [Fact]
+    public void SpriteSheetExists_FullSheet_ReflectsLoadState()
+    {
+        var engine = new GameEngine();
+
+        Assert.False(engine.SpriteSheetExists("hero"));
+
+        using (var stream = CharacterTestHelper.CreateSheetStream(0))
+        {
+            engine.LoadSpriteSheet("hero", stream);
+        }
+
+        Assert.True(engine.SpriteSheetExists("hero"));
+    }
+
+    /// <summary>Verifies SpriteSheetExists returns true after a part sheet is loaded (part sheets share the registry).</summary>
+    [Fact]
+    public void SpriteSheetExists_PartSheet_ReturnsTrue()
+    {
+        var engine = new GameEngine();
+        using (var stream = CharacterTestHelper.CreateSheetStream(1))
+        {
+            engine.LoadPartSpriteSheet("hair", stream, CharacterPartType.Hair1);
+        }
+
+        Assert.True(engine.SpriteSheetExists("hair"));
+    }
+
+    /// <summary>Verifies SpriteSheetExists returns false for a name that was never loaded.</summary>
+    [Fact]
+    public void SpriteSheetExists_UnknownName_ReturnsFalse()
+    {
+        var engine = new GameEngine();
+
+        Assert.False(engine.SpriteSheetExists("missing"));
+    }
+
+    /// <summary>Verifies the check is case-sensitive: after loading "hero", "Hero" is not found.</summary>
+    [Fact]
+    public void SpriteSheetExists_DifferentCase_ReturnsFalse()
+    {
+        var engine = new GameEngine();
+        using (var stream = CharacterTestHelper.CreateSheetStream(0))
+        {
+            engine.LoadSpriteSheet("hero", stream);
+        }
+
+        Assert.True(engine.SpriteSheetExists("hero"));
+        Assert.False(engine.SpriteSheetExists("Hero"));
+    }
+
+    /// <summary>Verifies surrounding whitespace is trimmed before the lookup, matching how sheets are registered.</summary>
+    [Fact]
+    public void SpriteSheetExists_SurroundingWhitespace_IsTrimmed()
+    {
+        var engine = new GameEngine();
+        using (var stream = CharacterTestHelper.CreateSheetStream(0))
+        {
+            engine.LoadSpriteSheet("hero", stream);
+        }
+
+        Assert.True(engine.SpriteSheetExists(" hero "));
+        Assert.True(engine.SpriteSheetExists("\thero\n"));
+    }
+
+    /// <summary>Verifies SpriteSheetExists(null) throws ArgumentNullException.</summary>
+    [Fact]
+    public void SpriteSheetExists_NullName_ThrowsArgumentNullException()
+    {
+        var engine = new GameEngine();
+
+        Assert.Throws<ArgumentNullException>(() => engine.SpriteSheetExists(null!));
+    }
+
+    // ---------------------------------------------------------------------
     // Async loading (story 22): the engine's LoadSpriteSheetAsync /
     // LoadPartSpriteSheetAsync delegate to the sprite sheet manager and must
     // work with streams that only support asynchronous reads.


### PR DESCRIPTION
## Summary

Adds `bool SpriteSheetExists(string name)` to `GameEngine` so users can check whether a spritesheet (full **or** part) is already registered under a given name, without catching `KeyNotFoundException` from the render path.

Closes #34.

## Changes

- **`src/RPGEngine/GameEngine.cs`**: New `public bool SpriteSheetExists(string name)` delegating to the existing `_spriteSheetManager.Contains(name)`, placed next to the spritesheet loading API. Fully XML-documented: full and part sheets are both visible (shared registry), the check is case-sensitive and trims the name, and `null` throws `ArgumentNullException` (delegated).
- **`tests/RPGEngine.Tests/GameEngineTests.cs`**: Six new test cases next to the existing `LoadSpriteSheet` tests covering every acceptance criterion:
  - `SpriteSheetExists_FullSheet_ReflectsLoadState` — false before load, true after `LoadSpriteSheet` (full sheet).
  - `SpriteSheetExists_PartSheet_ReturnsTrue` — true after `LoadPartSpriteSheet("hair", …, CharacterPartType.Hair1)`.
  - `SpriteSheetExists_UnknownName_ReturnsFalse`.
  - `SpriteSheetExists_DifferentCase_ReturnsFalse` — `"Hero"` ≠ `"hero"`.
  - `SpriteSheetExists_SurroundingWhitespace_IsTrimmed`.
  - `SpriteSheetExists_NullName_ThrowsArgumentNullException`.
- **`docs/api/GameEngine.md`**: Documents `SpriteSheetExists` with a commented, compilable example.
- **`docs/README.md`**: Mentions `SpriteSheetExists` in the asset-loading note and in the reading-order table (no structural change).

## Verification

- `dotnet build -c Release` → 0 warnings, 0 errors.
- `dotnet test tests/RPGEngine.Tests -c Release` → 293 passed (287 baseline + 6 new), 0 failed.
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~GameEngineTests"` → 31 passed, 0 failed.