### PR TITLE
Story 38: click-to-move with A* auto-walk and Player.OnMove event

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -276,6 +276,54 @@ orthogonally adjacent cells are walkable. The heuristic is the **octile distance
 optimal. The open set is a `PriorityQueue` keyed by `f = g + h`, and a tile is re-opened only when
 a strictly better `g` is found.
 
+
+## Click-to-move and auto-walk
+
+Click-to-move wires the three pieces above — the surface↔world camera, `TileMap.IsSolid` and
+`AStarPathfinder` — into one feature: the host passes a click to `GameEngine.Click`, and the
+engine walks the player to the clicked tile.
+
+**The click pipeline** (`GameEngine.Click(surfaceX, surfaceY)`):
+
+1. The host reports a click on the **main** game canvas in host-surface (canvas) pixels, the
+   same coordinate space as `SurfaceToWorld`. The engine converts it with the canvas size
+   recorded by the most recent `Render` (unknown size — no render yet — ⇒ the click is
+   ignored). Without a map the click cancels any in-progress walk and does nothing else.
+2. The target tile is `floor(world)` of the converted position.
+3. If the target tile is solid (`TileMap.IsSolid`) the current auto-walk is **cancelled** and the
+   player does not move.
+4. Otherwise the engine computes
+   `AStarPathfinder.FindPath(playerTile, targetTile, (x, y) => !Map.IsSolid(x, y), Map.Width,
+   Map.Height)`. An empty path (start == goal, or the target is unreachable) also cancels the
+   walk without moving; a non-empty path **replaces** the current auto-walk path, even mid-walk.
+
+**Auto-walk** (inside `GameEngine.Update`): the engine keeps an internal queue of target tile
+waypoints (the A* path). When there is **no manual key movement** this frame and the path is
+non-empty, it moves the player toward the center of the next waypoint tile
+(`(tileX + 0.5, tileY + 0.5)`) at `BaseSpeed` (tile units). When the distance to the waypoint
+center is ≤ the frame's step, the player snaps to the center, the waypoint is popped, and the
+walk continues; when the queue empties, the engine calls `Player.Stop()`. The path is computed
+over walkable tiles (no corner cutting), so the direct movement toward each waypoint center never
+crosses a solid tile and no per-frame collision resolution is needed.
+
+**Input precedence during auto-walk**:
+
+- A **key press** (`Input(key, true)`) cancels the auto-walk path; a key **release** does not.
+- While a bound movement key is held, manual movement takes priority and the auto-walk does not
+  advance (the press has already cleared the path).
+- A `Click` always **replaces** the path (even mid-walk); an invalid click (solid tile or no
+  path) **cancels** it.
+
+**Movement-state events**: `Player` exposes `OnMove` (`EventHandler<PlayerMoveEventArgs>`), fired
+on every movement-state transition — starts moving (idle → moving), stops moving (moving →
+idle, via `Player.Stop()`), and changes direction while moving. It carries
+`PlayerMoveEventArgs.IsMoving` and the current facing `Direction`. The engine raises it for both
+manual key movement and auto-walk through `Player.ReportMovement` (the internal bridge used for
+collision-resolved and auto-walk movement, which cannot go through `Player.Move` because that
+method applies the whole displacement at once). `Player.Stop()` raises it with `IsMoving = false`
+only when the player was moving; the engine calls it when there is no input and no auto-walk
+target.
+
 ## Rendering
 
 `GameEngine.Render(canvas, dt)` draws a single frame in a fixed order:

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,14 +110,22 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > `1.0` fits the whole map (the default); `> 1` zooms in around the player's dot (clamped to the
 > map edges, like the main camera); `0 < zoomLevel < 1` zooms out further. It does not clear its
 > canvas — the host owns the minimap background (see `docs/api/GameEngine.md`).
