### PR TITLE
Story 36: Minimap — RenderMinimap on GameEngine

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -310,3 +310,43 @@ below-player layers → NPCs → player → above-player layers
   the area around it stays black (`offset = max(0, (canvasSize − mapPixelSize) / (2*ts))` tiles),
   so a small map is never letterboxed with transparent or leftover pixels. When the map fills
   (or exceeds) the canvas, the behaviour is the classic follow-and-clamp camera.
+
+## Minimap
+
+`GameEngine.RenderMinimap(canvas, zoomLevel)` renders a **minimap** of the current map onto a
+canvas separate from the main game canvas. It is a pure renderer: it never mutates engine state,
+and it reuses the same prerendered layer images the main render path uses.
+
+- **What is drawn.** Every visible tile layer's prerendered `SKImage` — both the below- and the
+  above-player layers, in file order bottom → top, because a minimap shows the full picture (the
+  `above_player` distinction only matters when characters are drawn between the two passes). On
+  top of the map, a **green dot** marks the player and a **yellow dot** marks each NPC in
+  `Characters`, drawn as small filled circles at their world positions converted to map pixels
+  (`Position * tileWidth`) then scaled to the canvas.
+- **Zoom semantics.** `zoomLevel` is relative to the "fit the whole map" view:
+  - `1.0` (the default) fits the entire map into the canvas, centered, with the aspect ratio
+    preserved.
+  - `> 1` zooms in: the map is drawn larger than the canvas and the view pans around the
+    player's dot, clamped to the map edges — the same follow-and-clamp behaviour as the main
+    camera.
+  - `0 < zoomLevel < 1` zooms out further (the map is drawn smaller with larger blank margins).
+  - `<= 0` throws `ArgumentOutOfRangeException`.
+- **Layout.** The base fit scale is
+  `baseFit = min(canvasWidth / Map.PixelWidth, canvasHeight / Map.PixelHeight)` and the effective
+  scale is `scale = baseFit * zoomLevel`, so the aspect ratio is preserved by construction (one
+  scale for both axes). When the whole scaled map fits in the canvas it is centered and drawn
+  entirely; when zoomed in, the visible region is `(canvasWidth / scale, canvasHeight / scale)`
+  map pixels, centered on the player's position in map pixels and clamped inside
+  `(0, 0, PixelWidth, PixelHeight)`. Each layer is blitted with `canvas.DrawImage` where the
+  **source** rect is the visible region ∩ layer bounds (in map pixels) and the **dest** rect is
+  the same region scaled by `scale` and offset by the centering/pan origin. Dots outside the
+  visible region are skipped.
+- **Background.** The method does **not** clear the canvas and never draws into the unused area
+  — "unused space is left blank", and the host owns the minimap background (e.g. a translucent
+  panel behind the minimap).
+
+The minimap's camera is the same follow + clamp + center model as the main camera
+(`ComputeCameraOrigin`), expressed in map pixels instead of tiles: per axis,
+`origin = clamp(playerPx − visibleSize/2, 0, max(0, mapPixelSize − visibleSize)) −
+max(0, (canvasSize − scaledMapSize) / (2*scale))`. The first clamp keeps the view inside the map;
+the subtracted term centers the map when it is smaller than the visible region on that axis.

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,13 +104,19 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > set to `true` contains **solid** tiles that block the player (see `docs/Architecture.md`); the
 > map edge is solid (characters cannot leave the map), and tiles drawn from non-collision layers
 > never block.
