### PR TITLE
Story 35: Map collisions — is_collision layers and solid-tile movement blocking

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -109,7 +109,8 @@ The map exposes a read-only view of everything the Tiled file declares:
 - `TileMap.Layers` — the **tile layers** only, in file order (bottom → top). Each
   `TileMapLayer` exposes its `Name`, `Visible`, `Opacity`, `TileIds`/`GetTileId`, the
   `AbovePlayer` flag (a layer whose `above_player` boolean custom property is `true` is
-  rendered **after** the player) and its own custom `Properties`.
+  rendered **after** the player), the `IsCollision` flag (a layer whose `is_collision` boolean
+  custom property is `true` contains solid tiles) and its own custom `Properties`.
 - `TileMap.Properties` / `TileMap.GetProperty(name)` — the **map's custom properties**,
   looked up case-sensitively. Properties are typed (`MapPropertyType`: bool/int/float/string/
   color/file/object/class) and boxed into C# values by `MapProperty`.
@@ -220,6 +221,40 @@ so at `BaseSpeed == AnimationCycleSpeed == 2` (both in tiles/s, the defaults) on
 0.25 s and the cycle completes exactly **once per second** (4 frames/s). Doubling `BaseSpeed`
 doubles the cycle rate; raising `AnimationCycleSpeed` (the reference speed) slows the animation
 relative to movement speed.