+>
+> **Click-to-move (optional demo):** after at least one `Render` (so the engine knows the canvas
+> size), the host can pass a mouse click to `engine.Click(surfaceX, surfaceY)` and the player
+> **auto-walks** along an A* tile path to the clicked tile, stopping centered on it. Clicking a
+> solid tile or an unreachable target cancels the walk without moving; a key press cancels it and
+> a click mid-walk replaces the destination. `Player.OnMove` fires on every movement-state
+> transition (start / stop / direction change) with the current facing direction. See
+> `docs/api/GameEngine.md` and `docs/api/Player.md`.
 
 ### Reading order
 
 | Page | What it covers |
 | --- | --- |
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering, rendering order and the Tiled read model. |
-| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
-| [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references and the speed-scaled walk-cycle animation (`AnimationCycleSpeed`). |
+| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), **click-to-move auto-walk (`Click`)** and the input-precedence rules, asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
+| [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references, the speed-scaled walk-cycle animation (`AnimationCycleSpeed`), and the movement-state event (`OnMove` / `PlayerMoveEventArgs` / `Stop()`). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |
 | [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading (sync + async); prerendered layer images, viewport-culled image-blit rendering and `IDisposable`; map custom properties, object layers, the `above_player` flag and collision (`IsSolid`, the `is_collision` layer convention). |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -34,6 +34,18 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
 - Movement input combines every held bound key into a single 8-direction vector: opposite keys
   cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
   at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
+- **Click-to-move** (auto-walk): `Click(surfaceX, surfaceY)` converts a host-surface click on the
+  main canvas (using the canvas size recorded by the most recent `Render`) to a world position,
+  computes an **A*** tile path from the player's tile to the clicked tile over the non-solid
+  tiles, and queues those tiles. Each `Update` then moves the player toward the center of the next
+  waypoint at `BaseSpeed`, popping waypoints as they are reached and calling `Player.Stop()` when
+  the path completes. Clicking a **solid tile** or an **unreachable target** cancels the walk
+  without moving; a click that yields a path **replaces** the current walk even mid-walk.
+- **Input precedence during auto-walk**: a **key press** (`Input(key, true)`) cancels the
+  auto-walk path; a key **release** does not; and while a bound movement key is held the
+  auto-walk does not advance (manual key movement takes priority). A `Click` always replaces the
+  path unless the new target is invalid (solid / no path), in which case it cancels the walk.
+  See [Architecture](../Architecture.md).
 - When a map is set, the player's displacement is resolved with **axis-separated movement**
   against the map's solid tiles (layers declaring the Tiled `is_collision` bool property): each
   axis is applied in turn and reverted when the player's sprite footprint would overlap a solid
@@ -114,20 +126,60 @@ a set of currently pressed keys and derives the movement direction in `Update` v
 directions. Host applications translate their framework's key events to a `Key` value before
 calling this method.
 
+A **key press** (`isPressed: true`) cancels any in-progress auto-walk; a key **release** does
+not. The walk is replaced by the next `Click`, or the player simply stops on the next `Update`
+when no movement key is held.
+
 ```csharp
-engine.Input(Key.D, isPressed: true);   // key-down
+engine.Input(Key.D, isPressed: true);   // key-down (also cancels any auto-walk)
 engine.Update(dt);
 engine.Input(Key.D, isPressed: false);  // key-up
 ```
 
 ### `void Update(double dt)`
 
-Advances the simulation by `dt` seconds: resolves the movement direction from the currently
-pressed keys, moves the player (in tiles, resolving collisions against the map's solid tiles
-with axis-separated movement when a map is set), clamps it inside the map, and advances the
-walk-cycle animation of the player and every NPC.
+Advances the simulation by `dt` seconds. Manual key movement takes priority over auto-walk:
+when a bound movement key is held the player moves in that direction (in tiles, resolving
+collisions against the map's solid tiles with axis-separated movement when a map is set).
+Otherwise, when an auto-walk path is queued (from `Click`), the player walks toward the center
+of the next waypoint tile at `BaseSpeed`, popping waypoints as they are reached and calling
+`Player.Stop()` when the path completes. When there is no key input and no auto-walk target the
+player stops. The player is then clamped inside the map and the walk-cycle animation of the
+player and every NPC advances.
 
 ```csharp
+engine.Update(dt: 1.0 / 60);
+```
+
+
+### `void Click(double surfaceX, double surfaceY)`
+
+Reports a **click on the main game canvas** to the engine, in host-surface (canvas) coordinates
+— the same coordinate space as `SurfaceToWorld`. The engine converts the click to a world
+position using the canvas size recorded by the most recent `Render`, computes an **A*** tile
+path from the player's tile to the clicked tile over the non-solid tiles, and queues it for
+auto-walk (see the class remarks and [Architecture](../Architecture.md)).
+
+- If no `Render` has happened yet (the recorded canvas size is zero) the click is **ignored**.
+- Without a map the click cancels any in-progress auto-walk and does nothing else.
+- The target tile is `floor(world)` of the converted position. Clicking a **solid tile**
+  (`TileMap.IsSolid`) cancels any current auto-walk without moving.
+- Otherwise the engine computes `AStarPathfinder.FindPath(playerTile, targetTile, (x, y) =>
+  !Map.IsSolid(x, y), Map.Width, Map.Height)`. An **empty path** (start == goal, or the target
+  is unreachable) also cancels the walk without moving.
+- A **valid path replaces** the current auto-walk path, even mid-walk: the player changes course
+  toward the new target without stopping first.
+
+```csharp
+// Render at least once so the engine knows the canvas size, then translate a mouse click.
+engine.Render(canvas, dt: 1.0 / 60);
+
+// Click at the canvas position of the tile the host wants the player to walk to.
+double surfaceX = 264; // e.g. a mouse position in canvas pixels
+double surfaceY = 264;
+engine.Click(surfaceX, surfaceY);
+
+// The player now auto-walks along the A* path; drive the loop normally.
 engine.Update(dt: 1.0 / 60);
 ```
 

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -11,7 +11,14 @@ and movement to that character, so configuring `SpriteSheets` or moving the play
 equivalent to configuring/moving the underlying `Character`.
 
 The player does not listen to input itself. The engine (`GameEngine`) owns the pressed-keys
-state and calls `Move(direction, 1, dt)` in its update loop.
+state and calls `Move(direction, 1, dt)` in its update loop (or drives the player directly for
+collision-resolved and auto-walk movement through its internal `ReportMovement` bridge).
+
+The player exposes a **movement-state machine** through the `OnMove` event: it fires whenever
+the player *starts moving* (idle → moving), *stops moving* (moving → idle, via `Stop()`), or
+*changes direction while moving*. The event is raised for both manual (key) movement and
+auto-walk movement, so hosts can react to the player's movement state without polling the
+position every frame.
 
 ## Fields
 
@@ -42,7 +49,8 @@ var player = new Player(character);
 
 Gets or sets the `Character` that represents the player in the game world. All other members of
 `Player` forward to this character, so replacing it replaces the player's position, direction,
-speed and spritesheets as well.
+speed and spritesheets as well. The movement event state is re-synchronized to the new
+character's facing direction.
 
 ```csharp
 var player = new Player();
@@ -60,7 +68,8 @@ player.Position = new Position(6, 6);
 
 ### `Direction Direction`
 
-Gets or sets the direction the player is facing. Forwards to `Character.Direction`.
+Gets or sets the direction the player is facing. Forwards to `Character.Direction` and keeps
+the movement event state in sync so `OnMove` reports the correct facing direction.
 
 ```csharp
 player.Direction = Direction.Up;
@@ -77,6 +86,41 @@ visible on the underlying character.
 player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 ```
 
+## Events
+
+### `event EventHandler<PlayerMoveEventArgs>? OnMove`
+
+Occurs when the player's movement state changes: it **starts moving** (idle → moving), **stops
+moving** (moving → idle, via `Stop()`), or **changes direction while moving**. The event
+carries the new state (`PlayerMoveEventArgs.IsMoving`) and the player's current facing direction
+(`PlayerMoveEventArgs.Direction`). It is raised for both manual (key) movement and auto-walk
+movement.
+
+```csharp
+var player = new Player();
+player.OnMove += (_, e) =>
+{
+    Console.WriteLine(e.IsMoving ? "moving" : "stopped");
+    Console.WriteLine($"facing {e.Direction}");
+};
+
+player.Move(Direction.Right, speedFactor: 1, dt: 1); // prints "moving" / "facing Right"
+player.Stop();                                       // prints "stopped" / "facing Right"
+```
+
+### `sealed record PlayerMoveEventArgs(bool IsMoving, Direction Direction)`
+
+The event arguments of `OnMove`: whether the player is now moving (`IsMoving`) and its current
+facing direction (`Direction`). For a speed-factor-zero turn (see `Move`), `IsMoving` reflects
+the movement state at the moment of the turn (moving or idle).
+
+```csharp
+void OnPlayerMove(object? sender, PlayerMoveEventArgs e)
+{
+    Console.WriteLine($"IsMoving = {e.IsMoving}, Direction = {e.Direction}");
+}
+```
+
 ## Methods
 
 ### `void Move(Direction direction, double speedFactor = 1, double dt = 1)`
@@ -84,8 +128,15 @@ player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 Moves the player in `direction` by `BaseSpeed * speedFactor * dt` tiles and sets the facing
 direction. Forwards to `Character.Move`.
 
+This method also drives the movement-state machine: with `speedFactor` greater than zero the
+player is considered *moving* (it actually moves), so `OnMove` fires with `IsMoving = true`
+when the player starts moving or changes direction while moving. With `speedFactor == 0` the
+player only turns: `OnMove` fires on a direction change carrying the current movement state
+(`true` when the player was already moving, `false` when idle).
+
 ```csharp
 player.Move(Direction.Right, dt: 1.0 / 60);
+player.Move(Direction.Up, speedFactor: 0); // turn only: OnMove with the current moving state
 ```
 
 ### `void Move(double speedFactor = 1, double dt = 1)`
@@ -96,12 +147,31 @@ Moves the player in its current facing direction. Forwards to `Character.Move`.
 player.Move(dt: 1.0 / 60);
 ```
 
-## Example: configuring the player with a sheet name + index
+### `void Stop()`
+
+Transitions the player to idle (stops moving) and raises `OnMove` with `IsMoving = false`. When
+the player is already idle this is a no-op and does not raise the event. The engine calls it when
+there is no key input and no auto-walk target. Stopping does not change the facing direction: the
+player keeps facing the direction it was last moving, and that direction is reported in the event.
+
+```csharp
+player.Move(Direction.Right, speedFactor: 1, dt: 1);
+player.Stop(); // raises OnMove with IsMoving = false, Direction = Right
+player.Stop(); // already idle: no event
+```
+
+## Example: subscribing to OnMove for both key and auto-walk movement
 
 ```csharp
 var player = new Player();
-player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+var moveLog = new List<PlayerMoveEventArgs>();
+player.OnMove += (_, e) => moveLog.Add(e);
 
-// The list is the underlying character's list.
-Console.WriteLine(ReferenceEquals(player.Character.SpriteSheets, player.SpriteSheets)); // True
+// Manual movement: the engine calls Move (or drives the player directly).
+player.Move(Direction.Right, speedFactor: 1, dt: 1);  // IsMoving = true
+player.Stop();                                         // IsMoving = false
+
+// Auto-walk (via GameEngine.Click) raises the same events through the engine's
+// internal ReportMovement bridge, so the log above is identical in shape.
+Console.WriteLine(string.Join(", ", moveLog));
 ```

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -55,6 +55,24 @@ namespace RPGEngine;
 /// animation snaps back to the standing frame.
 /// </para>
 /// <para>
+/// Click input drives the player with <em>auto-walk</em>: <see cref="Click"/> converts a
+/// host-surface click on the main canvas (using the canvas size recorded by the most recent
+/// <see cref="Render"/> call) to a world position, computes an A* tile path from the player's
+/// tile to the clicked tile over the non-solid tiles (see <c>AStarPathfinder</c>), and queues
+/// those tiles. Each <see cref="Update"/> then moves the player toward the center of the next
+/// waypoint at <see cref="Player.DefaultBaseSpeed"/>, popping waypoints as they are reached and
+/// calling <see cref="Player.Stop"/> when the path completes. Clicking a solid tile or an
+/// unreachable target cancels the walk without moving; a click that yields a path <em>replaces</em>
+/// the current walk even mid-walk.
+/// </para>
+/// <para>
+/// Input precedence during auto-walk: a <strong>key press</strong> (<c>isPressed == true</c> in
+/// <see cref="Input"/>) cancels the auto-walk path, a key <strong>release</strong> does not,
+/// and while a bound movement key is held the auto-walk does not advance (manual key movement
+/// takes priority). A <see cref="Click"/> always replaces the path unless the new target is
+/// invalid (solid / no path), in which case it cancels the walk.
+/// </para>
+/// <para>
 /// When a map is set, the player's displacement is resolved with <em>axis-separated
 /// movement</em> against the map's solid tiles: each axis is applied in turn and reverted when
 /// the player's sprite footprint would overlap a solid tile or leave the map (the map edge is
@@ -88,6 +106,12 @@ public sealed class GameEngine : IDisposable
     private readonly List<Character> _characters = [];
     private readonly HashSet<Key> _pressedKeys = [];
     private TileMap? _map;
+
+    // The queue of target tile waypoints the auto-walk is following (the A* path produced by
+    // Click). The head of the queue is the tile the player is currently walking toward; each
+    // tile is popped when the player reaches its center. A key press or an invalid click clears
+    // the queue (see the input-precedence rules in the class remarks).
+    private readonly Queue<(int X, int Y)> _autoWalkPath = new();
 
     // The canvas size (in pixels) of the most recent Render call, stored so the future
     // click-to-move story can translate host-surface coordinates with the same camera without
@@ -166,6 +190,14 @@ public sealed class GameEngine : IDisposable
     internal double LastCanvasHeight => _lastCanvasHeight;
 
     /// <summary>
+    /// Gets a snapshot of the tiles the auto-walk is currently following, in order from the tile
+    /// after the player's current tile to the clicked target tile. Internal so tests can assert
+    /// that <see cref="Click"/> computed the expected path and that the path is replaced or
+    /// cancelled by the input-precedence rules.
+    /// </summary>
+    internal IReadOnlyList<(int X, int Y)> AutoWalkPath => _autoWalkPath.ToArray();
+
+    /// <summary>
     /// Reports a key event to the engine. A value of <see langword="true"/> for
     /// <paramref name="isPressed"/> presses the key (key-down); <see langword="false"/> releases
     /// it (key-up). The engine keeps a set of currently pressed keys; the movement direction is
@@ -183,10 +215,88 @@ public sealed class GameEngine : IDisposable
         if (isPressed)
         {
             _pressedKeys.Add(key);
+
+            // Input precedence: a key press cancels any in-progress auto-walk. The path is
+            // replaced by the next Click, or the player simply stops on the next Update when no
+            // movement key is held. A key release does not cancel the walk.
+            _autoWalkPath.Clear();
         }
         else
         {
             _pressedKeys.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Reports a click on the <em>main</em> game canvas to the engine, in host-surface (canvas)
+    /// coordinates — the same coordinate space as <see cref="SurfaceToWorld"/>. The engine
+    /// converts the click to a world position using the canvas size recorded by the most recent
+    /// <see cref="Render"/> call, computes an A* tile path from the player's tile to the clicked
+    /// tile over the non-solid tiles, and queues it for auto-walk (see the class remarks).
+    /// </summary>
+    /// <param name="surfaceX">The horizontal surface coordinate in pixels.</param>
+    /// <param name="surfaceY">The vertical surface coordinate in pixels.</param>
+    /// <remarks>
+    /// <para>
+    /// If no <see cref="Render"/> has happened yet (the recorded canvas size is zero) the click
+    /// is ignored. Without a map the click cancels any in-progress auto-walk and does nothing
+    /// else, since there is no grid to path over.
+    /// </para>
+    /// <para>
+    /// The target tile is <c>floor(world)</c> of the converted position. Clicking a solid tile
+    /// (<see cref="Tiled.TileMap.IsSolid"/>) cancels any current auto-walk without moving.
+    /// Otherwise the engine computes
+    /// <c>AStarPathfinder.FindPath(playerTile, targetTile, (x, y) =&gt; !Map.IsSolid(x, y), Map.Width, Map.Height)</c>;
+    /// an empty path (start == goal, or the target is unreachable) also cancels the walk without
+    /// moving. A valid path <em>replaces</em> the current auto-walk path, even mid-walk.
+    /// </para>
+    /// </remarks>
+    public void Click(double surfaceX, double surfaceY)
+    {
+        // Unknown canvas size: no Render has happened yet, so the surface coordinates cannot be
+        // translated with the camera. The click is ignored.
+        if (_lastCanvasWidth <= 0 || _lastCanvasHeight <= 0)
+        {
+            return;
+        }
+
+        if (Map is null)
+        {
+            // Nothing to path over without a map: cancel any in-progress auto-walk.
+            CancelAutoWalk();
+            return;
+        }
+
+        var world = SurfaceToWorld(surfaceX, surfaceY, _lastCanvasWidth, _lastCanvasHeight);
+        (int X, int Y) targetTile = ((int)Math.Floor(world.X), (int)Math.Floor(world.Y));
+
+        // A solid target is invalid: cancel any in-progress auto-walk and do not move.
+        if (Map.IsSolid(targetTile.X, targetTile.Y))
+        {
+            CancelAutoWalk();
+            return;
+        }
+
+        var path = AStarPathfinder.FindPath(
+            Player.Position.ToTile(),
+            targetTile,
+            isWalkable: (x, y) => !Map.IsSolid(x, y),
+            Map.Width,
+            Map.Height);
+
+        // An empty path means no movement is needed or the target is unreachable: cancel the
+        // walk and do not move.
+        if (path.Count == 0)
+        {
+            CancelAutoWalk();
+            return;
+        }
+
+        // A valid click always replaces the current auto-walk path, even mid-walk.
+        _autoWalkPath.Clear();
+        foreach (var tile in path)
+        {
+            _autoWalkPath.Enqueue(tile);
         }
     }
 
@@ -200,9 +310,18 @@ public sealed class GameEngine : IDisposable
     public void Update(double dt)
     {
         var direction = Config.GetMovementDirection(_pressedKeys);
+
+        // Manual key movement takes priority over auto-walk: while a bound movement key is held
+        // the auto-walk does not advance (a key press has already cancelled the path, see Input).
+        // Otherwise, when a path is queued, the player auto-walks toward the next waypoint; when
+        // there is no key input and no auto-walk target, the player stops.
         if (direction.HasValue)
         {
             MovePlayerWithCollisionResolution(direction.Value, dt);
+        }
+        else if (!TryAdvanceAutoWalk(dt))
+        {
+            Player.Stop();
         }
 
         if (Map is not null)
@@ -713,6 +832,100 @@ public sealed class GameEngine : IDisposable
     }
 
     /// <summary>
+    /// Advances the auto-walk by one frame: moves the player toward the center of the next
+    /// waypoint tile at <see cref="Player.DefaultBaseSpeed"/> (tile units), popping waypoints as
+    /// they are reached and calling <see cref="Player.Stop"/> when the queue empties.
+    /// </summary>
+    /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
+    /// <returns>
+    /// <see langword="true"/> when the auto-walk advanced the player this frame (including the
+    /// frame on which the path completed and the player stopped); <see langword="false"/> when
+    /// there is no path to advance, so the caller knows to stop the player itself.
+    /// </returns>
+    private bool TryAdvanceAutoWalk(double dt)
+    {
+        if (_autoWalkPath.Count == 0)
+        {
+            return false;
+        }
+
+        var (nextX, nextY) = _autoWalkPath.Peek();
+        var target = new Position(nextX + 0.5, nextY + 0.5);
+        var toTarget = target - Player.Position;
+        var distance = Math.Sqrt((toTarget.X * toTarget.X) + (toTarget.Y * toTarget.Y));
+        var step = Player.Character.BaseSpeed * dt;
+
+        if (distance <= step)
+        {
+            // The player reaches this waypoint: snap to its center and pop it.
+            Player.Position = target;
+            _autoWalkPath.Dequeue();
+
+            if (_autoWalkPath.Count == 0)
+            {
+                // The path is complete: the player stops (raises Player.OnMove with IsMoving =
+                // false only if it was moving, which it is here).
+                Player.Stop();
+                return true;
+            }
+
+            // More waypoints remain: keep the player moving, facing the next waypoint.
+            var (nextTargetX, nextTargetY) = _autoWalkPath.Peek();
+            Player.ReportMovement(DirectionFromVector(new Position(nextTargetX + 0.5, nextTargetY + 0.5) - Player.Position));
+            return true;
+        }
+
+        // Move toward the waypoint center by at most one step, without overshooting.
+        var direction = DirectionFromVector(toTarget);
+        Player.Position += toTarget * (step / distance);
+        Player.ReportMovement(direction);
+        return true;
+    }
+
+    /// <summary>
+    /// Cancels any in-progress auto-walk by clearing the waypoint queue. The player itself stops
+    /// on the next <see cref="Update"/> (no input and no path &#8594; <see cref="Player.Stop"/>).
+    /// </summary>
+    private void CancelAutoWalk()
+    {
+        _autoWalkPath.Clear();
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Direction"/> closest to <paramref name="vector"/>: the vector is
+    /// normalized and the direction whose unit delta has the largest dot product with it wins,
+    /// mirroring <see cref="GameConfig.GetMovementDirection(System.Collections.Generic.IEnumerable{Key})"/>'s
+    /// quantization. Used by the auto-walk to face the waypoint it is moving toward.
+    /// </summary>
+    /// <param name="vector">The movement vector (never the zero vector when called).</param>
+    /// <returns>The closest of the eight <see cref="Direction"/> values.</returns>
+    private static Direction DirectionFromVector(Vector2 vector)
+    {
+        var length = Math.Sqrt((vector.X * vector.X) + (vector.Y * vector.Y));
+        if (length <= 0)
+        {
+            return Direction.Down;
+        }
+
+        var normalized = new Vector2(vector.X / length, vector.Y / length);
+
+        Direction? best = null;
+        var bestDot = double.NegativeInfinity;
+        foreach (var direction in Enum.GetValues<Direction>())
+        {
+            var delta = direction.Delta();
+            var dot = (normalized.X * delta.X) + (normalized.Y * delta.Y);
+            if (dot > bestDot)
+            {
+                bestDot = dot;
+                best = direction;
+            }
+        }
+
+        return best!.Value;
+    }
+
+    /// <summary>
     /// Moves the player in <paramref name="direction"/> by <c>BaseSpeed * dt</c> tiles and, when
     /// a map is set, resolves collisions against the map's solid tiles using
     /// <em>axis-separated movement</em>: the horizontal displacement is applied first and
@@ -734,37 +947,38 @@ public sealed class GameEngine : IDisposable
     private void MovePlayerWithCollisionResolution(Direction direction, double dt)
     {
         // The engine resolves the displacement itself (axis by axis) instead of calling
-        // Player.Move, which would move both axes at once; setting the direction here keeps the
-        // facing behaviour identical to the previous Player.Move call.
-        Player.Direction = direction;
-
+        // Player.Move, which would move both axes at once; the direction is set through
+        // Player.ReportMovement at the end, which also raises Player.OnMove on state transitions.
         var delta = direction.Delta() * (Player.Character.BaseSpeed * dt);
 
         if (Map is null)
         {
             Player.Position += delta;
-            return;
         }
-
-        var position = Player.Position;
-
-        // Horizontal axis: apply the X displacement, then revert it if the resulting footprint
-        // overlaps a solid tile (or leaves the map, which IsSolid treats as solid).
-        var afterX = position.WithOffset(delta.X, 0);
-        if (!PlayerFootprintOverlapsSolid(afterX))
+        else
         {
-            position = afterX;
+            var position = Player.Position;
+
+            // Horizontal axis: apply the X displacement, then revert it if the resulting
+            // footprint overlaps a solid tile (or leaves the map, which IsSolid treats as solid).
+            var afterX = position.WithOffset(delta.X, 0);
+            if (!PlayerFootprintOverlapsSolid(afterX))
+            {
+                position = afterX;
+            }
+
+            // Vertical axis: same rule, starting from the horizontal result (this is what makes
+            // diagonal movement slide along a wall on the free axis).
+            var afterY = position.WithOffset(0, delta.Y);
+            if (!PlayerFootprintOverlapsSolid(afterY))
+            {
+                position = afterY;
+            }
+
+            Player.Position = position;
         }
 
-        // Vertical axis: same rule, starting from the horizontal result (this is what makes
-        // diagonal movement slide along a wall on the free axis).
-        var afterY = position.WithOffset(0, delta.Y);
-        if (!PlayerFootprintOverlapsSolid(afterY))
-        {
-            position = afterY;
-        }
-
-        Player.Position = position;
+        Player.ReportMovement(direction);
     }
 
     /// <summary>

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -19,6 +19,13 @@ namespace RPGEngine;
 /// direction derived from <see cref="GameConfig"/>. This keeps <see cref="Player"/> a thin,
 /// easily testable wrapper.
 /// </para>
+/// <para>
+/// The player exposes a movement-state machine through <see cref="OnMove"/>: it fires whenever
+/// the player <em>starts moving</em> (idle &#8594; moving), <em>stops moving</em> (moving &#8594;
+/// idle, via <see cref="Stop"/>), or <em>changes direction while moving</em>. The event is raised
+/// for both manual (key) movement and auto-walk movement, so hosts can react to the player's
+/// movement state without polling the position every frame.
+/// </para>
 /// </remarks>
 public sealed class Player
 {
@@ -30,12 +37,39 @@ public sealed class Player
     /// </summary>
     public const double DefaultBaseSpeed = 2;
 
+    private Character _character = null!;
+
+    // The player's movement-state machine. _isMoving tracks whether the engine (or a direct
+    // Move call) is currently moving the player; _lastDirection is the last facing direction the
+    // event machinery reported, used to detect direction changes and to report the facing
+    // direction in OnMove when the player stops.
+    private bool _isMoving;
+    private Direction _lastDirection = Direction.Down;
+
+    /// <summary>
+    /// Occurs when the player's movement state changes: it starts moving (idle &#8594; moving),
+    /// stops moving (moving &#8594; idle, via <see cref="Stop"/>), or changes direction while
+    /// moving. The event carries the new state (<see cref="PlayerMoveEventArgs.IsMoving"/>) and
+    /// the player's current facing direction (<see cref="PlayerMoveEventArgs.Direction"/>). It is
+    /// raised for both manual (key) movement and auto-walk movement.
+    /// </summary>
+    public event EventHandler<PlayerMoveEventArgs>? OnMove;
+
     /// <summary>Gets or sets the <see cref="Character"/> that represents the player in the game world.</summary>
     /// <remarks>
     /// All other members of <see cref="Player"/> forward to this character, so replacing it
-    /// replaces the player's position, direction, speed and spritesheets as well.
+    /// replaces the player's position, direction, speed and spritesheets as well. The movement
+    /// event state is re-synchronized to the new character's facing direction.
     /// </remarks>
-    public Character Character { get; set; }
+    public Character Character
+    {
+        get => _character;
+        set
+        {
+            _character = value;
+            _lastDirection = _character.Direction;
+        }
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Player"/> class with its own
@@ -68,12 +102,17 @@ public sealed class Player
 
     /// <summary>
     /// Gets or sets the direction the player is facing. Forwards to
-    /// <see cref="Character.Direction"/>.
+    /// <see cref="Character.Direction"/> and keeps the movement event state in sync so
+    /// <see cref="OnMove"/> reports the correct facing direction.
     /// </summary>
     public Direction Direction
     {
         get => Character.Direction;
-        set => Character.Direction = value;
+        set
+        {
+            Character.Direction = value;
+            _lastDirection = value;
+        }
     }
 
     /// <summary>
@@ -90,11 +129,53 @@ public sealed class Player
     /// tiles and sets the facing direction. Forwards to
     /// <see cref="Character.Move(Direction, double, double)"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method also drives the movement-state machine: with <paramref name="speedFactor"/>
+    /// greater than zero the player is considered <em>moving</em> (it actually moves), so
+    /// <see cref="OnMove"/> fires with <see cref="PlayerMoveEventArgs.IsMoving"/> set to
+    /// <see langword="true"/> when the player starts moving (idle &#8594; moving) or changes
+    /// direction while moving.
+    /// </para>
+    /// <para>
+    /// With <paramref name="speedFactor"/> equal to zero the player only turns to face
+    /// <paramref name="direction"/>: <see cref="OnMove"/> fires on a direction change carrying
+    /// the current movement state (<see langword="true"/> when the player was already moving,
+    /// <see langword="false"/> when idle).
+    /// </para>
+    /// </remarks>
     /// <param name="direction">The direction to face and move towards.</param>
     /// <param name="speedFactor">A multiplier applied to the character's <see cref="Character.BaseSpeed"/>.</param>
     /// <param name="dt">The elapsed time in seconds.</param>
     public void Move(Direction direction, double speedFactor = 1, double dt = 1)
-        => Character.Move(direction, speedFactor, dt);
+    {
+        var wasMoving = _isMoving;
+        var previousDirection = _lastDirection;
+
+        // Face the requested direction first so the character, the event state and the reported
+        // facing all agree.
+        Direction = direction;
+
+        if (speedFactor == 0)
+        {
+            // Only turns: the movement state is unchanged; raise OnMove on a direction change
+            // with the current moving state.
+            if (direction != previousDirection)
+            {
+                OnMove?.Invoke(this, new PlayerMoveEventArgs(_isMoving, direction));
+            }
+
+            return;
+        }
+
+        Character.Move(direction, speedFactor, dt);
+
+        _isMoving = true;
+        if (!wasMoving || direction != previousDirection)
+        {
+            OnMove?.Invoke(this, new PlayerMoveEventArgs(true, direction));
+        }
+    }
 
     /// <summary>
     /// Moves the player in its current facing direction. Forwards to
@@ -103,5 +184,54 @@ public sealed class Player
     /// <param name="speedFactor">A multiplier applied to the character's <see cref="Character.BaseSpeed"/>.</param>
     /// <param name="dt">The elapsed time in seconds.</param>
     public void Move(double speedFactor = 1, double dt = 1)
-        => Character.Move(speedFactor, dt);
+        => Move(Direction, speedFactor, dt);
+
+    /// <summary>
+    /// Transitions the player to idle (stops moving) and raises <see cref="OnMove"/> with
+    /// <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/>. When the player
+    /// is already idle this method is a no-op and does not raise the event. The engine calls it
+    /// when there is no key input and no auto-walk target.
+    /// </summary>
+    /// <remarks>
+    /// Stopping does not change the facing direction: the player keeps facing the direction it
+    /// was last moving, and that direction is reported in the event.
+    /// </remarks>
+    public void Stop()
+    {
+        if (!_isMoving)
+        {
+            return;
+        }
+
+        _isMoving = false;
+        OnMove?.Invoke(this, new PlayerMoveEventArgs(false, _lastDirection));
+    }
+
+    /// <summary>
+    /// Records that the player moved and raises <see cref="OnMove"/> on state transitions,
+    /// mirroring the state-machine behavior of <see cref="Move(Direction, double, double)"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the internal bridge the engine uses for movement it resolves itself (the
+    /// axis-separated collision resolution of <see cref="GameEngine"/> and the auto-walk
+    /// movement), which cannot go through <see cref="Move(Direction, double, double)"/> because
+    /// that method applies the whole displacement at once. It faces the player, marks it as
+    /// moving and raises <see cref="OnMove"/> with <see cref="PlayerMoveEventArgs.IsMoving"/>
+    /// set to <see langword="true"/> when the player starts moving or changes direction while
+    /// moving.
+    /// </remarks>
+    /// <param name="direction">The direction the player moved in (and now faces).</param>
+    internal void ReportMovement(Direction direction)
+    {
+        var wasMoving = _isMoving;
+        var previousDirection = _lastDirection;
+
+        Direction = direction;
+        _isMoving = true;
+
+        if (!wasMoving || direction != previousDirection)
+        {
+            OnMove?.Invoke(this, new PlayerMoveEventArgs(true, direction));
+        }
+    }
 }

--- a/src/RPGEngine/PlayerMoveEventArgs.cs
+++ b/src/RPGEngine/PlayerMoveEventArgs.cs
@@ -1,0 +1,13 @@
+namespace RPGEngine;
+
+/// <summary>
+/// Provides data for the <see cref="Player.OnMove"/> event: whether the player is now moving
+/// and the direction it is currently facing.
+/// </summary>
+/// <param name="IsMoving">
+/// <see langword="true"/> when the player is now moving; <see langword="false"/> when it has
+/// stopped. For a speed-factor-zero turn (see <see cref="Player.Move(Direction, double, double)"/>)
+/// the value reflects the current movement state (moving or idle) at the moment of the turn.
+/// </param>
+/// <param name="Direction">The direction the player is currently facing.</param>
+public sealed record PlayerMoveEventArgs(bool IsMoving, Direction Direction);

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -74,6 +74,53 @@ public class DocsExamplesTests
         Assert.NotEqual(0, bitmap.GetPixel(320, 240).Alpha);
     }
 
+
+    // ---------------------------------------------------------------------
+    // docs/api/GameEngine.md and docs/api/Player.md: click-to-move auto-walk
+    // and the OnMove movement-state event (story 38).
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// The click-to-move example from the documentation: render once so the engine knows the
+    /// canvas size, click a distant walkable tile, and the player auto-walks along the A* path
+    /// to the clicked tile center while <see cref="Player.OnMove"/> fires on the start and the
+    /// completion.
+    /// </summary>
+    [Fact]
+    public void ClickToMove_AutoWalksToClickedTileAndFiresOnMove()
+    {
+        using var fixture = new TiledTestFixture(
+            10, 10,
+            new[] { new TileLayerSpec("ground", Enumerable.Repeat(1u, 10 * 10).ToArray()) });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        var moveEvents = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => moveEvents.Add(e);
+
+        // Render at least once so the engine knows the canvas size, then translate a mouse click.
+        const int canvas = 480; // 10 tiles x 48 px: the whole map is visible
+        using (var bitmap = new SKBitmap(canvas, canvas))
+        using (var renderCanvas = new SKCanvas(bitmap))
+        {
+            engine.Render(renderCanvas, FrameDt);
+        }
+
+        // Click at the canvas position of the tile the host wants the player to walk to.
+        var surface = engine.WorldToSurface(new Position(5.5, 5.5), canvas, canvas);
+        engine.Click(surface.X, surface.Y);
+
+        // The player now auto-walks along the A* path; drive the loop normally.
+        var target = new Position(5.5, 5.5);
+        for (var frame = 0; frame < 5000 && engine.Player.Position != target; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(target, engine.Player.Position);
+        Assert.Contains(moveEvents, e => e.IsMoving);   // the walk started
+        Assert.Contains(moveEvents, e => !e.IsMoving);  // and completed (stopped)
+    }
+
     // ---------------------------------------------------------------------
     // docs/api/GameEngine.md: the Render example. When a map is smaller than the
     // canvas it is centered and the area around it is black (story 24).

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -1198,6 +1198,331 @@ public class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 38: click-to-move with A* auto-walk and Player.OnMove. Click
+    // converts a host-surface click (using the canvas size recorded by the most
+    // recent Render) to a tile, computes an A* path over the non-solid tiles,
+    // and auto-walks the player along it at BaseSpeed, stopping on the clicked
+    // tile center. Clicking a solid tile or an unreachable target cancels the
+    // walk without moving; a key press cancels it (a release does not); a click
+    // mid-walk replaces the destination. OnMove fires for auto-walk too.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies clicking a walkable tile computes an A* path and auto-walks the player along it,
+    /// ending exactly centered on the clicked tile and visiting every waypoint tile.
+    /// </summary>
+    [Fact]
+    public void Click_OnWalkableTile_WalksAlongPathAndEndsCenteredOnClickedTile()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        const int canvas = 480; // 10 tiles x 48 px, the whole map is visible
+        ClickOnTile(engine, 5, 5, canvas, canvas);
+
+        // Snapshot the computed path before the walk consumes it: it leads from the player's
+        // tile (0,0) to the clicked tile (5,5).
+        var path = engine.AutoWalkPath;
+        Assert.NotEmpty(path);
+        Assert.Equal((5, 5), path[^1]);
+
+        var target = new Position(5.5, 5.5);
+        var visited = new HashSet<(int X, int Y)>();
+        for (var frame = 0; frame < 5000; frame++)
+        {
+            engine.Update(FrameDt);
+            visited.Add(engine.Player.Position.ToTile());
+            if (engine.Player.Position == target)
+            {
+                break;
+            }
+        }
+
+        // The player ends exactly centered on the clicked tile and the path is consumed.
+        Assert.Equal(target, engine.Player.Position);
+        Assert.Empty(engine.AutoWalkPath);
+
+        // The path was followed tile by tile: every waypoint tile was visited.
+        foreach (var tile in path)
+        {
+            Assert.Contains(tile, visited);
+        }
+    }
+
+    /// <summary>
+    /// Verifies OnMove fires for auto-walk: clicking a distant walkable tile starts the walk
+    /// (IsMoving = true on the first Update) and completing it stops the player (IsMoving =
+    /// false), both with the correct facing direction.
+    /// </summary>
+    [Fact]
+    public void Click_OnMove_FiresTrueWhenWalkStartsAndFalseWhenItCompletes()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        const int canvas = 480;
+        ClickOnTile(engine, 3, 3, canvas, canvas);
+
+        // The first Update starts the walk toward (1.5, 1.5): down-right.
+        engine.Update(FrameDt);
+        Assert.Equal(new[] { new PlayerMoveEventArgs(true, Direction.DownRight) }, events);
+        events.Clear();
+
+        var target = new Position(3.5, 3.5);
+        for (var frame = 0; frame < 5000 && engine.Player.Position != target; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(target, engine.Player.Position);
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.DownRight) }, events);
+    }
+
+    /// <summary>
+    /// Verifies clicking a solid tile cancels any in-progress auto-walk and leaves the player
+    /// unmoved on the next Update.
+    /// </summary>
+    [Fact]
+    public void Click_OnSolidTile_CancelsAutoWalkAndDoesNotMove()
+    {
+        // 6x6 map with a solid wall column at x=3.
+        var gids = new uint[36];
+        for (var y = 0; y < 6; y++)
+        {
+            gids[(y * 6) + 3] = 1;
+        }
+
+        using var fixture = CreateCollisionMapFixture(6, 6, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        const int canvas = 288; // 6 tiles x 48 px
+        ClickOnTile(engine, 1, 1, canvas, canvas);
+        engine.Update(FrameDt);
+        Assert.NotEmpty(engine.AutoWalkPath);
+
+        // Mid-walk, click a solid tile: the walk is cancelled and the player does not move.
+        ClickOnTile(engine, 3, 0, canvas, canvas);
+        Assert.Empty(engine.AutoWalkPath);
+
+        var positionBefore = engine.Player.Position;
+        engine.Update(FrameDt);
+        Assert.Equal(positionBefore, engine.Player.Position);
+    }
+
+    /// <summary>
+    /// Verifies a click on a reachable target behind a wall computes a detour around the wall and
+    /// the player walks to the target.
+    /// </summary>
+    [Fact]
+    public void Click_OnReachableTargetBehindWall_WalksAroundTheWall()
+    {
+        // 7x5 map: a "walls" collision layer with a solid column at x=3 for rows 0..2, leaving a
+        // gap at the bottom (rows 3-4) so the target at (5,0) is reachable only with a detour.
+        var gids = new uint[35];
+        gids[(0 * 7) + 3] = 1;
+        gids[(1 * 7) + 3] = 1;
+        gids[(2 * 7) + 3] = 1;
+
+        using var fixture = CreateCollisionMapFixture(7, 5, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        const int canvas = 336; // 7 tiles x 48 px
+        ClickOnTile(engine, 5, 0, canvas, canvas);
+
+        Assert.NotEmpty(engine.AutoWalkPath);
+        // The path must detour around the wall: it cannot cross x=3 at rows 0..2, so it has to go
+        // through a row at or below y=3.
+        Assert.Contains(engine.AutoWalkPath, tile => tile.Y >= 3);
+
+        var target = new Position(5.5, 0.5);
+        for (var frame = 0; frame < 5000 && engine.Player.Position != target; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(target, engine.Player.Position);
+    }
+
+    /// <summary>
+    /// Verifies clicking an unreachable target (a tile enclosed by walls) leaves the player
+    /// unmoved and cancels any in-progress auto-walk.
+    /// </summary>
+    [Fact]
+    public void Click_OnUnreachableTarget_DoesNotMove()
+    {
+        // 7x7 map with a closed 3x3 ring of walls around the center tile (3,3).
+        var gids = new uint[49];
+        for (var y = 0; y < 7; y++)
+        {
+            for (var x = 0; x < 7; x++)
+            {
+                var onRing = ((y == 2 || y == 4) && x >= 2 && x <= 4) ||
+                             ((x == 2 || x == 4) && y >= 2 && y <= 4);
+                gids[(y * 7) + x] = onRing ? 1u : 0u;
+            }
+        }
+
+        using var fixture = CreateCollisionMapFixture(7, 7, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        const int canvas = 336; // 7 tiles x 48 px
+        ClickOnTile(engine, 3, 3, canvas, canvas);
+
+        // No path to the enclosed tile: the walk is cancelled and the player does not move.
+        Assert.Empty(engine.AutoWalkPath);
+        var positionBefore = engine.Player.Position;
+        engine.Update(FrameDt);
+        Assert.Equal(positionBefore, engine.Player.Position);
+    }
+
+    /// <summary>
+    /// Verifies a key press during auto-walk cancels the path and the player stops on the next
+    /// Update, while a key release alone does not cancel the walk.
+    /// </summary>
+    [Fact]
+    public void Input_KeyPressDuringAutoWalk_CancelsWalk_ButReleaseAloneDoesNot()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        const int canvas = 480;
+        ClickOnTile(engine, 5, 5, canvas, canvas);
+
+        // A key release alone does not cancel the walk.
+        engine.Input(Key.X, isPressed: false);
+        Assert.NotEmpty(engine.AutoWalkPath);
+
+        // A key press cancels it.
+        engine.Input(Key.X, isPressed: true);
+        Assert.Empty(engine.AutoWalkPath);
+
+        // The player stops on the next Update (no input, no path) and does not move further.
+        var positionBefore = engine.Player.Position;
+        engine.Update(FrameDt);
+        Assert.Equal(positionBefore, engine.Player.Position);
+        Assert.Empty(engine.AutoWalkPath);
+    }
+
+    /// <summary>
+    /// Verifies a click during auto-walk replaces the destination: the player changes course
+    /// toward the new target without stopping first (no IsMoving = false before the final stop).
+    /// </summary>
+    [Fact]
+    public void Click_DuringAutoWalk_ReplacesDestinationWithoutStopping()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 0.5);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        const int canvas = 480;
+        ClickOnTile(engine, 5, 5, canvas, canvas);
+        engine.Update(FrameDt); // the walk starts (IsMoving = true)
+        Assert.NotEmpty(engine.AutoWalkPath);
+
+        // Mid-walk, click a different target: the path is replaced.
+        ClickOnTile(engine, 8, 1, canvas, canvas);
+        Assert.NotEmpty(engine.AutoWalkPath);
+        Assert.Equal((8, 1), engine.AutoWalkPath[^1]);
+
+        var target = new Position(8.5, 1.5);
+        for (var frame = 0; frame < 5000 && engine.Player.Position != target; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(target, engine.Player.Position);
+        // The player never stopped mid-course: the only stop event is the final one.
+        Assert.Equal(1, events.Count(e => !e.IsMoving));
+        Assert.False(events[^1].IsMoving);
+        // It did start moving from the first click.
+        Assert.Contains(events, e => e.IsMoving);
+    }
+
+    /// <summary>
+    /// Verifies a click before any Render (unknown canvas size) is ignored without throwing, even
+    /// when a map is loaded.
+    /// </summary>
+    [Fact]
+    public void Click_BeforeAnyRender_IsIgnoredWithoutThrowing()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        // No Render has happened, so the canvas size is unknown: the click must be a no-op.
+        engine.Click(120, 90);
+        Assert.Empty(engine.AutoWalkPath);
+        Assert.Equal(new Position(0, 0), engine.Player.Position);
+
+        engine.Update(FrameDt);
+        Assert.Equal(new Position(0, 0), engine.Player.Position);
+    }
+
+    /// <summary>
+    /// Verifies manual key movement still raises OnMove with the exact start/stop sequence (the
+    /// engine reports movement through Player.ReportMovement after its collision resolution).
+    /// </summary>
+    [Fact]
+    public void Update_KeyMovement_RaisesOnMoveOnStartAndStop()
+    {
+        var engine = new GameEngine();
+        engine.Player.Character.BaseSpeed = 2;
+        engine.Player.Position = new Position(10, 10);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.D, true);
+        engine.Update(FrameDt);
+        Assert.Equal(new[] { new PlayerMoveEventArgs(true, Direction.Right) }, events);
+
+        engine.Input(Key.D, false);
+        events.Clear();
+        engine.Update(FrameDt);
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.Right) }, events);
+    }
+
+    /// <summary>Verifies changing direction with the keys while moving raises OnMove with the new direction.</summary>
+    [Fact]
+    public void Update_KeyMovement_ChangingDirectionRaisesOnMove()
+    {
+        var engine = new GameEngine();
+        engine.Player.Character.BaseSpeed = 2;
+        engine.Player.Position = new Position(10, 10);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.D, true);
+        engine.Update(FrameDt); // moving right
+
+        // Switch to moving down: direction change while moving.
+        engine.Input(Key.D, false);
+        engine.Input(Key.S, true);
+        engine.Update(FrameDt);
+
+        Assert.Contains(new PlayerMoveEventArgs(true, Direction.Down), events);
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
@@ -1232,6 +1557,17 @@ public class GameEngineTests
         using var stream = CharacterTestHelper.CreateSheetStream(seed);
         engine.LoadSpriteSheet("hero", stream);
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+    }
+
+    /// <summary>
+    /// Renders once (recording the canvas size in the engine) and clicks the center of the given
+    /// tile in host-surface coordinates, translated through the same camera as <see cref="Render"/>.
+    /// </summary>
+    private static void ClickOnTile(GameEngine engine, int tileX, int tileY, int canvasWidth, int canvasHeight)
+    {
+        using var bitmap = Render(engine, canvasWidth, canvasHeight);
+        var surface = engine.WorldToSurface(new Position(tileX + 0.5, tileY + 0.5), canvasWidth, canvasHeight);
+        engine.Click(surface.X, surface.Y);
     }
 
     /// <summary>Renders the engine into a fresh transparent bitmap of the requested size.</summary>