+>
+> **Minimap:** `engine.RenderMinimap(canvas, zoomLevel)` draws the map's prerendered layers plus a
+> green dot for the player and a yellow dot for each NPC onto a separate surface. `zoomLevel`
+> `1.0` fits the whole map (the default); `> 1` zooms in around the player's dot (clamped to the
+> map edges, like the main camera); `0 < zoomLevel < 1` zooms out further. It does not clear its
+> canvas — the host owns the minimap background (see `docs/api/GameEngine.md`).
 
 ### Reading order
 
 | Page | What it covers |
 | --- | --- |
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering, rendering order and the Tiled read model. |
-| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, map ownership (`IDisposable`). |
+| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
 | [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references and the speed-scaled walk-cycle animation (`AnimationCycleSpeed`). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -38,6 +38,12 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   against the map's solid tiles (layers declaring the Tiled `is_collision` bool property): each
   axis is applied in turn and reverted when the player's sprite footprint would overlap a solid
   tile or leave the map (the map edge is solid). See [Architecture](../Architecture.md).
+- A minimap can be rendered on a separate surface with `RenderMinimap`: it draws the map's
+  prerendered tile layers, a green dot for the player and a yellow dot for each NPC.
+  `zoomLevel` `1.0` fits the whole map to the canvas; values above `1` zoom in and pan around
+  the player's dot (clamped to the map edges, like the main camera); values between `0` and `1`
+  zoom out further. The minimap does not clear its canvas and leaves the unused margins blank,
+  so the host owns the minimap background.
 - The engine is **`IDisposable`**: it owns the assigned map and disposes it when `Map` is
   replaced or when the engine itself is disposed (a `TileMap` is disposable because it
   prerenders each tile layer into an `SKImage` on load).
@@ -141,6 +147,51 @@ using (var canvas = new SKCanvas(bitmap))
 {
     canvas.Clear(SKColors.Transparent);
     engine.Render(canvas, dt: 1.0 / 60);
+}
+```
+
+### `void RenderMinimap(SKCanvas canvas, double zoomLevel)`
+
+Draws a **minimap** of the current map onto `canvas`, a surface separate from the main game
+canvas. It renders the map's prerendered tile layers (both below- and above-player layers, in
+file order bottom → top — a minimap shows the full picture), a **green dot** for the player and a
+**yellow dot** for each NPC in `Characters`. The canvas size is read from the canvas clip bounds,
+the same convention as `Render`.
+
+**Zoom semantics** (`zoomLevel`, relative to the "fit the whole map" view):
+
+- `1.0` (the default) **fits the entire map** into the canvas, centered, with the aspect ratio
+  preserved and the unused margins left blank.
+- `> 1` **zooms in**: the map is drawn larger than the canvas and the view pans around the
+  player's dot, clamped to the map edges (like the main camera).
+- `0 < zoomLevel < 1` zooms out further.
+- `<= 0` throws `ArgumentOutOfRangeException`.
+
+The base fit scale is `min(canvasWidth / Map.PixelWidth, canvasHeight / Map.PixelHeight)` and the
+effective scale is `baseFit * zoomLevel`. When the whole scaled map fits, it is centered; when
+zoomed in, the visible region (`canvasWidth / scale` × `canvasHeight / scale` map pixels) is
+centered on the player's position in map pixels (`Player.Position * ts`) and clamped inside the
+map bounds. With no map it is a **no-op** (the canvas is left untouched). The method does **not**
+clear the canvas and never draws into the unused area — the host owns the minimap background — and
+it is a pure render (it never mutates engine state).
+
+```csharp
+// Default fit: the whole map is drawn into the minimap canvas, centered, aspect preserved; the
+// unused margins stay blank (the host owns the minimap background).
+using var minimap = new SKBitmap(240, 240);
+using (var canvas = new SKCanvas(minimap))
+{
+    canvas.Clear(SKColors.Transparent);
+    engine.RenderMinimap(canvas, zoomLevel: 1.0);
+}
+
+// Zoomed in: the view is centered on the player's green dot and clamps at the map edges (like
+// the main camera), so only the region around the player is visible.
+using var zoomed = new SKBitmap(240, 240);
+using (var canvas = new SKCanvas(zoomed))
+{
+    canvas.Clear(SKColors.Transparent);
+    engine.RenderMinimap(canvas, zoomLevel: 4.0);
 }
 ```
 

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -71,6 +71,16 @@ namespace RPGEngine;
 /// its layers reference (they are created when the map is loaded). Standalone tilesets can be
 /// loaded directly through the <c>TileSet.Load</c> factories in <c>RPGEngine.Tiled</c>.
 /// </para>
+/// <para>
+/// A minimap can be rendered on a separate surface with <see cref="RenderMinimap"/>: it draws
+/// the map's prerendered tile layers (both below- and above-player layers, in file order
+/// bottom → top, so it shows the full picture), a green dot for the player and a yellow dot
+/// for each NPC in <see cref="Characters"/>. A <c>zoomLevel</c> of <c>1.0</c> fits the whole
+/// map into the minimap canvas; values above <c>1</c> zoom in and the view pans around the
+/// player's dot, clamped to the map edges like the main camera; values between <c>0</c> and
+/// <c>1</c> zoom out further. The minimap does not clear its canvas and leaves the unused
+/// margins blank, so the host owns the minimap background.
+/// </para>
 /// </remarks>
 public sealed class GameEngine : IDisposable
 {
@@ -84,6 +94,10 @@ public sealed class GameEngine : IDisposable
     // further API churn.
     private double _lastCanvasWidth;
     private double _lastCanvasHeight;
+
+    // The radius in canvas pixels of each minimap dot (the green player dot and the yellow NPC
+    // dots). Dots are small markers on top of the minimap map, not full sprites.
+    private const float MinimapDotRadius = 3f;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameEngine"/> class with default state: a
@@ -279,6 +293,145 @@ public sealed class GameEngine : IDisposable
         finally
         {
             canvas.Restore();
+        }
+    }
+
+    /// <summary>
+    /// Draws a minimap of the current map onto <paramref name="canvas"/>, a surface separate from
+    /// the main game canvas. It renders the map's prerendered tile layers (both below- and
+    /// above-player layers, in file order bottom → top — a minimap shows the
+    /// full picture), a green dot for the player and a yellow dot for each NPC in
+    /// <see cref="Characters"/>. The canvas size is read from the canvas clip bounds, the same
+    /// convention as <see cref="Render"/>.
+    /// </summary>
+    /// <param name="canvas">The minimap surface to draw onto (separate from the main game canvas).</param>
+    /// <param name="zoomLevel">
+    /// The zoom relative to the &quot;fit the whole map&quot; view: <c>1.0</c> (the default
+    /// callers pass when no zoom is wanted) fits the entire map into the canvas; a value
+    /// greater than <c>1</c> zooms in (the map is drawn larger than the canvas and the view pans
+    /// around the player's dot like the main camera, clamped to the map edges); a value between
+    /// <c>0</c> and <c>1</c> zooms out further. A value of zero or less throws
+    /// <see cref="ArgumentOutOfRangeException"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="canvas"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="zoomLevel"/> is zero or negative.</exception>
+    /// <remarks>
+    /// <para>
+    /// When <see cref="Map"/> is <see langword="null"/> this method is a no-op: nothing is drawn
+    /// and the canvas is left untouched.
+    /// </para>
+    /// <para>
+    /// Layout: the base fit scale is
+    /// <c>min(canvasWidth / Map.PixelWidth, canvasHeight / Map.PixelHeight)</c> and the effective
+    /// scale is <c>baseFit * zoomLevel</c>, so the aspect ratio is preserved by construction.
+    /// When the whole (scaled) map fits in the canvas it is centered and drawn entirely; when
+    /// zoomed in, the visible region is <c>(canvasWidth / scale, canvasHeight / scale)</c> map
+    /// pixels, centered on the player's position in map pixels
+    /// (<c>Player.Position * ts</c>) and clamped so it stays inside the map bounds (edge-clamped
+    /// like the main camera).
+    /// </para>
+    /// <para>
+    /// The method does not clear the canvas and does not draw into the unused margins —
+    /// &quot;unused space is left blank&quot; and the host owns the minimap background. It is a
+    /// pure render: it never mutates engine state.
+    /// </para>
+    /// </remarks>
+    public void RenderMinimap(SKCanvas canvas, double zoomLevel)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(zoomLevel, 0);
+
+        if (Map is null)
+        {
+            // No map: draw nothing and leave the canvas untouched.
+            return;
+        }
+
+        var bounds = canvas.LocalClipBounds;
+        var canvasWidth = Math.Max(0, bounds.Width);
+        var canvasHeight = Math.Max(0, bounds.Height);
+        if (canvasWidth <= 0 || canvasHeight <= 0)
+        {
+            // A zero-size minimap surface has nothing to draw onto.
+            return;
+        }
+
+        var ts = Map.TileWidth;
+        var mapWidth = Map.PixelWidth;
+        var mapHeight = Map.PixelHeight;
+
+        // The base fit scale fits the whole map into the canvas; the effective scale applies the
+        // zoom. Aspect ratio is preserved by construction (one scale for both axes).
+        var baseFit = Math.Min(canvasWidth / mapWidth, canvasHeight / mapHeight);
+        var scale = baseFit * zoomLevel;
+
+        var scaledWidth = mapWidth * scale;
+        var scaledHeight = mapHeight * scale;
+
+        // The visible region size, in map pixels, that maps to the full canvas.
+        var visibleWidth = canvasWidth / scale;
+        var visibleHeight = canvasHeight / scale;
+
+        // Positions are in tiles, so dots (and the view centre) are scaled by the tile size.
+        var playerPixelX = Player.Position.X * ts;
+        var playerPixelY = Player.Position.Y * ts;
+
+        // The camera origin in map pixels, mirroring the main camera (see ComputeCameraOrigin):
+        // the desired origin centres the player in the visible region, is clamped so the region
+        // stays inside the map, and when the map is smaller than the visible region on an axis
+        // the origin is shifted by half the difference so the map is centered on that axis (the
+        // leftover canvas is left blank).
+        var maxOriginX = Math.Max(0, mapWidth - visibleWidth);
+        var maxOriginY = Math.Max(0, mapHeight - visibleHeight);
+        var centerOffsetX = Math.Max(0, (canvasWidth - scaledWidth) / (2.0 * scale));
+        var centerOffsetY = Math.Max(0, (canvasHeight - scaledHeight) / (2.0 * scale));
+        var originX = Math.Clamp(playerPixelX - (visibleWidth / 2.0), 0, maxOriginX) - centerOffsetX;
+        var originY = Math.Clamp(playerPixelY - (visibleHeight / 2.0), 0, maxOriginY) - centerOffsetY;
+
+        // Draw every prerendered layer image in file order (bottom → top), both below- and
+        // above-player layers, so the minimap shows the full picture. For each layer the source
+        // rect is the visible region intersected with the layer bounds (in map pixels) and the
+        // destination rect is that region mapped to the canvas by the effective scale and the
+        // pan/center origin.
+        using var layerPaint = new SKPaint { IsAntialias = false };
+        for (var layerIndex = 0; layerIndex < Map.Layers.Count; layerIndex++)
+        {
+            var image = Map.PrerenderedLayerImages[layerIndex];
+            if (image is null)
+            {
+                continue;
+            }
+
+            var sourceLeft = Math.Max(originX, 0);
+            var sourceTop = Math.Max(originY, 0);
+            var sourceRight = Math.Min(originX + visibleWidth, mapWidth);
+            var sourceBottom = Math.Min(originY + visibleHeight, mapHeight);
+            if (sourceLeft >= sourceRight || sourceTop >= sourceBottom)
+            {
+                continue;
+            }
+
+            var source = new SKRect(
+                (float)sourceLeft,
+                (float)sourceTop,
+                (float)sourceRight,
+                (float)sourceBottom);
+            var destination = new SKRect(
+                (float)((sourceLeft - originX) * scale),
+                (float)((sourceTop - originY) * scale),
+                (float)((sourceRight - originX) * scale),
+                (float)((sourceBottom - originY) * scale));
+
+            canvas.DrawImage(image, source, destination, layerPaint);
+        }
+
+        // The player dot (green) and each NPC dot (yellow), drawn as small filled circles at
+        // their world positions converted to map pixels then scaled to the canvas. Dots whose
+        // centre lies outside the visible region are skipped.
+        DrawMinimapDot(canvas, playerPixelX, playerPixelY, originX, originY, scale, visibleWidth, visibleHeight, SKColors.Green);
+        foreach (var character in _characters)
+        {
+            DrawMinimapDot(canvas, character.Position.X * ts, character.Position.Y * ts, originX, originY, scale, visibleWidth, visibleHeight, SKColors.Yellow);
         }
     }
 
@@ -517,6 +670,46 @@ public sealed class GameEngine : IDisposable
         return new Position(
             Math.Clamp(desiredX, 0, maxX) - offsetX,
             Math.Clamp(desiredY, 0, maxY) - offsetY);
+    }
+
+    /// <summary>
+    /// Draws a single minimap dot as a small filled circle at the given map-pixel position,
+    /// converted to canvas coordinates with the minimap's scale and pan/center origin. A dot
+    /// whose centre lies outside the visible region (in map pixels) is skipped — it would
+    /// be off-canvas, and "dots outside the visible region are skipped".
+    /// </summary>
+    /// <param name="canvas">The minimap canvas to draw onto.</param>
+    /// <param name="mapPixelX">The dot's X position in map pixels.</param>
+    /// <param name="mapPixelY">The dot's Y position in map pixels.</param>
+    /// <param name="originX">The minimap camera origin X in map pixels (the visible region's left).</param>
+    /// <param name="originY">The minimap camera origin Y in map pixels (the visible region's top).</param>
+    /// <param name="scale">The effective minimap scale (canvas pixels per map pixel).</param>
+    /// <param name="visibleWidth">The visible region width in map pixels.</param>
+    /// <param name="visibleHeight">The visible region height in map pixels.</param>
+    /// <param name="color">The dot color (green for the player, yellow for NPCs).</param>
+    private void DrawMinimapDot(
+        SKCanvas canvas,
+        double mapPixelX,
+        double mapPixelY,
+        double originX,
+        double originY,
+        double scale,
+        double visibleWidth,
+        double visibleHeight,
+        SKColor color)
+    {
+        if (mapPixelX < originX || mapPixelX >= originX + visibleWidth ||
+            mapPixelY < originY || mapPixelY >= originY + visibleHeight)
+        {
+            return;
+        }
+
+        using var paint = new SKPaint { Color = color, IsAntialias = false };
+        canvas.DrawCircle(
+            (float)((mapPixelX - originX) * scale),
+            (float)((mapPixelY - originY) * scale),
+            MinimapDotRadius,
+            paint);
     }
 
     /// <summary>

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -113,6 +113,60 @@ public class DocsExamplesTests
     }
 
     // ---------------------------------------------------------------------
+    // docs/api/GameEngine.md: the RenderMinimap example. The minimap renders
+    // the map's prerendered layers plus a green player dot and yellow NPC dots
+    // on a separate canvas; zoomLevel 1.0 fits the whole map, > 1 zooms in
+    // around the player's dot (clamped to the map edges).
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies the RenderMinimap doc example: the default fit draws the whole map and the dots
+    /// on a separate minimap canvas, and a zoomed render shows the region around the player's
+    /// dot with the green/yellow dots present.
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_Example_DefaultFitAndZoom()
+    {
+        using var fixture = new TiledTestFixture(
+            4, 2,
+            new[] { new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1, 1, 1, 1, 1 }) });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        engine.Player.Position = new Position(0.5, 0.5);
+        engine.Characters.Add(new Character { Position = new Position(3.5, 1.5) });
+
+        // Default fit: the whole map is drawn into the minimap canvas, centered, aspect preserved;
+        // the unused margins stay blank (the host owns the minimap background).
+        using var minimap = new SKBitmap(240, 240);
+        using (var canvas = new SKCanvas(minimap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.RenderMinimap(canvas, zoomLevel: 1.0);
+        }
+
+        // A 4x2 (192x96) map on a 240x240 canvas: baseFit = min(240/192, 240/96) = 1.25, so the
+        // map is scaled to 240x120 and centered vertically (60 px margins); a map pixel and the
+        // dots are present at their scaled positions.
+        Assert.NotEqual(0, minimap.GetPixel(120, 90).Alpha);   // a tile pixel inside the map
+        Assert.Equal(SKColors.Green, minimap.GetPixel(30, 90));  // player dot (0.5,0.5) -> (30,90)
+        Assert.Equal(SKColors.Yellow, minimap.GetPixel(210, 150)); // NPC dot (3.5,1.5) -> (210,150)
+        Assert.Equal(0, minimap.GetPixel(120, 5).Alpha);       // top margin blank
+
+        // Zoomed in: the view is centered on the player's dot and clamps at the map edges.
+        using var zoomed = new SKBitmap(240, 240);
+        using (var canvas = new SKCanvas(zoomed))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.RenderMinimap(canvas, zoomLevel: 4.0);
+        }
+
+        // scale = 1.25 * 4 = 5, visible region = 48x48 map px centered on the player at map px
+        // (24,24) and clamped to the top-left corner, so tile (0,0) fills the canvas and the
+        // player's green dot stays centered. (The NPC at (3.5,1.5) is outside this region and its
+        // dot is skipped.)
+        Assert.Equal(SKColors.Green, zoomed.GetPixel(120, 120));
+        Assert.Equal(SKColors.Red, zoomed.GetPixel(40, 40));
+    }
+
+    // ---------------------------------------------------------------------
     // docs/api/SpriteSheet.md: the character index 1..8 semantics.
     // ---------------------------------------------------------------------
     /// <summary>

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -942,6 +942,262 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 36: minimap rendering. RenderMinimap draws the map's prerendered
+    // tile layers (both below- and above-player layers, in file order), a
+    // green dot for the player and a yellow dot for each NPC, onto a canvas
+    // separate from the main game canvas. zoomLevel 1.0 fits the whole map
+    // centered with the aspect preserved; > 1 zooms in around the player's
+    // dot with the same edge clamp as the main camera; the canvas is not
+    // cleared and unused margins stay blank. The method is pure (it never
+    // mutates engine state), a null map is a no-op, and zoomLevel <= 0 throws
+    // ArgumentOutOfRangeException.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies the default zoom fits the whole (non-square) map into the canvas, centered with
+    /// the aspect ratio preserved, leaves the unused margins blank, and shows every distinct
+    /// tile color of a two-color map plus both dots at their scaled positions.
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_DefaultZoom_FitsWholeMapCenteredWithBlankMargins()
+    {
+        // A 4x2 map (192x96 px): red tiles on the left half, blue on the right half, so the map
+        // is non-square and the two tile colors are distinguishable.
+        using var fixture = new TiledTestFixture(
+            4, 2,
+            new[] { new TileLayerSpec("ground", new uint[]
+            {
+                1, 1, 2, 2,
+                1, 1, 2, 2,
+            }) },
+            tileColors: new[] { SKColors.Red, SKColors.Blue });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        // Player near the top-left, NPC near the bottom-right, both away from the sampled tiles.
+        engine.Player.Position = new Position(0.5, 0.5);
+        engine.Characters.Add(new Character { Position = new Position(3.5, 1.5) });
+
+        const int canvasWidth = 400;
+        const int canvasHeight = 300;
+        using var bitmap = RenderMinimap(engine, canvasWidth, canvasHeight, zoomLevel: 1.0);
+
+        // Aspect-preserving fit: baseFit = min(400/192, 300/96) = 25/12, so the map is scaled to
+        // exactly 400x200 and centered with 50 px margins top and bottom (it fills the width).
+        const double scale = 25.0 / 12;
+        Assert.Equal(192 * scale, 400, precision: 6);
+        Assert.Equal(96 * scale, 200, precision: 6);
+
+        // Both distinct tile colors are visible at their scaled centers, away from the dots.
+        // Red tile (1,0) center (72,24) px -> screen (150,100); blue tile (2,0) center (120,24)
+        // px -> screen (250,100).
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(150, 100));
+        Assert.Equal(SKColors.Blue, bitmap.GetPixel(250, 100));
+
+        // The dots are drawn at the scaled world positions: player (0.5,0.5) -> map px (24,24)
+        // -> screen (50,100) green; NPC (3.5,1.5) -> map px (168,72) -> screen (350,200) yellow.
+        Assert.Equal(SKColors.Green, bitmap.GetPixel(50, 100));
+        Assert.Equal(SKColors.Yellow, bitmap.GetPixel(350, 200));
+
+        // The map is centered vertically with ~50 px margins above and below (it fills the 400 px
+        // width), so it is not stretched to fill the 300 px canvas. Sample well inside each
+        // region to avoid the rasterizer's sub-pixel edge rows.
+        Assert.Equal(0, bitmap.GetPixel(200, 20).Alpha);   // top margin blank
+        Assert.Equal(0, bitmap.GetPixel(200, 40).Alpha);   // top margin blank
+        Assert.NotEqual(0, bitmap.GetPixel(200, 60).Alpha);  // map interior (top half)
+        Assert.NotEqual(0, bitmap.GetPixel(200, 240).Alpha); // map interior (bottom half)
+        Assert.Equal(0, bitmap.GetPixel(200, 260).Alpha);  // bottom margin blank
+        Assert.Equal(0, bitmap.GetPixel(200, 280).Alpha);  // bottom margin blank
+    }
+
+    /// <summary>
+    /// Verifies the player dot (green) and NPC dots (yellow) are drawn as small filled circles
+    /// at the scaled world positions, and that with no NPCs only the green dot is drawn.
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_Dots_AtScaledPositions()
+    {
+        using var fixture = CreateFilledMapFixture(2, 2); // 96x96 red map
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        // A 200x200 canvas: baseFit = min(200/96, 200/96) = 25/12, so the 96x96 map is scaled to
+        // exactly 200x200 and fills the canvas (origin 0,0).
+        engine.Player.Position = new Position(0.5, 0.5);   // map px (24,24) -> screen (50,50)
+        var npc = new Character { Position = new Position(1.5, 1.5) }; // map px (72,72) -> screen (150,150)
+        engine.Characters.Add(npc);
+
+        using var bitmap = RenderMinimap(engine, 200, 200, zoomLevel: 1.0);
+        Assert.Equal(SKColors.Green, bitmap.GetPixel(50, 50));
+        Assert.Equal(SKColors.Yellow, bitmap.GetPixel(150, 150));
+
+        // With no NPCs only the green dot is drawn.
+        engine.Characters.Clear();
+        using var withoutNpc = RenderMinimap(engine, 200, 200, zoomLevel: 1.0);
+        Assert.Equal(SKColors.Green, withoutNpc.GetPixel(50, 50));
+        Assert.Equal(0, CountColor(withoutNpc, SKColors.Yellow));
+    }
+
+    /// <summary>
+    /// Verifies zoom-in shows only the sub-region around the player, and that moving the player
+    /// to the top-left / bottom-right corners clamps the view so the map edge is shown (never
+    /// blank space) — the same clamping behavior as the main camera.
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_ZoomIn_ShowsSubRegionAndClampsToMapEdges()
+    {
+        // A 10x10 (480x480) map: red everywhere, with blue corner tiles at (0,0) and (9,9) so the
+        // visible sub-region can be told apart from the rest of the map.
+        var gids = Enumerable.Repeat(1u, 100).ToArray();
+        gids[0] = 2;   // tile (0,0) is blue
+        gids[99] = 2;  // tile (9,9) is blue
+        using var fixture = new TiledTestFixture(
+            10, 10,
+            new[] { new TileLayerSpec("ground", gids) },
+            tileColors: new[] { SKColors.Red, SKColors.Blue });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        const int canvasSize = 240; // baseFit 0.5; zoom 4 -> scale 2, visible region 120x120 map px
+
+        // Center: player at (5,5) tiles = map px (240,240); the visible region clamps to
+        // (180,180)-(300,300). The blue corner tiles lie outside it, so no blue is visible and a
+        // tile inside the region (e.g. tile (4,4) at screen (72,72)) is shown.
+        engine.Player.Position = new Position(5, 5);
+        using (var bitmap = RenderMinimap(engine, canvasSize, canvasSize, zoomLevel: 4))
+        {
+            Assert.Equal(0, CountColor(bitmap, SKColors.Blue));     // corner tiles are outside the region
+            Assert.Equal(SKColors.Red, bitmap.GetPixel(72, 72));    // a tile inside the region is visible
+            Assert.Equal(SKColors.Green, bitmap.GetPixel(120, 120)); // the player dot is centered
+        }
+
+        // Top-left corner: player at (0,0); the visible region clamps to (0,0)-(120,120) so the
+        // map edge is shown at the canvas edge instead of blank space — the blue corner tile (0,0)
+        // is visible at the top-left of the canvas (a few pixels away from the green dot at 0,0).
+        engine.Player.Position = new Position(0, 0);
+        using (var bitmap = RenderMinimap(engine, canvasSize, canvasSize, zoomLevel: 4))
+        {
+            Assert.Equal(SKColors.Blue, bitmap.GetPixel(10, 10));
+        }
+
+        // Bottom-right corner: player at (9,9); the visible region clamps to (360,360)-(480,480)
+        // so the blue corner tile (9,9) is visible at the bottom-right of the canvas.
+        engine.Player.Position = new Position(9, 9);
+        using (var bitmap = RenderMinimap(engine, canvasSize, canvasSize, zoomLevel: 4))
+        {
+            Assert.Equal(SKColors.Blue, bitmap.GetPixel(239, 239));
+        }
+    }
+
+    /// <summary>
+    /// Verifies a dot outside the visible region is not drawn (no yellow pixels), while a dot
+    /// inside the region is drawn at its scaled position.
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_DotOutsideVisibleRegion_IsNotDrawn()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480x480 red map
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        const int canvasSize = 240; // zoom 4 -> scale 2, visible region 120x120 map px
+        engine.Player.Position = new Position(5, 5); // visible region (180,180)-(300,300)
+
+        // An NPC inside the visible region is drawn at its scaled position.
+        engine.Characters.Add(new Character { Position = new Position(6, 5) }); // map px (288,240) -> screen (216,120)
+        using (var bitmap = RenderMinimap(engine, canvasSize, canvasSize, zoomLevel: 4))
+        {
+            Assert.Equal(SKColors.Yellow, bitmap.GetPixel(216, 120));
+        }
+
+        // An NPC outside the visible region is skipped entirely.
+        engine.Characters.Clear();
+        engine.Characters.Add(new Character { Position = new Position(1, 5) }); // map px (48,240), left of the region
+        using (var bitmap = RenderMinimap(engine, canvasSize, canvasSize, zoomLevel: 4))
+        {
+            Assert.Equal(0, CountColor(bitmap, SKColors.Yellow));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that with no map RenderMinimap is a no-op: the canvas is left untouched.
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_NoMap_LeavesCanvasUntouched()
+    {
+        var engine = new GameEngine(); // no map
+
+        using var bitmap = new SKBitmap(120, 90);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            // Pre-fill the canvas with an arbitrary backdrop the minimap must not overwrite.
+            canvas.Clear(SKColors.Orange);
+            engine.RenderMinimap(canvas, zoomLevel: 1.0);
+        }
+
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                Assert.Equal(SKColors.Orange, bitmap.GetPixel(x, y));
+            }
+        }
+    }
+
+    /// <summary>Verifies a zoom level of zero or negative throws ArgumentOutOfRangeException.</summary>
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(-0.5)]
+    public void RenderMinimap_NonPositiveZoom_ThrowsArgumentOutOfRangeException(double zoomLevel)
+    {
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        using var bitmap = new SKBitmap(96, 96);
+        using var canvas = new SKCanvas(bitmap);
+        Assert.Throws<ArgumentOutOfRangeException>(() => engine.RenderMinimap(canvas, zoomLevel));
+    }
+
+    /// <summary>Verifies a small positive zoom (zoom out) is accepted and still draws the map.</summary>
+    [Fact]
+    public void RenderMinimap_SmallPositiveZoom_IsAccepted()
+    {
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        // zoom 0.5 on a 200x200 canvas: scale = 25/24, the 96x96 map is scaled to 100x100 and
+        // centered with 50 px margins; the map is still drawn (e.g. its center is a map pixel).
+        using var bitmap = RenderMinimap(engine, 200, 200, zoomLevel: 0.5);
+        Assert.NotEqual(0, bitmap.GetPixel(100, 100).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha); // the margin stays blank
+    }
+
+    /// <summary>
+    /// Verifies RenderMinimap is pure: rendering a minimap on a separate surface does not change
+    /// the output of the main Render nor the engine state (regression guard for the minimap work).
+    /// </summary>
+    [Fact]
+    public void RenderMinimap_DoesNotMutateEngineState_MainRenderUnchanged()
+    {
+        using var fixture = CreateFilledMapFixture(4, 4);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(1.5, 1.5);
+        engine.Characters.Add(new Character { Position = new Position(2.5, 2.5) });
+
+        var before = Render(engine, 240, 240);
+
+        // Render a minimap on a separate surface; it must not touch the main render path or state.
+        using (var minimap = RenderMinimap(engine, 120, 120, zoomLevel: 1.0))
+        {
+            Assert.NotEqual(0, minimap.GetPixel(60, 60).Alpha); // the minimap did draw something
+        }
+
+        var after = Render(engine, 240, 240);
+        AssertBitmapsEqual(before, after);
+
+        Assert.Equal(new Position(1.5, 1.5), engine.Player.Position);
+        Assert.Single(engine.Characters);
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
@@ -997,4 +1253,51 @@ public class GameEngineTests
         var expected = CharacterTestHelper.SpriteColor(seed, characterIndex, Direction.Down, StandingFrame);
         Assert.Equal(expected, bitmap.GetPixel(topLeftX + (CellSize / 2), topLeftY + (CellSize / 2)));
     }
+
+    /// <summary>Renders the minimap into a fresh transparent bitmap of the requested size.</summary>
+    private static SKBitmap RenderMinimap(GameEngine engine, int width, int height, double zoomLevel)
+    {
+        var bitmap = new SKBitmap(width, height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.RenderMinimap(canvas, zoomLevel);
+        }
+
+        return bitmap;
+    }
+
+    /// <summary>Counts the pixels in <paramref name="bitmap"/> equal to <paramref name="color"/>.</summary>
+    private static int CountColor(SKBitmap bitmap, SKColor color)
+    {
+        var count = 0;
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y) == color)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Asserts two bitmaps have identical dimensions and pixels.</summary>
+    private static void AssertBitmapsEqual(SKBitmap expected, SKBitmap actual)
+    {
+        Assert.Equal(expected.Width, actual.Width);
+        Assert.Equal(expected.Height, actual.Height);
+
+        for (var y = 0; y < expected.Height; y++)
+        {
+            for (var x = 0; x < expected.Width; x++)
+            {
+                Assert.Equal(expected.GetPixel(x, y), actual.GetPixel(x, y));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Closes #36

## Summary

Adds `GameEngine.RenderMinimap(SKCanvas canvas, double zoomLevel)` — a minimap renderer for a canvas separate from the main game canvas.

### Source (`src/RPGEngine/GameEngine.cs`)
- `RenderMinimap` draws every visible tile layer's prerendered `SKImage` (both below- and above-player layers, in file order bottom→top), then a **green dot** for the player and a **yellow dot** for each NPC in `Characters`.
- Zoom semantics: `1.0` fits the whole map into the canvas (centered, aspect preserved); `> 1` zooms in and pans around the player's dot, clamped to the map edges like the main camera; `0 < zoom < 1` zooms out further; `<= 0` throws `ArgumentOutOfRangeException`.
- Layout uses `baseFit = min(canvasWidth/PixelWidth, canvasHeight/PixelHeight)` and `effectiveScale = baseFit * zoomLevel`; the visible region (`canvasWidth/scale × canvasHeight/scale` map pixels) is centered on the player's map-pixel position and clamped inside the map — the same follow + clamp + center model as the main camera, expressed in map pixels.
- Pure render: it never mutates engine state (does not touch `LastCanvasWidth`/`LastCanvasHeight`), does not clear the canvas, and leaves unused margins blank (host owns the minimap background). `Map == null` is a no-op.
- Class remarks updated with the minimap + zoom semantics.

### Tests
- `GameEngineTests` (10 new cases, using `TiledTestFixture` multi-color maps and `CharacterTestHelper`):
  1. Default zoom fits a non-square map centered with blank margins, aspect preserved, both tile colors + both dots present.
  2. Dots at scaled positions; with no NPCs only the green dot.
  3. Zoom-in shows only the sub-region around the player and clamps to the top-left/bottom-right map edges.
  4. A dot outside the visible region is not drawn.
  5. `Map == null` → no-op (canvas untouched).
  6. `zoomLevel <= 0` throws `ArgumentOutOfRangeException`.
  7. Small positive zoom (zoom out) is accepted.
  8. Regression: `RenderMinimap` is pure — main `Render` output and engine state are unchanged.
- `DocsExamplesTests`: `RenderMinimap_Example_DefaultFitAndZoom` mirrors the new doc snippet.

### Docs
- `docs/api/GameEngine.md`: `RenderMinimap` with commented examples (default fit + zoomed).
- `docs/Architecture.md`: new Minimap section (zoom semantics, pan/clamp, dots).
- `docs/README.md`: minimap note in the quick start and reading-order table.

### Verification
- `dotnet build -c Release` → 0 warnings / 0 errors.
- `dotnet test tests/RPGEngine.Tests -c Release` → 318 passed (was 307; +10 GameEngineTests, +1 DocsExamplesTests).
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~GameEngineTests"` → 46 passed.