+
+## Collision
+
+Tile maps can declare **collision layers**: a tile layer whose custom boolean property
+`is_collision` is set to `true` (Tiled convention, mirroring `above_player`) contains **solid**
+tiles that Characters (including the player) cannot walk through. `TileMapLayer.IsCollision`
+surfaces the flag, and `TileMap.IsSolid(tileX, tileY)` returns `true` when *any* collision layer
+has a non-empty tile (GID != 0) at that cell. The **map edge is solid**: `IsSolid` returns
+`true` for out-of-bounds coordinates, so characters cannot leave the map through its edge. When
+a map has no collision layer, every in-bounds cell is walkable. Non-collision layers never block
+(a tile drawn from a normal layer is walkable even if it visually overlaps the character).
+
+The engine resolves the player's movement with **axis-separated movement** against a footprint
+in tile units:
+
+- The footprint is the player's sprite size in pixels (`Character.GetSpriteSize`) converted to
+  tiles (`px / ts`, where `ts` is the map's tile width), positioned at the player's top-left.
+- `TileMap.IsAreaSolid(x, y, width, height)` (internal) tests the tiles overlapped by that
+  tile-unit rectangle: the bounds are floored to the containing cells, and a rectangle that ends
+  exactly on a tile boundary does not count the next tile.
+- Each frame the engine applies the **X displacement first**, then reverts it if the resulting
+  footprint overlaps a solid tile or leaves the map (the map edge is solid); it then applies the
+  **Y displacement the same way**, starting from the horizontal result.
+
+This keeps **wall-sliding** natural (a blocked axis reverts while the other axis still moves, so
+a diagonal move into a wall slides along the wall on the free axis) and prevents **diagonal
+corner-cutting** (each axis is resolved independently, so a diagonal cannot squeeze diagonally
+through a corner). The existing map-bounds clamp (`ClampPlayerToMap`) remains as a safety net
+for positions placed outside the map by other means.
+
+NPCs are not moved by the engine (they have no AI yet), so collision resolution currently only
+applies to the player; the public `TileMap.IsSolid` API is available for future NPC logic.
+Per-tile collision shapes other than full-cell solidity, dynamic (runtime-mutable) collision
+layers and one-way platforms are out of scope for this story.
 
 ## Pathfinding
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,11 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > an `SKImage` on load. The engine owns the assigned map: replacing `engine.Map` disposes the
 > previous map, and disposing the engine (`using var engine = ...` or `engine.Dispose()`) disposes
 > the current one.
+>
+> **Collision layers:** a tile layer declaring the Tiled `is_collision` boolean custom property
+> set to `true` contains **solid** tiles that block the player (see `docs/Architecture.md`); the
+> map edge is solid (characters cannot leave the map), and tiles drawn from non-collision layers
+> never block.
 
 ### Reading order
 
@@ -109,8 +114,8 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 | [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references and the speed-scaled walk-cycle animation (`AnimationCycleSpeed`). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |
-| [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading (sync + async); prerendered layer images, viewport-culled image-blit rendering and `IDisposable`; map custom properties, object layers and the `above_player` flag. |
-| [api/TileMapLayer.md](api/TileMapLayer.md) | Tile-layer data and the `AbovePlayer` flag. |
+| [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading (sync + async); prerendered layer images, viewport-culled image-blit rendering and `IDisposable`; map custom properties, object layers, the `above_player` flag and collision (`IsSolid`, the `is_collision` layer convention). |
+| [api/TileMapLayer.md](api/TileMapLayer.md) | Tile-layer data and the `AbovePlayer` / `IsCollision` flags. |
 | [api/MapProperty.md](api/MapProperty.md) / [api/MapPropertyType.md](api/MapPropertyType.md) | Typed map/layer/object custom properties. |
 | [api/TileMapObject.md](api/TileMapObject.md) / [api/TileMapObjectShape.md](api/TileMapObjectShape.md) / [api/TileMapObjectLayer.md](api/TileMapObjectLayer.md) | The object-layer read model. |
 | [api/TiledAssetFetcher.md](api/TiledAssetFetcher.md) / [api/TiledAssetFetcherAsync.md](api/TiledAssetFetcherAsync.md) | Resolving Tiled assets by URI (sync and async). |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -34,6 +34,10 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
 - Movement input combines every held bound key into a single 8-direction vector: opposite keys
   cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
   at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
+- When a map is set, the player's displacement is resolved with **axis-separated movement**
+  against the map's solid tiles (layers declaring the Tiled `is_collision` bool property): each
+  axis is applied in turn and reverted when the player's sprite footprint would overlap a solid
+  tile or leave the map (the map edge is solid). See [Architecture](../Architecture.md).
 - The engine is **`IDisposable`**: it owns the assigned map and disposes it when `Map` is
   replaced or when the engine itself is disposed (a `TileMap` is disposable because it
   prerenders each tile layer into an `SKImage` on load).
@@ -113,7 +117,8 @@ engine.Input(Key.D, isPressed: false);  // key-up
 ### `void Update(double dt)`
 
 Advances the simulation by `dt` seconds: resolves the movement direction from the currently
-pressed keys, moves the player (in tiles), clamps it inside the map, and advances the
+pressed keys, moves the player (in tiles, resolving collisions against the map's solid tiles
+with axis-separated movement when a map is set), clamps it inside the map, and advances the
 walk-cycle animation of the player and every NPC.
 
 ```csharp

--- a/docs/api/TileMap.md
+++ b/docs/api/TileMap.md
@@ -23,6 +23,10 @@ Namespace: `RPGEngine.Tiled` — a tile map loaded from a Tiled `.tmx` file (and
   `TileMapLayer.AbovePlayer` is `false`) are drawn first, and the layers **above** the player
   (those declaring the Tiled `above_player` custom property set to `true`) are drawn afterwards,
   so those tiles appear in front of the player.
+- **Collision**: a layer declaring the Tiled `is_collision` boolean custom property set to
+  `true` is a collision layer; its non-empty tiles are solid and block character movement.
+  `IsSolid` reports solid tiles and treats the map edge as solid (see the `IsSolid` method
+  below).
 
 ## Properties
 
@@ -120,12 +124,19 @@ var flags = map.GetTileFlags("ground", 0, 0);
 
 ### `bool IsSolid(int tileX, int tileY)`
 
-Returns whether the tile at `(tileX, tileY)` blocks movement. The current contract always
-returns `false`; collision data will be added by a later story.
+Returns whether the tile at `(tileX, tileY)` blocks movement. A tile is solid when **any**
+collision layer (`TileMapLayer.IsCollision`) has a non-empty tile (GID != 0) at that cell.
+Coordinates **outside the map are always solid**: the map edge blocks characters, so they cannot
+leave the map through it. When the map has no collision layer, every in-bounds cell is walkable.
 
 ```csharp
-Console.WriteLine(map.IsSolid(1, 1)); // False
+Console.WriteLine(map.IsSolid(1, 1)); // False (no collision layer in this map)
 ```
+
+Collision layers are declared with the Tiled `is_collision` boolean custom property set to
+`true` (see `TileMapLayer.IsCollision`). The engine uses `IsSolid` to block the player against
+solid tiles with axis-separated movement (see `docs/Architecture.md`); the same public API is
+available for future NPC logic.
 
 ### `void Dispose()`
 
@@ -152,7 +163,7 @@ Console.WriteLine(map.Height);             // 12
 Console.WriteLine(map.Layers.Count);       // 3 ("ground" + "decor" + "trees_above")
 Console.WriteLine(map.Layers[0].Name);     // "ground"
 Console.WriteLine(map.GetTileId("ground", 0, 0)); // >= 1 (a grass tile)
-Console.WriteLine(map.IsSolid(1, 1));      // False
+Console.WriteLine(map.IsSolid(1, 1));      // False (no collision layer here)
 
 // Map custom properties (looked up case-sensitively; null when absent).
 var difficulty = map.GetProperty("difficulty");

--- a/docs/api/TileMapLayer.md
+++ b/docs/api/TileMapLayer.md
@@ -13,13 +13,20 @@ corresponding flip flags are stored in a parallel list.
 | `Visible` | Gets whether the layer is visible (shown) in the map. |
 | `Opacity` | Gets the opacity of the layer, from 0 (fully transparent) to 1 (fully opaque). |
 | `AbovePlayer` | Gets whether the layer is rendered **above** the player (declared by the Tiled `above_player` boolean custom property set to `true`). |
-| `Properties` | Gets the layer's custom properties, in file order (includes `above_player` when declared). |
+| `IsCollision` | Gets whether the layer is a **collision** layer (declared by the Tiled `is_collision` boolean custom property set to `true`); its non-empty tiles are solid and block movement. |
+| `Properties` | Gets the layer's custom properties, in file order (includes `above_player`/`is_collision` when declared). |
 | `Width` / `Height` | Get the size of the layer in tiles. |
 | `TileIds` | Gets the tile IDs in row-major order (0 = empty cell). |
 
 `AbovePlayer` is `true` when the layer declares a custom boolean property named `above_player`
 with value `true` (Tiled convention, case-sensitive). When the property is absent, is not a
 boolean, or is `false`, it is `false` and the layer is rendered below the player.
+
+`IsCollision` is `true` when the layer declares a custom boolean property named `is_collision`
+with value `true` (Tiled convention, case-sensitive, mirroring `above_player`). When the
+property is absent, is not a boolean, or is `false`, it is `false` and the layer never blocks
+movement. The engine treats every non-empty tile (GID != 0) of a collision layer as solid — see
+`TileMap.IsSolid` and `docs/Architecture.md` for how characters collide with them.
 
 ## Methods
 
@@ -59,4 +66,12 @@ Console.WriteLine(ground.Properties.Count); // custom properties declared on the
 var treesAbove = map.Layers.Single(layer => layer.Name == "trees_above");
 Console.WriteLine(treesAbove.AbovePlayer); // True
 Console.WriteLine(treesAbove.Properties.Single(p => p.Name == "above_player").Value); // True
+
+// A collision layer (is_collision = true) contains solid tiles that block characters.
+// The committed fixture map has no collision layer; this snippet assumes the loaded map
+// declares one named "walls" (e.g. your own map with a walls layer).
+var walls = map.Layers.Single(layer => layer.Name == "walls");
+Console.WriteLine(walls.IsCollision);      // True
+Console.WriteLine(walls.Properties.Single(p => p.Name == "is_collision").Value); // True
+Console.WriteLine(map.IsSolid(3, 4));      // e.g. True where the walls layer has a tile
 ```

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -55,6 +55,13 @@ namespace RPGEngine;
 /// animation snaps back to the standing frame.
 /// </para>
 /// <para>
+/// When a map is set, the player's displacement is resolved with <em>axis-separated
+/// movement</em> against the map's solid tiles: each axis is applied in turn and reverted when
+/// the player's sprite footprint would overlap a solid tile or leave the map (the map edge is
+/// solid). This blocks the player at solid tiles, keeps wall-sliding natural and prevents
+/// diagonal corner-cutting. See <c>docs/Architecture.md</c> for the collision model.
+/// </para>
+/// <para>
 /// The engine is <see cref="IDisposable"/>: it owns the assigned map and disposes it when
 /// <see cref="Map"/> is replaced or when the engine itself is disposed (a <see cref="TileMap"/>
 /// is disposable because it prerenders each tile layer into an <see cref="SKImage"/> on load).
@@ -171,8 +178,9 @@ public sealed class GameEngine : IDisposable
 
     /// <summary>
     /// Advances the simulation by <paramref name="dt"/> seconds: resolves the movement direction
-    /// from the currently pressed keys, moves the player, clamps it inside the map, and advances
-    /// the walk-cycle animation of the player and every NPC.
+    /// from the currently pressed keys, moves the player (resolving collisions against the map's
+    /// solid tiles with axis-separated movement when a map is set), clamps it inside the map, and
+    /// advances the walk-cycle animation of the player and every NPC.
     /// </summary>
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
     public void Update(double dt)
@@ -180,7 +188,7 @@ public sealed class GameEngine : IDisposable
         var direction = Config.GetMovementDirection(_pressedKeys);
         if (direction.HasValue)
         {
-            Player.Move(direction.Value, speedFactor: 1, dt);
+            MovePlayerWithCollisionResolution(direction.Value, dt);
         }
 
         if (Map is not null)
@@ -509,6 +517,75 @@ public sealed class GameEngine : IDisposable
         return new Position(
             Math.Clamp(desiredX, 0, maxX) - offsetX,
             Math.Clamp(desiredY, 0, maxY) - offsetY);
+    }
+
+    /// <summary>
+    /// Moves the player in <paramref name="direction"/> by <c>BaseSpeed * dt</c> tiles and, when
+    /// a map is set, resolves collisions against the map's solid tiles using
+    /// <em>axis-separated movement</em>: the horizontal displacement is applied first and
+    /// reverted if the player's sprite footprint (see <see cref="PlayerFootprintOverlapsSolid"/>)
+    /// would overlap a solid tile or leave the map (the map edge is solid, see
+    /// <see cref="Tiled.TileMap.IsSolid"/>); the vertical displacement is then applied the same
+    /// way, starting from the horizontal result. This keeps wall-sliding natural (a blocked axis
+    /// reverts while the other axis still moves) and prevents diagonal corner-cutting (each axis
+    /// is resolved independently). Without a map the displacement is applied directly, matching
+    /// <see cref="Character.Move(Direction, double, double)"/>.
+    /// </summary>
+    /// <param name="direction">The direction to face and move towards.</param>
+    /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
+    /// <remarks>
+    /// NPCs are not moved by the engine (they have no AI yet), so collision resolution only
+    /// applies to the player here; the public <see cref="Tiled.TileMap.IsSolid"/> API is
+    /// available for future NPC logic.
+    /// </remarks>
+    private void MovePlayerWithCollisionResolution(Direction direction, double dt)
+    {
+        // The engine resolves the displacement itself (axis by axis) instead of calling
+        // Player.Move, which would move both axes at once; setting the direction here keeps the
+        // facing behaviour identical to the previous Player.Move call.
+        Player.Direction = direction;
+
+        var delta = direction.Delta() * (Player.Character.BaseSpeed * dt);
+
+        if (Map is null)
+        {
+            Player.Position += delta;
+            return;
+        }
+
+        var position = Player.Position;
+
+        // Horizontal axis: apply the X displacement, then revert it if the resulting footprint
+        // overlaps a solid tile (or leaves the map, which IsSolid treats as solid).
+        var afterX = position.WithOffset(delta.X, 0);
+        if (!PlayerFootprintOverlapsSolid(afterX))
+        {
+            position = afterX;
+        }
+
+        // Vertical axis: same rule, starting from the horizontal result (this is what makes
+        // diagonal movement slide along a wall on the free axis).
+        var afterY = position.WithOffset(0, delta.Y);
+        if (!PlayerFootprintOverlapsSolid(afterY))
+        {
+            position = afterY;
+        }
+
+        Player.Position = position;
+    }
+
+    /// <summary>
+    /// Returns whether the player's sprite footprint with its top-left at
+    /// <paramref name="position"/> overlaps a solid tile or leaves the map. The footprint size
+    /// is the player's sprite size in pixels (<see cref="Character.GetSpriteSize"/>) converted
+    /// to tiles with the map's tile width, and the overlap is tested with
+    /// <see cref="Tiled.TileMap.IsAreaSolid"/>.
+    /// </summary>
+    private bool PlayerFootprintOverlapsSolid(Position position)
+    {
+        var ts = Map!.TileWidth;
+        var (spriteWidth, spriteHeight) = Player.Character.GetSpriteSize(_spriteSheetManager);
+        return Map.IsAreaSolid(position.X, position.Y, spriteWidth / (double)ts, spriteHeight / (double)ts);
     }
 
     /// <summary>

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -18,7 +18,7 @@ namespace RPGEngine.Tiled;
 /// </para>
 /// <para>
 /// Tile coordinates are 0-based. Layer data is stored row-major. Only the orthogonal map
-/// layout is supported by this story; collision, pathfinding and <c>.tmj</c> are out of scope.
+/// layout is supported; <c>.tmj</c> is out of scope.
 /// </para>
 /// <para>
 /// Rendering is a per-layer image blit. When the map is loaded, every visible, non-empty tile
@@ -281,14 +281,79 @@ public sealed class TileMap : IDisposable
 
     /// <summary>
     /// Returns whether the tile at (<paramref name="tileX"/>, <paramref name="tileY"/>) blocks
-    /// movement. The current contract always returns <see langword="false"/>; collision data will
-    /// be added by a later story, at which point this method will consult the map's collision
-    /// information instead.
+    /// movement. A tile is solid when <em>any</em> collision layer
+    /// (<see cref="TileMapLayer.IsCollision"/> is <see langword="true"/>) has a non-empty tile
+    /// (GID != 0) at that cell. Coordinates outside the map are always solid: the map edge blocks
+    /// characters, so they cannot leave the map through it. When the map has no collision layer,
+    /// every in-bounds cell is walkable.
     /// </summary>
     /// <param name="tileX">The 0-based tile X coordinate.</param>
     /// <param name="tileY">The 0-based tile Y coordinate.</param>
-    /// <returns><see langword="false"/> for every tile under the current contract.</returns>
-    public bool IsSolid(int tileX, int tileY) => false;
+    /// <returns>
+    /// <see langword="true"/> when the cell is occupied by a collision-layer tile or lies
+    /// outside the map; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool IsSolid(int tileX, int tileY)
+    {
+        if (tileX < 0 || tileX >= Width || tileY < 0 || tileY >= Height)
+        {
+            // The map edge is solid: characters cannot leave the map through it.
+            return true;
+        }
+
+        foreach (var layer in Layers)
+        {
+            if (layer.IsCollision && layer.GetTileId(tileX, tileY) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns whether any tile overlapped by the axis-aligned rectangle from
+    /// (<paramref name="x"/>, <paramref name="y"/>) to
+    /// (<paramref name="x"/> + <paramref name="width"/>, <paramref name="y"/> +
+    /// <paramref name="height"/>), given in tile units, is solid (see
+    /// <see cref="IsSolid(int, int)"/>). The rectangle's bounds are floored to the containing
+    /// cells; a rectangle that ends exactly on a tile boundary does not count the next tile.
+    /// Used by the engine's footprint check to test the tiles overlapped by a character's sprite
+    /// footprint.
+    /// </summary>
+    /// <param name="x">The left bound of the rectangle, in tiles.</param>
+    /// <param name="y">The top bound of the rectangle, in tiles.</param>
+    /// <param name="width">The width of the rectangle, in tiles.</param>
+    /// <param name="height">The height of the rectangle, in tiles.</param>
+    /// <returns>
+    /// <see langword="true"/> when at least one overlapped tile is solid; otherwise
+    /// <see langword="false"/>. A rectangle that lies (or extends) outside the map is solid,
+    /// per the map-edge rule of <see cref="IsSolid(int, int)"/>.
+    /// </returns>
+    internal bool IsAreaSolid(double x, double y, double width, double height)
+    {
+        // The overlapped tile range of [x, x+width) x [y, y+height): floor the minimum corner
+        // and floor the maximum corner (via ceil(max) - 1) so a rectangle that ends exactly on
+        // a tile boundary stays inside the last cell it overlaps.
+        var minTileX = (int)Math.Floor(x);
+        var minTileY = (int)Math.Floor(y);
+        var maxTileX = (int)Math.Ceiling(x + width) - 1;
+        var maxTileY = (int)Math.Ceiling(y + height) - 1;
+
+        for (var tileY = minTileY; tileY <= maxTileY; tileY++)
+        {
+            for (var tileX = minTileX; tileX <= maxTileX; tileX++)
+            {
+                if (IsSolid(tileX, tileY))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Draws the visible part of the map to <paramref name="canvas"/>, rendering only the

--- a/src/RPGEngine/Tiled/TileMapLayer.cs
+++ b/src/RPGEngine/Tiled/TileMapLayer.cs
@@ -37,9 +37,20 @@ public sealed class TileMapLayer
     public bool AbovePlayer { get; }
 
     /// <summary>
+    /// Gets whether the layer is a <em>collision</em> layer: its tiles are solid and block
+    /// character movement (see <see cref="TileMap.IsSolid"/>). A layer declares this by setting
+    /// a custom boolean property named <c>is_collision</c> to <see langword="true"/> (Tiled
+    /// convention, mirroring <c>above_player</c>). When the property is absent, is not a
+    /// boolean, or is <see langword="false"/>, this is <see langword="false"/> and the layer
+    /// never blocks movement.
+    /// </summary>
+    public bool IsCollision { get; }
+
+    /// <summary>
     /// Gets the layer's custom properties (from the layer's <c>&lt;properties&gt;</c> block), in
-    /// file order. The Tiled <c>above_player</c> flag, when present, appears here too; the flag
-    /// is additionally surfaced as <see cref="AbovePlayer"/>.
+    /// file order. The Tiled <c>above_player</c> and <c>is_collision</c> flags, when present,
+    /// appear here too; the flags are additionally surfaced as <see cref="AbovePlayer"/> and
+    /// <see cref="IsCollision"/>.
     /// </summary>
     public IReadOnlyList<MapProperty> Properties { get; }
 
@@ -63,6 +74,7 @@ public sealed class TileMapLayer
         int width,
         int height,
         bool abovePlayer,
+        bool isCollision,
         IReadOnlyList<MapProperty> properties)
     {
         Name = name;
@@ -73,6 +85,7 @@ public sealed class TileMapLayer
         Width = width;
         Height = height;
         AbovePlayer = abovePlayer;
+        IsCollision = isCollision;
         Properties = properties;
     }
 
@@ -88,8 +101,9 @@ public sealed class TileMapLayer
     /// <summary>
     /// Builds a <see cref="TileMapLayer"/> from a DotTiled <see cref="TileLayer"/>. The raw GIDs
     /// (which may carry flip bits) are split into masked tile IDs and <see cref="TileFlags"/>,
-    /// and the layer's custom properties are consulted for the <c>above_player</c> flag and
-    /// exposed through <see cref="Properties"/>.
+    /// and the layer's custom properties are consulted for the <c>above_player</c> and
+    /// <c>is_collision</c> flags, exposed through <see cref="Properties"/> and the dedicated
+    /// <see cref="AbovePlayer"/>/<see cref="IsCollision"/> members.
     /// </summary>
     internal static TileMapLayer FromDotTiled(TileLayer layer)
     {
@@ -131,6 +145,8 @@ public sealed class TileMapLayer
         var properties = layer.Properties.Select(MapProperty.Create).ToArray();
         var abovePlayer = layer.Properties.Any(p =>
             p.Name == "above_player" && p is BoolProperty boolProperty && boolProperty.Value);
+        var isCollision = layer.Properties.Any(p =>
+            p.Name == "is_collision" && p is BoolProperty boolProperty && boolProperty.Value);
 
         return new TileMapLayer(
             layer.Name,
@@ -141,6 +157,7 @@ public sealed class TileMapLayer
             width,
             height,
             abovePlayer,
+            isCollision,
             properties);
     }
 

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -782,12 +782,189 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 35: map collisions. A tile layer declaring the Tiled is_collision
+    // bool property contains solid tiles that block the player; the engine
+    // resolves the player's displacement with axis-separated movement so the
+    // player stops at solid boundaries (never overlapping them) and slides
+    // along walls on the free axis, while the map edge is solid (characters
+    // cannot leave the map) and non-collision layers never block.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a player walking right into a solid tile stops at its exact tile-unit boundary and never overlaps it.</summary>
+    [Fact]
+    public void Update_PlayerWalksIntoSolidTile_StopsAtBoundary()
+    {
+        // 4x4 map: a "walls" collision layer with a solid column at x=2 for every row.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+        });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // The default 48x48 sprite is a 1x1-tile footprint. Start at (0.5, 1.0) and hold D.
+        engine.Player.Position = new Position(0.5, 1.0);
+        engine.Input(Key.D, true);
+
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The player slides to exactly the left edge of the solid tile at x=2: position.x = 1.0
+        // (the footprint's right edge is at 2.0) and it never overlaps the solid tile.
+        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6); // straight line, Y unchanged
+        Assert.True(engine.Player.Position.X + 1.0 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
+        Assert.Equal(Direction.Right, engine.Player.Direction);
+    }
+
+    /// <summary>Verifies a player walking down into a solid tile stops at its exact tile-unit boundary and never overlaps it.</summary>
+    [Fact]
+    public void Update_PlayerWalksDownIntoSolidTile_StopsAtBoundary()
+    {
+        // 4x4 map: a "walls" collision layer with a solid row at y=2 for every column.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            1, 1, 1, 1,
+            1, 1, 1, 1,
+        });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        engine.Player.Position = new Position(1.0, 0.5);
+        engine.Input(Key.S, true);
+
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The player stops at exactly the top edge of the solid row at y=2: position.y = 1.0.
+        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
+        Assert.True(engine.Player.Position.Y + 1.0 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
+        Assert.Equal(Direction.Down, engine.Player.Direction);
+    }
+
+    /// <summary>Verifies a player moving diagonally into a vertical wall slides along the wall on the free axis (axis-separated movement).</summary>
+    [Fact]
+    public void Update_PlayerMovesDiagonallyIntoWall_SlidesAlongWall()
+    {
+        // 5x5 map: a "walls" collision layer with a solid column at x=3 for every row.
+        var gids = new uint[25];
+        for (var y = 0; y < 5; y++)
+        {
+            gids[(y * 5) + 3] = 1;
+        }
+
+        using var fixture = CreateCollisionMapFixture(5, 5, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Start flush against the left edge of the wall column (x=3): the 1x1 footprint spans
+        // [2,3) at x=2. Moving UpRight, the X displacement is blocked by the wall while Y is
+        // free, so the player slides straight up along the wall.
+        engine.Player.Position = new Position(2.0, 4.0);
+        engine.Input(Key.W, true);
+        engine.Input(Key.D, true);
+
+        for (var frame = 0; frame < 60; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // X never moves into the wall: it stays at exactly 2.0 (the wall's left edge).
+        Assert.Equal(2.0, engine.Player.Position.X, precision: 6);
+        // Y slides up along the wall: one second at 2 tiles/s diagonally = 2 * sqrt(0.5) ~ 1.414.
+        Assert.Equal(4.0 - (2 * Math.Sqrt(0.5)), engine.Player.Position.Y, precision: 6);
+    }
+
+    /// <summary>Verifies tiles drawn from a normal (non-collision) layer never block: the player walks across them freely.</summary>
+    [Fact]
+    public void Update_NonCollisionLayer_NeverBlocksMovement()
+    {
+        // A 4x4 map whose ground layer draws a tile in every cell but has no collision layer.
+        using var fixture = CreateFilledMapFixture(4, 4);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        engine.Player.Position = new Position(0.5, 0.5);
+        engine.Input(Key.D, true);
+
+        for (var frame = 0; frame < 60; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // One second at 2 tiles/s: moved ~2 tiles right, Y unchanged (the drawn tiles never block).
+        Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
+    }
+
+    /// <summary>Verifies the map edge is solid: with no collision layer the player cannot walk out of the map.</summary>
+    [Fact]
+    public void Update_MapEdgeIsSolid_PlayerCannotLeaveMap()
+    {
+        // A 2x2 map with a ground layer only (no collision layer).
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Walk right: the 1x1 footprint stops when its right edge reaches the map edge at x=2,
+        // so the player clamps to x = 1.0 instead of leaving the map.
+        engine.Player.Position = new Position(0.5, 0.5);
+        engine.Input(Key.D, true);
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
+        Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
+        Assert.True(engine.Player.Position.X + 1.0 <= 2.0 + 1e-9);
+
+        // Then walk down: the same rule clamps Y to 1.0 (the footprint's bottom edge at y=2).
+        engine.Input(Key.D, false);
+        engine.Input(Key.S, true);
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
+        Assert.True(engine.Player.Position.Y + 1.0 <= 2.0 + 1e-9);
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
     /// <summary>Creates a map fixture filled with red tiles in a single "ground" layer.</summary>
     private static TiledTestFixture CreateFilledMapFixture(int width, int height)
         => new(width, height, new[] { FilledLayer(width, height) });
+
+    /// <summary>
+    /// Creates a map fixture with a filled "ground" layer (walkable) and a "walls" collision
+    /// layer declaring the Tiled <c>is_collision</c> bool property set to <c>true</c>.
+    /// </summary>
+    private static TiledTestFixture CreateCollisionMapFixture(int width, int height, uint[] collisionGids)
+        => new(
+            width,
+            height,
+            new[]
+            {
+                FilledLayer(width, height),
+                new TileLayerSpec(
+                    "walls",
+                    collisionGids,
+                    Properties: new[] { new FixtureProperty("is_collision", "bool", "true") }),
+            });
 
     /// <summary>Builds a fully filled single-layer spec for a map of the given size.</summary>
     private static TileLayerSpec FilledLayer(int width, int height)

--- a/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
+++ b/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
@@ -88,11 +88,16 @@ public class TileMapTests
     }
 
     // ---------------------------------------------------------------------
-    // Acceptance 4: IsSolid returns false for all tiles (current contract).
+    // Story 35: collision layers (is_collision) and solid-tile queries. A layer
+    // declaring the Tiled <property name="is_collision" type="bool" value="true"/>
+    // custom property is reported by TileMapLayer.IsCollision; TileMap.IsSolid
+    // consults those layers (a non-empty tile is solid and the map edge is solid),
+    // and the internal IsAreaSolid helper tests the tiles overlapped by a tile-unit
+    // rectangle (the engine's footprint check).
     // ---------------------------------------------------------------------
-    /// <summary>Verifies IsSolid returns false for every tile under the current (collision-less) contract.</summary>
+    /// <summary>Verifies IsSolid returns false for every in-bounds cell when the map has no collision layer (no is_collision property).</summary>
     [Fact]
-    public void IsSolid_ReturnsFalseForAllTiles()
+    public void IsSolid_NoCollisionLayer_ReturnsFalseForAllInBoundsCells()
     {
         using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
 
@@ -105,6 +110,172 @@ public class TileMapTests
                 Assert.False(map.IsSolid(x, y));
             }
         }
+    }
+
+    /// <summary>Verifies TileMapLayer.IsCollision is true for a layer declaring the is_collision bool property and false for a layer without it.</summary>
+    [Fact]
+    public void IsCollision_ReadsCustomProperty_FromTmx()
+    {
+        var ground = new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 });
+        var walls = new TileLayerSpec(
+            "walls",
+            new uint[] { 0, 1, 0, 1 },
+            Properties: new[] { new FixtureProperty("is_collision", "bool", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { ground, walls });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.Layers[0].IsCollision);
+        Assert.True(map.Layers[1].IsCollision);
+    }
+
+    /// <summary>Verifies a layer without the is_collision property (or with it set to false, or with a non-bool property of that name) reports IsCollision == false.</summary>
+    [Fact]
+    public void IsCollision_AbsentFalseOrNonBool_ReportsFalse()
+    {
+        var absent = new TileLayerSpec("absent", new uint[] { 1, 1, 1, 1 });
+        var falseValue = new TileLayerSpec(
+            "false_value",
+            new uint[] { 0, 0, 0, 0 },
+            Properties: new[] { new FixtureProperty("is_collision", "bool", "false") });
+        var nonBool = new TileLayerSpec(
+            "non_bool",
+            new uint[] { 0, 0, 0, 0 },
+            Properties: new[] { new FixtureProperty("is_collision", "string", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { absent, falseValue, nonBool });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.Layers[0].IsCollision);
+        Assert.False(map.Layers[1].IsCollision);
+        Assert.False(map.Layers[2].IsCollision);
+    }
+
+    /// <summary>Verifies the new is_collision parsing does not affect the existing above_player parsing (regression).</summary>
+    [Fact]
+    public void IsCollision_AndAbovePlayer_ParseIndependently()
+    {
+        var above = new TileLayerSpec(
+            "above",
+            new uint[] { 0, 0, 0, 0 },
+            Properties: new[]
+            {
+                new FixtureProperty("above_player", "bool", "true"),
+                new FixtureProperty("is_collision", "bool", "false"),
+            });
+        var walls = new TileLayerSpec(
+            "walls",
+            new uint[] { 0, 1, 0, 0 },
+            Properties: new[] { new FixtureProperty("is_collision", "bool", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { above, walls });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.True(map.Layers[0].AbovePlayer);
+        Assert.False(map.Layers[0].IsCollision);
+        Assert.False(map.Layers[1].AbovePlayer);
+        Assert.True(map.Layers[1].IsCollision);
+    }
+
+    /// <summary>Verifies IsSolid returns true exactly where a collision layer has a non-empty tile, and false on empty cells.</summary>
+    [Fact]
+    public void IsSolid_CollisionLayerTile_IsSolid_AndEmptyCellsAreWalkable()
+    {
+        var ground = new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 }); // walkable
+        var walls = new TileLayerSpec(
+            "walls",
+            new uint[] { 0, 1, 0, 1 },
+            Properties: new[] { new FixtureProperty("is_collision", "bool", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { ground, walls });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // (0,0) is empty in the collision layer -> walkable even though ground draws a tile there.
+        Assert.False(map.IsSolid(0, 0));
+        // (1,0) has a tile in the collision layer -> solid.
+        Assert.True(map.IsSolid(1, 0));
+        // (0,1) is empty -> walkable.
+        Assert.False(map.IsSolid(0, 1));
+        // (1,1) has a tile -> solid.
+        Assert.True(map.IsSolid(1, 1));
+    }
+
+    /// <summary>Verifies IsSolid ignores tiles on non-collision layers: a tile drawn from a normal layer is walkable.</summary>
+    [Fact]
+    public void IsSolid_NonCollisionLayer_NeverBlocks()
+    {
+        // All four cells have a tile on the ground layer, but none is a collision layer.
+        using var fixture = TiledTestFixture.Create2x2(new[] { new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 }) });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.IsSolid(0, 0));
+        Assert.False(map.IsSolid(1, 0));
+        Assert.False(map.IsSolid(0, 1));
+        Assert.False(map.IsSolid(1, 1));
+    }
+
+    /// <summary>Verifies IsSolid returns true for out-of-bounds coordinates (negative and >= map size): the map edge is solid.</summary>
+    [Fact]
+    public void IsSolid_OutOfBounds_ReturnsTrue()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.True(map.IsSolid(-1, 0));
+        Assert.True(map.IsSolid(0, -1));
+        Assert.True(map.IsSolid(2, 0));
+        Assert.True(map.IsSolid(0, 2));
+        Assert.True(map.IsSolid(-1, -1));
+        Assert.True(map.IsSolid(2, 2));
+    }
+
+    /// <summary>Verifies IsAreaSolid reports solid when the rectangle overlaps a collision-layer tile, using the floored bounds.</summary>
+    [Fact]
+    public void IsAreaSolid_OverlappingSolidTile_ReturnsTrue()
+    {
+        // Collision layer with a single solid tile at (1,1).
+        var walls = new TileLayerSpec(
+            "walls",
+            new uint[] { 0, 0, 0, 1 },
+            Properties: new[] { new FixtureProperty("is_collision", "bool", "true") });
+
+        using var fixture = TiledTestFixture.Create2x2(new[] { walls });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // A rectangle inside the solid cell is solid.
+        Assert.True(map.IsAreaSolid(1.2, 1.2, 0.5, 0.5));
+
+        // A rectangle fully inside a walkable cell is not.
+        Assert.False(map.IsAreaSolid(0.2, 0.2, 0.5, 0.5));
+
+        // A rectangle that ends exactly on the boundary of the solid cell does not include it;
+        // once it spills past the boundary (even slightly) it becomes solid.
+        Assert.False(map.IsAreaSolid(0.0, 1.0, 1.0, 0.5));
+        Assert.True(map.IsAreaSolid(0.0, 1.0, 1.0001, 0.5));
+    }
+
+    /// <summary>Verifies IsAreaSolid returns false for an in-bounds rectangle when the map has no collision layers.</summary>
+    [Fact]
+    public void IsAreaSolid_NoCollisionLayer_ReturnsFalse()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.False(map.IsAreaSolid(0, 0, 2, 2));
+        Assert.False(map.IsAreaSolid(0.25, 0.25, 1.5, 1.5));
+    }
+
+    /// <summary>Verifies IsAreaSolid treats a rectangle that extends outside the map as solid (the map-edge rule).</summary>
+    [Fact]
+    public void IsAreaSolid_OutsideMap_ReturnsTrue()
+    {
+        using var fixture = TiledTestFixture.Create2x2(new[] { Ground });
+        var map = TileMap.Load(fixture.MapPath);
+
+        Assert.True(map.IsAreaSolid(-1, 0, 1, 1));  // starts left of the map
+        Assert.True(map.IsAreaSolid(1.5, 0, 1, 1)); // extends past the right edge
+        Assert.True(map.IsAreaSolid(0, 1.5, 1, 1)); // extends past the bottom edge
+        Assert.True(map.IsAreaSolid(1.5, 1.5, 1, 1)); // extends past both edges
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Story 35: Map collisions — `is_collision` layers and solid-tile movement blocking

Closes #35 (parent epic: #33).

### What changed

**`TileMapLayer` (`RPGEngine.Tiled`)**
- New `bool IsCollision` property: `true` when the layer declares a `BoolProperty` named `is_collision` with value `true` (mirrors the existing `above_player` parsing in `FromDotTiled`); absent / non-boolean / `false` → `false`.

**`TileMap` (`RPGEngine.Tiled`)**
- `IsSolid(int tileX, int tileY)` is no longer a stub:
  - `true` when **any** collision layer has a non-empty tile (GID != 0) at the cell;
  - `true` for out-of-bounds coordinates (**the map edge is solid**);
  - `false` for every in-bounds cell when no collision layer exists.
- New internal `IsAreaSolid(x, y, width, height)` (tile units) that tests the tiles overlapped by an axis-aligned rectangle (floor of the bounds; a rectangle ending exactly on a tile boundary does not count the next tile).

**`GameEngine` (`RPGEngine`)**
- `Update` now resolves the player's displacement with **axis-separated movement** after determining the movement direction: apply X, revert if the player's sprite footprint (pixels from `Character.GetSpriteSize` converted to tiles) would overlap a solid tile or leave the map; then apply Y the same way. This blocks the player at solid boundaries (exact tile-unit edge, never overlapping), keeps wall-sliding natural, and prevents diagonal corner-cutting.
- `ClampPlayerToMap` is kept as a safety net (the map edge is already solid via `IsSolid`).
- NPC collision resolution is documented as out of scope until NPC movement exists; the public `IsSolid` API is available for future NPC logic.

### Tests
- `TileMapTests`: `IsCollision` parsing (present true / absent / false / non-bool, plus the `above_player` regression), `IsSolid` (collision tiles, empty cells, no collision layer, non-collision layers never block, out-of-bounds = solid edge), and the internal `IsAreaSolid` helper.
- `GameEngineTests`: movement blocking against a solid column (X) and a solid row (Y) stops at the exact tile-unit boundary and never overlaps; diagonal movement into a wall slides along the wall on the free axis; non-collision layers never block; the map edge is solid (player cannot leave the map even with no collision layer).

### Documentation
- `docs/api/TileMap.md` — `IsSolid` contract (no longer a stub) and the edge-is-solid rule.
- `docs/api/TileMapLayer.md` — `IsCollision` with an example.
- `docs/Architecture.md` — new Collision section (axis-separated resolution, footprint in tiles).
- `docs/README.md` — the `is_collision` layer convention.
- `docs/api/GameEngine.md` — `Update`/movement remarks mirror the XML docs.

### Verification
- `dotnet build RPGEngine.sln -c Release` → 0 warnings / 0 errors.
- `dotnet test tests/RPGEngine.Tests -c Release` → 307 passed (293 baseline + 14 new).
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~TileMapTests|FullyQualifiedName~GameEngineTests"` → 78 passed.

### Out of scope (unchanged)
Pathfinding (next story), click-to-move, per-tile collision shapes other than full-cell solidity, NPC movement/AI, dynamic collision layers, one-way platforms.