--- a/tests/RPGEngine.Tests/PlayerTests.cs
+++ b/tests/RPGEngine.Tests/PlayerTests.cs
@@ -169,4 +169,155 @@ public class PlayerTests
         Assert.Equal(2, player.Position.X, precision: 6);
         Assert.Equal(1, player.Position.Y, precision: 6);
     }
+
+    // ---------------------------------------------------------------------
+    // Story 38: Player.OnMove movement-state events. OnMove fires on every
+    // movement-state transition: starts moving (idle -> moving), stops moving
+    // (moving -> idle, via Stop()), and changes direction while moving. It is
+    // raised for both manual (key) movement and auto-walk movement, carries the
+    // new IsMoving state and the current facing direction, and a speed-factor-
+    // zero Move only turns (fires on direction change with the current state).
+    // ---------------------------------------------------------------------
+
+    /// <summary>Verifies the first Move from idle raises OnMove with IsMoving = true and the facing direction.</summary>
+    [Fact]
+    public void Move_WhenIdle_RaisesOnMoveWithIsMovingTrue()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+
+        Assert.Equal(new[] { new PlayerMoveEventArgs(true, Direction.Right) }, events);
+    }
+
+    /// <summary>Verifies moving again in the same direction while already moving does not raise OnMove (no transition).</summary>
+    [Fact]
+    public void Move_SameDirectionWhileMoving_DoesNotRaiseOnMove()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        events.Clear();
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+
+        Assert.Empty(events);
+    }
+
+    /// <summary>Verifies a direction change while moving raises OnMove with IsMoving = true and the new direction.</summary>
+    [Fact]
+    public void Move_DirectionChangeWhileMoving_RaisesOnMove()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        player.Move(Direction.Down, speedFactor: 1, dt: 1);
+
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.Right),
+                new PlayerMoveEventArgs(true, Direction.Down),
+            },
+            events);
+    }
+
+    /// <summary>
+    /// Verifies a speed-factor-zero Move only turns: it raises OnMove on a direction change with
+    /// the current moving state (false when idle, true when already moving) and never marks the
+    /// player as moving.
+    /// </summary>
+    [Fact]
+    public void Move_SpeedFactorZero_TurnsAndRaisesWithCurrentMovingState()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        // Idle turn: IsMoving = false.
+        player.Move(Direction.Right, speedFactor: 0);
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.Right) }, events);
+        events.Clear();
+
+        // Turn while moving: IsMoving = true, direction changes.
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        player.Move(Direction.Down, speedFactor: 0);
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.Right),
+                new PlayerMoveEventArgs(true, Direction.Down),
+            },
+            events);
+    }
+
+    /// <summary>Verifies a speed-factor-zero Move to the already-facing direction raises nothing.</summary>
+    [Fact]
+    public void Move_SpeedFactorZero_SameDirection_DoesNotRaiseOnMove()
+    {
+        var player = new Player { Direction = Direction.Right };
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 0);
+
+        Assert.Empty(events);
+    }
+
+    /// <summary>Verifies Stop() when moving raises OnMove with IsMoving = false and keeps the facing direction.</summary>
+    [Fact]
+    public void Stop_WhenMoving_RaisesOnMoveWithIsMovingFalse()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        events.Clear();
+        player.Stop();
+
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.Right) }, events);
+    }
+
+    /// <summary>Verifies Stop() when already idle is a no-op and raises nothing.</summary>
+    [Fact]
+    public void Stop_WhenIdle_DoesNotRaiseOnMove()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Stop();
+
+        Assert.Empty(events);
+    }
+
+    /// <summary>Verifies the exact event sequence across start, same-direction move, direction change and stop.</summary>
+    [Fact]
+    public void MoveThenStop_ProducesExactEventSequence()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        player.Move(Direction.Right, speedFactor: 1, dt: 1); // same direction: no event
+        player.Move(Direction.Down, speedFactor: 1, dt: 1);  // direction change: event
+        player.Stop();
+        player.Stop(); // already idle: no event
+
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.Right),
+                new PlayerMoveEventArgs(true, Direction.Down),
+                new PlayerMoveEventArgs(false, Direction.Down),
+            },
+            events);
+    }
 }


### PR DESCRIPTION
Closes #38

## Summary

Adds click-to-move with A* auto-walk and the `Player.OnMove` movement-state event.

### Source (`src/RPGEngine`)
- **`PlayerMoveEventArgs`** (new public sealed record): carries `IsMoving` and the current facing `Direction`; XML-documented.
- **`Player`**: new `OnMove` event (`EventHandler<PlayerMoveEventArgs>`) fired on every movement-state transition — starts moving (idle → moving), stops moving (moving → idle via the new `Stop()`), and changes direction while moving. `Move(direction, speedFactor, dt)` drives the state machine (`speedFactor == 0` only turns → raises on direction change with the current moving state); `Stop()` raises `IsMoving = false` only when the player was moving. Internal `ReportMovement` is the bridge the engine uses for collision-resolved and auto-walk movement.
- **`GameEngine`**: new `Click(surfaceX, surfaceY)` converts a host-surface click using the canvas size recorded by the most recent `Render` (ignored if no render yet), computes an A* tile path over non-solid tiles (`AStarPathfinder` wired to `!Map.IsSolid`), and queues it for auto-walk. `Update` auto-walks the player toward each waypoint's center at `BaseSpeed`, popping waypoints on arrival and calling `Player.Stop()` when the path completes. Input precedence: a key press cancels the walk, a release does not, a valid click replaces the path mid-walk, and an invalid click (solid tile / no path) cancels it. Class remarks updated.

### Tests
- **`PlayerTests`**: `OnMove` start/stop/direction-change sequences, speed-factor-zero turns, `Stop()` no-op when idle.
- **`GameEngineTests`**: click-to-move end-to-end (walk to clicked tile center, path followed tile by tile), `OnMove` for auto-walk, solid-tile cancel, reachable-behind-wall detour, unreachable target no-move, key-press cancel vs release, click-replaces-destination without stopping, click-before-render ignored, and key-movement `OnMove` regression. Uses `TiledTestFixture` maps with `is_collision` walls.
- **`DocsExamplesTests`**: a `ClickToMove_AutoWalksToClickedTileAndFiresOnMove` case mirroring the new docs example.

### Documentation
- `docs/api/Player.md`: `OnMove`, `PlayerMoveEventArgs`, `Stop()` with commented examples.
- `docs/api/GameEngine.md`: `Click` with a commented example plus remarks/input/update updates.
- `docs/Architecture.md`: click-to-move pipeline, auto-walk, input precedence and the pathfinding integration.
- `docs/README.md`: quick-start note and reading-order updates (optional click demo).

### Verification
- `dotnet build -c Release`: 0 warnings / 0 errors.
- `dotnet test tests/RPGEngine.Tests -c Release`: 337 passed (was 318 before this story).
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~PlayerTests|FullyQualifiedName~GameEngineTests"`: 76 passed.