### PR TITLE
Story 50: Sprite display origin (middle-bottom anchor) and lower-half collisions

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -28,8 +28,10 @@ Player ── Character (Position, Direction, BaseSpeed, SpriteSheets, walk-cycl
 `Player` is a thin wrapper that forwards state access and movement to its `Character`. All of
 the in-world state lives on `Character`:
 
-- `Character.Position` — top-left world position of the sprite, in **tiles** (its size is the
-  configured sheet's derived cell size, in pixels, used only for clamping).
+- `Character.Position` — the **feet** position (the *middle-bottom* of the sprite, where the
+  character stands), in **tiles**. The sprite is rendered above and centered on this point; its
+  size is the configured sheet's derived cell size, in pixels, used only for clamping and the
+  collision footprint.
 - `Character.Direction` — the facing direction (8 directions: Down/Left/Right/Up plus the four diagonals).
 - `Character.BaseSpeed` — movement speed in **tiles per second** (the player default is 2,
   i.e. the tile-unit equivalent of 96 px/s at 48 px tiles).
@@ -80,7 +82,10 @@ canvasHeight)` (internal, asserted by the tests):
 `Render` turns the tile origin into a pixel viewport for the map (a pure pixel renderer) and
 into pixel screen positions for the characters. The map's `TileMap.Draw` / `DrawAbovePlayer`
 receive a pixel `SKRect` and blit their prerendered layer images; each character is drawn at
-screen position `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`.
+its **feet** (anchor) screen position `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`. The
+compositor anchors every sprite at its **middle-bottom**, so a character's sprite top-left is
+at `(pos.X*ts - w/2 - origin.X*ts, pos.Y*ts - h - origin.Y*ts)` in world pixels (the sprite is
+drawn above and centered on its feet).
 
 The engine exposes two public conversions that use the **same camera** (follow + clamp) for the
 given canvas size, so a host can translate between canvas pixels and world tiles without
@@ -259,8 +264,11 @@ a map has no collision layer, every in-bounds cell is walkable. Non-collision la
 The engine resolves the player's movement with **axis-separated movement** against a footprint
 in tile units:
 
-- The footprint is the player's sprite size in pixels (`Character.GetSpriteSize`) converted to
-  tiles (`px / ts`, where `ts` is the map's tile width), positioned at the player's top-left.
+- The footprint is the **lower half** of the sprite **anchored at the feet** (`Position` is the
+  sprite's middle-bottom). With the sprite size in pixels (`Character.GetSpriteSize`) converted
+  to tiles (`px / ts`, where `ts` is the map's tile width), the footprint rectangle is
+  `(pos.X - w/(2*ts), pos.Y - h/(2*ts))` with size `(w/ts, h/(2*ts))` — the upper half of the
+  sprite (the upper body) never collides with the ground.
 - `TileMap.IsAreaSolid(x, y, width, height)` (internal) tests the tiles overlapped by that
   tile-unit rectangle: the bounds are floored to the containing cells, and a rectangle that ends
   exactly on a tile boundary does not count the next tile.
@@ -271,8 +279,11 @@ in tile units:
 This keeps **wall-sliding** natural (a blocked axis reverts while the other axis still moves, so
 a diagonal move into a wall slides along the wall on the free axis) and prevents **diagonal
 corner-cutting** (each axis is resolved independently, so a diagonal cannot squeeze diagonally
-through a corner). The existing map-bounds clamp (`ClampPlayerToMap`) remains as a safety net
-for positions placed outside the map by other means.
+through a corner). The map-bounds clamp (`ClampPlayerToMap`) keeps the **lower-half footprint**
+inside the map (the feet clamp to `x ∈ [halfWidth, max(halfWidth, Map.Width - halfWidth)]`,
+`y ∈ [halfHeight, max(halfHeight, Map.Height)]` — for the default 48×48 sprite with 48 px
+tiles this is `x ∈ [0.5, Map.Width - 0.5]`, `y ∈ [0.5, Map.Height]`) and remains as a
+safety net for positions placed outside the map by other means. The map edge is solid.
 
 NPCs are not moved by the engine (they have no AI yet), so collision resolution currently only
 applies to the player; the public `TileMap.IsSolid` API is available for future NPC logic.
@@ -374,9 +385,10 @@ below-player layers → NPCs → player → above-player layers
 - **The camera works in tiles and renders in pixels.** `Render` computes the camera origin in
   tiles (follow + clamp, see above), derives a pixel viewport
   `(origin.X*ts, origin.Y*ts, origin.X*ts + canvasWidth, origin.Y*ts + canvasHeight)` and passes
-  it to the map renderer (which stays a pure pixel renderer), and draws each character at the
-  screen position `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`. The canvas size is read
-  from the canvas clip bounds.
+  it to the map renderer (which stays a pure pixel renderer), and draws each character at its
+  **feet** (middle-bottom anchor) screen position
+  `(pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts)`; the sprite is drawn above and centered on
+  that point. The canvas size is read from the canvas clip bounds.
 - When the map is **smaller than the canvas** on an axis it is **centered** in the canvas and
   the area around it stays black (`offset = max(0, (canvasSize − mapPixelSize) / (2*ts))` tiles),
   so a small map is never letterboxed with transparent or leftover pixels. When the map fills

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,8 @@ using var heroStream = new MemoryStream(await http.GetByteArrayAsync("assets/cha
 await engine.LoadSpriteSheetAsync("hero", heroStream);
 
 // 3. Place the player (in tiles — the fixture map has 48 px tiles) and give it the "hero"
-//    sheet, character slot 1.
+//    sheet, character slot 1. Position is the player's FEET (the middle-bottom of the sprite,
+//    where it stands): the sprite is rendered above and centered on this point.
 engine.Player.Position = new Position(6, 6);
 engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -22,10 +22,16 @@ spritesheet references used to render it.
 
 ### `Position Position`
 
-Gets or sets the top-left world position of the character's sprite, in tiles.
+Gets or sets the world position of the character's **feet** — the *middle-bottom* of the
+sprite — in tiles. The sprite is rendered above and centered on this point, so a position of
+`(8.5, 8.5)` means the character stands with its feet at the centre of tile `(8, 8)`. In world
+pixels the sprite's top-left is at `(pos.X*ts - w/2, pos.Y*ts - h)` where `ts` is the map's
+tile size and `w`/`h` the sprite's pixel size.
 
 ```csharp
-var character = new Character { Position = new Position(3, 4) };
+// Feet (middle-bottom) at the centre of tile (3, 4): the sprite is drawn above and centered
+// on this point.
+var character = new Character { Position = new Position(3.5, 4.5) };
 ```
 
 ### `Direction Direction`

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -48,8 +48,11 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   See [Architecture](../Architecture.md).
 - When a map is set, the player's displacement is resolved with **axis-separated movement**
   against the map's solid tiles (layers declaring the Tiled `is_collision` bool property): each
-  axis is applied in turn and reverted when the player's sprite footprint would overlap a solid
-  tile or leave the map (the map edge is solid). See [Architecture](../Architecture.md).
+  axis is applied in turn and reverted when the player's collision footprint would overlap a
+  solid tile or leave the map (the map edge is solid). The footprint is the **lower half of the
+  sprite anchored at the feet** (`Position` is the middle-bottom of the sprite), so the upper
+  body never collides with the ground; the map-bounds clamp keeps that lower-half footprint
+  inside the map. See [Architecture](../Architecture.md).
 - A minimap can be rendered on a separate surface with `RenderMinimap`: it draws the map's
   prerendered tile layers, a green dot for the player and a yellow dot for each NPC.
   `zoomLevel` `1.0` fits the whole map to the canvas; values above `1` zoom in and pan around

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -59,11 +59,12 @@ player.Character.Position = new Position(6, 6);
 
 ### `Position Position`
 
-Gets or sets the top-left world position of the player's sprite, in tiles. Forwards to
+Gets or sets the world position of the player's **feet** — the *middle-bottom* of the
+sprite — in tiles. The sprite is rendered above and centered on this point. Forwards to
 `Character.Position`.
 
 ```csharp
-player.Position = new Position(6, 6);
+player.Position = new Position(6, 6); // feet at the centre of tile (6, 6)
 ```
 
 ### `Direction Direction`

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -62,7 +62,12 @@ public sealed class Character
     // the first step goes toward 0, then the bounce alternates direction at each end.
     private int _frameStep = -1;
 
-    /// <summary>Gets or sets the top-left world position of the character's sprite, in tiles.</summary>
+    /// <summary>
+    /// Gets or sets the world position of the character's feet, in tiles. The feet are the
+    /// <em>middle-bottom</em> of the sprite: the sprite is rendered above and centered on this
+    /// point, so a position of <c>(8.5, 8.5)</c> means the character stands with its feet at the
+    /// centre of tile <c>(8, 8)</c>.
+    /// </summary>
     public Position Position { get; set; }
 
     /// <summary>Gets or sets the direction the character is facing.</summary>
@@ -231,12 +236,14 @@ public sealed class Character
     }
 
     /// <summary>
-    /// Draws the character at <paramref name="screenPosition"/> (its world position minus the
-    /// camera origin). The spritesheet references are resolved through
-    /// <paramref name="spriteSheetManager"/>, which the engine supplies at draw time.
+    /// Draws the character at <paramref name="anchorPosition"/> (its feet position — the
+    /// middle-bottom of the sprite — minus the camera origin). The spritesheet references are
+    /// resolved through <paramref name="spriteSheetManager"/>, which the engine supplies at
+    /// draw time.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
-    /// <param name="screenPosition">The top-left screen position of the sprite (its size is the sheet's derived cell size).</param>
+    /// <param name="anchorPosition">The feet (middle-bottom) anchor of the sprite, in pixels:
+    /// the sprite is drawn above and centered on this point.</param>
     /// <param name="dt">The elapsed time in seconds (reserved for future animation timing).</param>
     /// <param name="spriteSheetManager">The manager that resolves the referenced sheet names.</param>
     /// <exception cref="InvalidOperationException">
@@ -246,9 +253,9 @@ public sealed class Character
     /// <exception cref="ArgumentOutOfRangeException">
     /// A <see cref="SpriteSheetRef"/> has a <see cref="SpriteSheetRef.CharacterIndex"/> outside 1..8.
     /// </exception>
-    internal void Draw(SKCanvas canvas, Position screenPosition, double dt, SpriteSheetManager spriteSheetManager)
+    internal void Draw(SKCanvas canvas, Position anchorPosition, double dt, SpriteSheetManager spriteSheetManager)
     {
-        _compositor.Draw(canvas, screenPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager);
+        _compositor.Draw(canvas, anchorPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager);
     }
 
     /// <summary>

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -75,9 +75,13 @@ namespace RPGEngine;
 /// <para>
 /// When a map is set, the player's displacement is resolved with <em>axis-separated
 /// movement</em> against the map's solid tiles: each axis is applied in turn and reverted when
-/// the player's sprite footprint would overlap a solid tile or leave the map (the map edge is
-/// solid). This blocks the player at solid tiles, keeps wall-sliding natural and prevents
-/// diagonal corner-cutting. See <c>docs/Architecture.md</c> for the collision model.
+/// the player's collision footprint would overlap a solid tile or leave the map (the map edge
+/// is solid). The footprint is the <em>lower half</em> of the sprite anchored at the feet
+/// (<see cref="Player.Position"/> is the middle-bottom of the sprite): only the lower half is
+/// tested against solid tiles, so the upper body never collides with the ground. Clamping keeps
+/// that lower-half footprint inside the map. This blocks the player at solid tiles, keeps
+/// wall-sliding natural and prevents diagonal corner-cutting. See <c>docs/Architecture.md</c>
+/// for the collision model.
 /// </para>
 /// <para>
 /// The engine is <see cref="IDisposable"/>: it owns the assigned map and disposes it when
@@ -383,8 +387,10 @@ public sealed class GameEngine : IDisposable
 
         // Draw everything through a single camera translation in pixels (origin * ts): the map
         // blits its prerendered pixel layers in world pixels, and each character is drawn at its
-        // world pixel position (pos * ts). The net screen position of a character is therefore
-        // (pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts).
+        // world pixel feet position (pos * ts). The compositor anchors each sprite at its
+        // middle-bottom, so a character's sprite top-left is at
+        // (pos.X*ts - w/2 - origin.X*ts, pos.Y*ts - h - origin.Y*ts) in world pixels and its
+        // feet (anchor) at (pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts).
         // Draw order is: below-player map layers -> each NPC -> the player -> above-player map
         // layers, so tiles marked with the Tiled above_player property appear on top of the player.
         canvas.Save();
@@ -929,13 +935,13 @@ public sealed class GameEngine : IDisposable
     /// Moves the player in <paramref name="direction"/> by <c>BaseSpeed * dt</c> tiles and, when
     /// a map is set, resolves collisions against the map's solid tiles using
     /// <em>axis-separated movement</em>: the horizontal displacement is applied first and
-    /// reverted if the player's sprite footprint (see <see cref="PlayerFootprintOverlapsSolid"/>)
-    /// would overlap a solid tile or leave the map (the map edge is solid, see
-    /// <see cref="Tiled.TileMap.IsSolid"/>); the vertical displacement is then applied the same
-    /// way, starting from the horizontal result. This keeps wall-sliding natural (a blocked axis
-    /// reverts while the other axis still moves) and prevents diagonal corner-cutting (each axis
-    /// is resolved independently). Without a map the displacement is applied directly, matching
-    /// <see cref="Character.Move(Direction, double, double)"/>.
+    /// reverted if the player's collision footprint (the lower half of the sprite anchored at the
+    /// feet, see <see cref="PlayerFootprintOverlapsSolid"/>) would overlap a solid tile or leave
+    /// the map (the map edge is solid, see <see cref="Tiled.TileMap.IsSolid"/>); the vertical
+    /// displacement is then applied the same way, starting from the horizontal result. This keeps
+    /// wall-sliding natural (a blocked axis reverts while the other axis still moves) and prevents
+    /// diagonal corner-cutting (each axis is resolved independently). Without a map the
+    /// displacement is applied directly, matching <see cref="Character.Move(Direction, double, double)"/>.
     /// </summary>
     /// <param name="direction">The direction to face and move towards.</param>
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
@@ -982,38 +988,54 @@ public sealed class GameEngine : IDisposable
     }
 
     /// <summary>
-    /// Returns whether the player's sprite footprint with its top-left at
-    /// <paramref name="position"/> overlaps a solid tile or leaves the map. The footprint size
-    /// is the player's sprite size in pixels (<see cref="Character.GetSpriteSize"/>) converted
-    /// to tiles with the map's tile width, and the overlap is tested with
-    /// <see cref="Tiled.TileMap.IsAreaSolid"/>.
+    /// Returns whether the player's collision footprint with its feet (middle-bottom) at
+    /// <paramref name="position"/> overlaps a solid tile or leaves the map. The footprint is the
+    /// <em>lower half</em> of the sprite: its size is half the player's sprite size in pixels
+    /// (<see cref="Character.GetSpriteSize"/>) converted to tiles with the map's tile width, and
+    /// it is anchored so the feet (the sprite's middle-bottom) sit at
+    /// <paramref name="position"/>. The upper half of the sprite (the upper body) never collides
+    /// with the ground; only this lower half is tested against solid tiles, and the map edge
+    /// (which <see cref="Tiled.TileMap.IsSolid"/> treats as solid) remains solid. The overlap is
+    /// tested with <see cref="Tiled.TileMap.IsAreaSolid"/>.
     /// </summary>
     private bool PlayerFootprintOverlapsSolid(Position position)
     {
         var ts = Map!.TileWidth;
         var (spriteWidth, spriteHeight) = Player.Character.GetSpriteSize(_spriteSheetManager);
-        return Map.IsAreaSolid(position.X, position.Y, spriteWidth / (double)ts, spriteHeight / (double)ts);
+        return Map.IsAreaSolid(
+            position.X - spriteWidth / (2.0 * ts),
+            position.Y - spriteHeight / (2.0 * ts),
+            spriteWidth / (double)ts,
+            spriteHeight / (2.0 * ts));
     }
 
     /// <summary>
-    /// Clamps the player's top-left position so its sprite stays inside the map bounds. The
-    /// sprite size is resolved in pixels from the player's configured spritesheet (see
-    /// <see cref="Character.GetSpriteSize"/>) and converted to tiles using the map's tile width;
-    /// when no sheet is configured it falls back to the 48×48 default.
-    /// <c>x ∈ [0, max(0, Map.Width - spriteWidth / ts)]</c>,
-    /// <c>y ∈ [0, max(0, Map.Height - spriteHeight / ts)]</c>, all in tiles.
+    /// Clamps the player's feet position so its collision footprint (the lower half of the sprite,
+    /// anchored at the feet) stays inside the map bounds. The sprite size is resolved in pixels
+    /// from the player's configured spritesheet (see <see cref="Character.GetSpriteSize"/>) and
+    /// converted to tiles using the map's tile width; when no sheet is configured it falls back
+    /// to the 48×48 default. With half-width <c>hw = spriteWidth / (2*ts)</c> and half-height
+    /// <c>hh = spriteHeight / (2*ts)</c> the feet are clamped to
+    /// <c>x ∈ [hw, max(hw, Map.Width - hw)]</c> and
+    /// <c>y ∈ [hh, max(hh, Map.Height)]</c>, all in tiles — the lower-half footprint
+    /// (whose bottom is the feet) never leaves the map. For the default 48×48 sprite with 48 px
+    /// tiles this is <c>x ∈ [0.5, Map.Width - 0.5]</c>, <c>y ∈ [0.5, Map.Height]</c>.
     /// Called after every move while a map is set.
     /// </summary>
     private void ClampPlayerToMap()
     {
         var ts = Map!.TileWidth;
         var (spriteWidth, spriteHeight) = Player.Character.GetSpriteSize(_spriteSheetManager);
-        var maxX = Math.Max(0, Map.Width - spriteWidth / (double)ts);
-        var maxY = Math.Max(0, Map.Height - spriteHeight / (double)ts);
+        var halfWidth = spriteWidth / (2.0 * ts);
+        var halfHeight = spriteHeight / (2.0 * ts);
+        var minX = halfWidth;
+        var maxX = Math.Max(minX, Map.Width - halfWidth);
+        var minY = halfHeight;
+        var maxY = Math.Max(minY, Map.Height);
 
         var position = Player.Position;
         Player.Position = new Position(
-            Math.Clamp(position.X, 0, maxX),
-            Math.Clamp(position.Y, 0, maxY));
+            Math.Clamp(position.X, minX, maxX),
+            Math.Clamp(position.Y, minY, maxY));
     }
 }

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -91,8 +91,9 @@ public sealed class Player
     }
 
     /// <summary>
-    /// Gets or sets the top-left world position of the player's sprite, in tiles. Forwards to
-    /// <see cref="Character.Position"/>.
+    /// Gets or sets the world position of the player's feet, in tiles. The feet are the
+    /// <em>middle-bottom</em> of the sprite: the sprite is rendered above and centered on this
+    /// point. Forwards to <see cref="Character.Position"/>.
     /// </summary>
     public Position Position
     {

--- a/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
+++ b/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
@@ -30,6 +30,13 @@ namespace RPGEngine.Sprites;
 /// Hair (hair1 and hair2) is shown unless a <see cref="CharacterPartType.Head"/> sheet is present
 /// whose name contains the <c>$</c> character (the <c>$</c>-prefix rule from the epic).
 /// </para>
+/// <para>
+/// Every cell (whether a single full sheet or one part of a composition) is drawn with its
+/// <em>middle-bottom</em> at the anchor position passed to <see cref="Draw"/>: the anchor is
+/// the character's feet (where it stands), and the sprite is rendered above and centered on it.
+/// A cell's top-left is therefore at
+/// <c>(anchorPosition.X - width/2, anchorPosition.Y - height)</c> in pixels.
+/// </para>
 /// </remarks>
 internal sealed class CharacterSpriteCompositor
 {
@@ -38,10 +45,12 @@ internal sealed class CharacterSpriteCompositor
 
     /// <summary>
     /// Draws the character described by <paramref name="spriteSheetRefs"/> at
-    /// <paramref name="screenPosition"/>.
+    /// <paramref name="anchorPosition"/>.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
-    /// <param name="screenPosition">The top-left screen position of the sprite (its size is the sheet's derived cell size).</param>
+    /// <param name="anchorPosition">The middle-bottom (feet) anchor of the sprite, in pixels:
+    /// the sprite is drawn above and centered on this point, so its top-left is at
+    /// <c>(anchorPosition.X - width/2, anchorPosition.Y - height)</c>.</param>
     /// <param name="spriteSheetRefs">The spritesheet references to use (sheet name + character index).</param>
     /// <param name="direction">The direction the character faces.</param>
     /// <param name="frame">The animation frame (0..2).</param>
@@ -55,7 +64,7 @@ internal sealed class CharacterSpriteCompositor
     /// </exception>
     public void Draw(
         SKCanvas canvas,
-        Position screenPosition,
+        Position anchorPosition,
         IReadOnlyList<SpriteSheetRef> spriteSheetRefs,
         Direction direction,
         int frame,
@@ -74,7 +83,7 @@ internal sealed class CharacterSpriteCompositor
         if (fullCount == 1 && partCount == 0)
         {
             // A single full sheet: draw its cell directly, no composition.
-            DrawCell(canvas, screenPosition, resolved[0], direction, frame);
+            DrawCell(canvas, anchorPosition, resolved[0], direction, frame);
             return;
         }
 
@@ -86,7 +95,7 @@ internal sealed class CharacterSpriteCompositor
                 $"sheets; the configured list contains {fullCount} full and {partCount} part sheet(s).");
         }
 
-        ComposeParts(canvas, screenPosition, resolved, direction, frame);
+        ComposeParts(canvas, anchorPosition, resolved, direction, frame);
     }
 
     /// <summary>
@@ -119,7 +128,7 @@ internal sealed class CharacterSpriteCompositor
     /// </summary>
     private static void ComposeParts(
         SKCanvas canvas,
-        Position screenPosition,
+        Position anchorPosition,
         IReadOnlyList<ResolvedRef> parts,
         Direction direction,
         int frame)
@@ -130,35 +139,35 @@ internal sealed class CharacterSpriteCompositor
         // 1. hair2 behind everything (when hair is shown).
         if (showHair)
         {
-            DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Hair2), direction, frame);
+            DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.Hair2), direction, frame);
         }
 
         // 2. face
-        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Face), direction, frame);
+        DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.Face), direction, frame);
 
         // 3. body
-        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Body), direction, frame);
+        DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.Body), direction, frame);
 
         // 4. hair1 (when hair is shown)
         if (showHair)
         {
-            DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Hair1), direction, frame);
+            DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.Hair1), direction, frame);
         }
 
         // 5. face_hair
-        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.FaceHair), direction, frame);
+        DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.FaceHair), direction, frame);
 
         // 6. armour
-        DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Armour), direction, frame);
+        DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.Armour), direction, frame);
 
         // 7. hair2 again, only when facing up (rear hair drawn over the body).
         if (showHair && direction == Direction.Up)
         {
-            DrawPart(canvas, screenPosition, FindPart(parts, CharacterPartType.Hair2), direction, frame);
+            DrawPart(canvas, anchorPosition, FindPart(parts, CharacterPartType.Hair2), direction, frame);
         }
 
         // 8. head (if present)
-        DrawPart(canvas, screenPosition, head, direction, frame);
+        DrawPart(canvas, anchorPosition, head, direction, frame);
     }
 
     /// <summary>
@@ -166,7 +175,7 @@ internal sealed class CharacterSpriteCompositor
     /// </summary>
     private static void DrawPart(
         SKCanvas canvas,
-        Position screenPosition,
+        Position anchorPosition,
         ResolvedRef? part,
         Direction direction,
         int frame)
@@ -176,21 +185,28 @@ internal sealed class CharacterSpriteCompositor
             return;
         }
 
-        DrawCell(canvas, screenPosition, part.Value, direction, frame);
+        DrawCell(canvas, anchorPosition, part.Value, direction, frame);
     }
 
-    /// <summary>Draws the cell selected by the part's own character index at its native size.</summary>
+    /// <summary>
+    /// Draws the cell selected by the part's own character index at its native size, anchored so
+    /// the cell's <em>middle-bottom</em> sits exactly at <paramref name="anchorPosition"/>.
+    /// </summary>
     private static void DrawCell(
         SKCanvas canvas,
-        Position screenPosition,
+        Position anchorPosition,
         ResolvedRef part,
         Direction direction,
         int frame)
     {
         // GetSprite validates the index/frame again defensively and returns an independent
-        // image at the sheet's derived cell size that the caller owns.
+        // image at the sheet's derived cell size that the caller owns. The cell is drawn with its
+        // middle-bottom (the character's feet) at the anchor: the top-left is offset left by half
+        // the cell width and up by the full cell height, so the sprite stands on the anchor.
         using var sprite = part.Sheet.GetSprite(part.Ref.CharacterIndex, direction, frame);
-        canvas.DrawImage(sprite, new SKPoint((float)screenPosition.X, (float)screenPosition.Y));
+        canvas.DrawImage(sprite, new SKPoint(
+            (float)(anchorPosition.X - sprite.Width / 2.0),
+            (float)(anchorPosition.Y - sprite.Height)));
     }
 
     /// <summary>Returns the first resolved part of the given type, or <see langword="null"/> when absent.</summary>

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -585,6 +585,53 @@ public class CharacterTests
     }
 
     // ---------------------------------------------------------------------
+    // Acceptance (story 50): the sprite is anchored at its middle-bottom (the
+    // feet). Position means where the character stands; the sprite is rendered
+    // above and centered on that point.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies the sprite's bottom-centre sits exactly at the anchor (the feet): drawing a
+    /// character whose feet are at (48, 72) places the 48×48 sprite from top-left (24, 24) to
+    /// bottom-right (72, 72), with the pixel just above the anchor still part of the sprite and
+    /// nothing drawn at or below the anchor.
+    /// </summary>
+    [Fact]
+    public void Draw_AnchorsSpriteMiddleBottom_FeetAtPosition()
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false));
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        character.Move(Direction.Down, speedFactor: 0); // face down without moving
+
+        // A bitmap larger than the sprite so the anchor point itself is inside the canvas.
+        using var bitmap = new SKBitmap(96, 96);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            // The sprite's middle-bottom (feet) sits at (48, 72): top-left (24, 24).
+            character.Draw(canvas, new Position(48, 72), dt: 1, manager);
+        }
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.Down, StandingFrame);
+
+        // The bottom-centre of the drawn sprite is exactly at the anchor: the pixel above the
+        // anchor is the sprite, and nothing is drawn at or below the anchor (the feet).
+        Assert.Equal(expected, bitmap.GetPixel(48, 71));
+        Assert.Equal(0, bitmap.GetPixel(48, 72).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(48, 73).Alpha);
+
+        // The sprite is centered horizontally on the anchor and spans top-left (24,24) to
+        // bottom-right (72,72).
+        Assert.Equal(expected, bitmap.GetPixel(47, 71));
+        Assert.Equal(expected, bitmap.GetPixel(49, 71));
+        Assert.Equal(expected, bitmap.GetPixel(24, 24));
+        Assert.Equal(expected, bitmap.GetPixel(71, 71));
+        Assert.Equal(0, bitmap.GetPixel(23, 23).Alpha); // nothing to the left/above the sprite
+        Assert.Equal(0, bitmap.GetPixel(72, 72).Alpha); // nothing to the right of / below it
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
@@ -623,7 +670,11 @@ public class CharacterTests
         return manager;
     }
 
-    /// <summary>Renders the character into a fresh bitmap of the requested size at the origin.</summary>
+    /// <summary>
+    /// Renders the character into a fresh bitmap of the requested size, anchoring the sprite's
+    /// middle-bottom (feet) at <c>(width/2, height)</c> so a sprite of the same size as the bitmap
+    /// exactly fills it (its top-left lands at <c>(0, 0)</c>).
+    /// </summary>
     private static SKBitmap Render(
         Character character,
         SpriteSheetManager manager,
@@ -634,7 +685,7 @@ public class CharacterTests
         using (var canvas = new SKCanvas(bitmap))
         {
             canvas.Clear(SKColors.Transparent);
-            character.Draw(canvas, new Position(0, 0), dt: 1, manager);
+            character.Draw(canvas, new Position(width / 2.0, height), dt: 1, manager);
         }
 
         return bitmap;

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -791,6 +791,7 @@ public class DocsExamplesTests
             await engine.LoadSpriteSheetAsync("hero", stream);
         }
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 bitmap
 
         using var bitmap = new SKBitmap(48, 48);
         using (var canvas = new SKCanvas(bitmap))

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -94,8 +94,9 @@ public class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Top-left corner: origin (0,0), the player sprite is at screen (0,0).
-        engine.Player.Position = new Position(0, 0);
+        // Top-left corner: origin (0,0). The player at (0.5, 1.0) has its feet (middle-bottom)
+        // at screen (24, 48), so the 48×48 sprite's top-left is at (0, 0) (centre (24, 24)).
+        engine.Player.Position = new Position(0.5, 1.0);
         Assert.Equal(new Position(0, 0), engine.ComputeCameraOrigin(canvasSize, canvasSize));
         using (var bitmap = Render(engine, canvasSize, canvasSize))
         {
@@ -105,20 +106,23 @@ public class GameEngineTests
         }
 
         // Bottom-right corner: origin clamped to (Map.Width - canvas/ts, Map.Height - canvas/ts)
-        // = (10 - 5, 10 - 5) = (5, 5) tiles (previously (240, 240) px).
-        engine.Player.Position = new Position(9, 9); // 432 px
+        // = (10 - 5, 10 - 5) = (5, 5) tiles (previously (240, 240) px). The player at (9, 9) has
+        // its feet at screen (192, 192); the sprite top-left is (168, 144), centre (192, 168).
+        engine.Player.Position = new Position(9, 9);
         Assert.Equal(new Position(5, 5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
         using (var bitmap = Render(engine, canvasSize, canvasSize))
         {
-            AssertSpriteColor(bitmap, topLeftX: 192, topLeftY: 192, seed: 1, characterIndex: 1);
+            AssertSpriteColor(bitmap, topLeftX: 168, topLeftY: 144, seed: 1, characterIndex: 1);
         }
 
         // Middle: origin = player - canvas/(2*ts) (no clamping), so the player is centered.
-        engine.Player.Position = new Position(4.5, 4.5); // 216 px
+        // Player at (4.5, 4.5) → origin (2, 2); feet at screen (120, 120), sprite top-left
+        // (96, 72), centre (120, 96).
+        engine.Player.Position = new Position(4.5, 4.5);
         Assert.Equal(new Position(2, 2), engine.ComputeCameraOrigin(canvasSize, canvasSize));
         using (var bitmap = Render(engine, canvasSize, canvasSize))
         {
-            AssertSpriteColor(bitmap, topLeftX: 120, topLeftY: 120, seed: 1, characterIndex: 1);
+            AssertSpriteColor(bitmap, topLeftX: 96, topLeftY: 72, seed: 1, characterIndex: 1);
         }
     }
 
@@ -136,9 +140,9 @@ public class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
 
         ConfigurePlayerSprite(engine, seed: 1);
-        engine.Player.Position = new Position(0, 0);
+        engine.Player.Position = new Position(0.5, 1.0); // feet at (24, 48) px, sprite at (0,0)
 
-        var npc = new Character { Position = new Position(2, 2) }; // 96 px
+        var npc = new Character { Position = new Position(2.5, 3.0) }; // feet at (120, 144) px
         using (var npcStream = CharacterTestHelper.CreateSheetStream(2))
         {
             engine.LoadSpriteSheet("npc", npcStream);
@@ -150,9 +154,9 @@ public class GameEngineTests
 
         // Map pixels present in a region no sprite covers.
         Assert.NotEqual(0, bitmap.GetPixel(200, 200).Alpha);
-        // Player drawn at screen (0,0).
+        // Player sprite drawn at screen top-left (0,0) (centre (24,24)).
         Assert.Equal(CharacterTestHelper.SpriteColor(1, 1, Direction.Down, StandingFrame), bitmap.GetPixel(24, 24));
-        // NPC drawn at screen (96,96).
+        // NPC sprite drawn at screen top-left (96,96) (centre (120,120)).
         Assert.Equal(CharacterTestHelper.SpriteColor(2, 2, Direction.Down, StandingFrame), bitmap.GetPixel(120, 120));
 
         // Replacing the map changes the output: the 2×2 (96×96) map is now centered on the
@@ -169,7 +173,8 @@ public class GameEngineTests
         }
 
         // Removing the NPC removes its pixels; re-adding restores them. On the centered 2×2
-        // map the NPC (world 2,2) is at screen (168,168); its centre pixel is (192,192).
+        // map the NPC (world 2.5,3.0) has its feet at (192,216) px screen; its sprite top-left is
+        // (168,168) and its centre pixel is (192,192).
         engine.Characters.Remove(npc);
         using (var withoutNpc = Render(engine, canvasSize, canvasSize))
         {
@@ -256,6 +261,7 @@ public class GameEngineTests
             engine.LoadSpriteSheet("hero", stream);
         }
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 bitmap
 
         using var bitmap = Render(engine, CellSize, CellSize);
         Assert.NotEqual(0, bitmap.GetPixel(24, 24).Alpha);
@@ -376,6 +382,7 @@ public class GameEngineTests
             await engine.LoadSpriteSheetAsync("hero", stream);
         }
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 bitmap
 
         using var bitmap = Render(engine, CellSize, CellSize);
         Assert.NotEqual(0, bitmap.GetPixel(24, 24).Alpha);
@@ -410,6 +417,7 @@ public class GameEngineTests
         // Facing up: the per-direction adjustment draws hair2 over the body; the transparent
         // head keeps it visible, so the rendered centre pixel is the hair2 colour.
         engine.Player.Character.Move(Direction.Up, speedFactor: 0);
+        engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 bitmap
 
         using var bitmap = Render(engine, CellSize, CellSize);
         var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 1, Direction.Up, StandingFrame);
@@ -500,18 +508,19 @@ public class GameEngineTests
         }
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
-        // Beyond the bottom-right corner: clamps to (10 - 78/48, 10 - 108/48) = (8.375, 7.75)
-        // tiles (the previous (402, 372) px).
+        // Beyond the bottom-right corner: the feet clamp so the lower-half footprint stays in
+        // the map: x = 10 - 78/(2*48) = 9.1875, y = 10 (the feet can reach the bottom edge).
         engine.Player.Position = new Position(1000, 1000);
         engine.Update(FrameDt);
-        Assert.Equal(10 - (78 / (double)CellSize), engine.Player.Position.X, precision: 6);
-        Assert.Equal(10 - (108 / (double)CellSize), engine.Player.Position.Y, precision: 6);
+        Assert.Equal(10 - (78 / (2.0 * CellSize)), engine.Player.Position.X, precision: 6);
+        Assert.Equal(10, engine.Player.Position.Y, precision: 6);
 
-        // Negative position clamps to (0, 0).
+        // Negative position clamps the feet to the top-left: x = 78/(2*48) = 0.8125,
+        // y = 108/(2*48) = 1.125 (the lower-half footprint just fits against the top edge).
         engine.Player.Position = new Position(-100, -100);
         engine.Update(FrameDt);
-        Assert.Equal(0, engine.Player.Position.X, precision: 6);
-        Assert.Equal(0, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(78 / (2.0 * CellSize), engine.Player.Position.X, precision: 6);
+        Assert.Equal(108 / (2.0 * CellSize), engine.Player.Position.Y, precision: 6);
     }
 
     /// <summary>Verifies the 78×108 clamp through ComputeCameraOrigin and rendered output.</summary>
@@ -529,15 +538,39 @@ public class GameEngineTests
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
         engine.Player.Position = new Position(1000, 1000);
-        engine.Update(FrameDt); // clamps to (8.375, 7.75)
+        engine.Update(FrameDt); // clamps to (9.1875, 10)
 
         // The camera origin clamps to the map: maxX = maxY = 10 - 240/48 = 5 tiles.
         Assert.Equal(new Position(5, 5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
 
-        // The 78×108 sprite renders at screen ((8.375 - 5)*48, (7.75 - 5)*48) = (162, 132).
+        // The 78×108 sprite is anchored at its middle-bottom (feet): with the player's feet at
+        // (9.1875, 10) tiles the screen feet are ((9.1875-5)*48, (10-5)*48) = (201, 240) and the
+        // sprite top-left is (201 - 39, 240 - 108) = (162, 132); its centre is (201, 186).
         using var bitmap = Render(engine, canvasSize, canvasSize);
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
         Assert.Equal(expected, bitmap.GetPixel(162 + 39, 132 + 54));
+    }
+
+    /// <summary>Verifies ClampPlayerToMap keeps the default 48×48 sprite's lower-half footprint in the map (feet x ∈ [0.5, 9.5], y ∈ [0.5, 10]).</summary>
+    [Fact]
+    public void ClampPlayerToMap_DefaultSprite_ClampsFeetFootprint()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480×480 px
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Beyond the bottom-right corner: the default 48×48 sprite's half-width is 0.5 tiles,
+        // so the feet clamp to x = 10 - 0.5 = 9.5 and y = 10 (feet at the bottom edge).
+        engine.Player.Position = new Position(1000, 1000);
+        engine.Update(FrameDt);
+        Assert.Equal(9.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(10, engine.Player.Position.Y, precision: 6);
+
+        // Negative position clamps the feet to the top-left: x = 0.5, y = 0.5.
+        engine.Player.Position = new Position(-100, -100);
+        engine.Update(FrameDt);
+        Assert.Equal(0.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
     }
 
     // ---------------------------------------------------------------------
@@ -620,7 +653,7 @@ public class GameEngineTests
         {
             var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
             ConfigurePlayerSprite(engine, seed: 1);
-            engine.Player.Position = new Position(0, 0);
+            engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 tile
 
             using var bitmap = Render(engine, canvasSize, canvasSize);
             Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(24, 24));
@@ -639,7 +672,7 @@ public class GameEngineTests
         {
             var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
             ConfigurePlayerSprite(engine, seed: 1);
-            engine.Player.Position = new Position(0, 0);
+            engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 tile
 
             using var bitmap = Render(engine, canvasSize, canvasSize);
             var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
@@ -709,7 +742,7 @@ public class GameEngineTests
     // Player.Position = (8.5, 8.5) tiles with camera origin (0,0) draws the
     // sprite at 408 px.
     // ---------------------------------------------------------------------
-    /// <summary>Verifies a player at (8.5, 8.5) tiles with origin (0,0) renders its sprite at screen position 408 px (pixel assertion).</summary>
+    /// <summary>Verifies a player at (8.5, 8.5) tiles with origin (0,0) renders its 48×48 sprite with its middle-bottom (feet) at screen position (408, 408) px (pixel assertion).</summary>
     [Fact]
     public void Render_PlayerAt8_5_WithOriginZero_DrawsSpriteAt408Px()
     {
@@ -734,11 +767,13 @@ public class GameEngineTests
             Assert.Equal(new Position(0, 0), engine.ComputeCameraOrigin(canvasWidth, canvasHeight));
         }
 
-        // The 48×48 sprite is drawn at screen top-left (408, 408); its centre is (432, 432).
+        // The player's feet (middle-bottom) are at (408, 408) px; the 48×48 sprite is drawn
+        // above and centered on that point: top-left (384, 360), centre (408, 384), bottom-right
+        // (431, 407).
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
-        Assert.Equal(expected, bitmap.GetPixel(408 + (CellSize / 2), 408 + (CellSize / 2)));
-        Assert.Equal(expected, bitmap.GetPixel(408, 408));
-        Assert.Equal(expected, bitmap.GetPixel(408 + CellSize - 1, 408 + CellSize - 1));
+        Assert.Equal(expected, bitmap.GetPixel(384 + (CellSize / 2), 360 + (CellSize / 2))); // centre (408, 384)
+        Assert.Equal(expected, bitmap.GetPixel(384, 360));   // top-left
+        Assert.Equal(expected, bitmap.GetPixel(384 + CellSize - 1, 360 + CellSize - 1)); // bottom-right (431, 407)
     }
 
     // ---------------------------------------------------------------------
@@ -829,20 +864,21 @@ public class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // The default 48x48 sprite is a 1x1-tile footprint. Start at (0.5, 1.0) and hold D.
+        // The default 48x48 sprite has a lower-half footprint 1 tile wide and 0.5 tile tall,
+        // anchored at the feet. Start at (0.5, 1.0) and hold D.
         engine.Player.Position = new Position(0.5, 1.0);
         engine.Input(Key.D, true);
 
-        for (var frame = 0; frame < 120; frame++)
-        {
-            engine.Update(FrameDt);
-        }
+        // Move right by exactly 1 tile (dt = 0.5 at 2 tiles/s): the feet reach X = 1.5, where
+        // the lower-half footprint [1.0, 2.0] just touches the solid tile at x = 2.0.
+        engine.Update(dt: 0.5);
+        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
 
-        // The player slides to exactly the left edge of the solid tile at x=2: position.x = 1.0
-        // (the footprint's right edge is at 2.0) and it never overlaps the solid tile.
-        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
+        // The next step would push the footprint into the solid tile and is reverted.
+        engine.Update(dt: 0.5);
+        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
         Assert.Equal(1.0, engine.Player.Position.Y, precision: 6); // straight line, Y unchanged
-        Assert.True(engine.Player.Position.X + 1.0 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
+        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
         Assert.Equal(Direction.Right, engine.Player.Direction);
     }
 
@@ -864,15 +900,16 @@ public class GameEngineTests
         engine.Player.Position = new Position(1.0, 0.5);
         engine.Input(Key.S, true);
 
-        for (var frame = 0; frame < 120; frame++)
-        {
-            engine.Update(FrameDt);
-        }
+        // Move down by exactly 1.5 tiles (dt = 0.75 at 2 tiles/s): the feet reach Y = 2.0, where
+        // the lower-half footprint [1.5, 2.0] just touches the solid row at y = 2.0.
+        engine.Update(dt: 0.75);
+        Assert.Equal(2.0, engine.Player.Position.Y, precision: 6);
 
-        // The player stops at exactly the top edge of the solid row at y=2: position.y = 1.0.
+        // The next step would push the footprint into the solid row and is reverted.
+        engine.Update(dt: 0.1);
         Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
-        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
-        Assert.True(engine.Player.Position.Y + 1.0 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
+        Assert.Equal(2.0, engine.Player.Position.Y, precision: 6);
+        Assert.True(engine.Player.Position.Y <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
         Assert.Equal(Direction.Down, engine.Player.Direction);
     }
 
@@ -891,10 +928,10 @@ public class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Start flush against the left edge of the wall column (x=3): the 1x1 footprint spans
-        // [2,3) at x=2. Moving UpRight, the X displacement is blocked by the wall while Y is
-        // free, so the player slides straight up along the wall.
-        engine.Player.Position = new Position(2.0, 4.0);
+        // Start flush against the left edge of the wall column (x=3): the lower-half footprint
+        // spans [2,3) horizontally at feet x=2.5. Moving UpRight, the X displacement is blocked by
+        // the wall while Y is free, so the player slides straight up along the wall.
+        engine.Player.Position = new Position(2.5, 4.0);
         engine.Input(Key.W, true);
         engine.Input(Key.D, true);
 
@@ -903,8 +940,8 @@ public class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // X never moves into the wall: it stays at exactly 2.0 (the wall's left edge).
-        Assert.Equal(2.0, engine.Player.Position.X, precision: 6);
+        // X never moves into the wall: it stays at exactly 2.5 (the feet at the wall's left edge).
+        Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
         // Y slides up along the wall: one second at 2 tiles/s diagonally = 2 * sqrt(0.5) ~ 1.414.
         Assert.Equal(4.0 - (2 * Math.Sqrt(0.5)), engine.Player.Position.Y, precision: 6);
     }
@@ -931,6 +968,56 @@ public class GameEngineTests
         Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
     }
 
+    /// <summary>Verifies a solid tile in the upper-body region does not block a player walking past it: only the lower half of the sprite collides with the ground.</summary>
+    [Fact]
+    public void Update_SolidTileInUpperBody_DoesNotBlockWalkingPast()
+    {
+        // 4x4 map with a single solid tile at (2, 0) — the upper-body region when the player's
+        // feet are in row 1 (the lower-half footprint spans y ∈ [1.0, 1.5]).
+        var gids = new uint[16];
+        gids[(0 * 4) + 2] = 1;
+        using var fixture = CreateCollisionMapFixture(4, 4, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Feet in row 1: the lower-half footprint spans y ∈ [1.0, 1.5], so the solid tile at
+        // (2, 0) is in the upper-body region and must not block the walk.
+        engine.Player.Position = new Position(0.5, 1.5);
+        engine.Input(Key.D, true);
+
+        // One second at 2 tiles/s (dt = 1.0): the player walks right past the tile to feet X = 2.5.
+        engine.Update(dt: 1.0);
+        Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.5, engine.Player.Position.Y, precision: 6);
+    }
+
+    /// <summary>Verifies a solid tile in the lower-half region blocks the player at the feet boundary (feet X = 1.5).</summary>
+    [Fact]
+    public void Update_SolidTileInLowerHalf_BlocksAtFeetBoundary()
+    {
+        // 4x4 map with a single solid tile at (2, 1) — the lower-half region when the player's
+        // feet are in row 1 (the lower-half footprint spans y ∈ [1.0, 1.5]).
+        var gids = new uint[16];
+        gids[(1 * 4) + 2] = 1;
+        using var fixture = CreateCollisionMapFixture(4, 4, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        engine.Player.Position = new Position(0.5, 1.5);
+        engine.Input(Key.D, true);
+
+        // Move right by exactly 1 tile: the feet reach X = 1.5, where the lower-half footprint
+        // [1.0, 2.0] just touches the solid tile at x = 2.0.
+        engine.Update(dt: 0.5);
+        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
+
+        // The next step would push the footprint into the solid tile and is reverted.
+        engine.Update(dt: 0.5);
+        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.5, engine.Player.Position.Y, precision: 6);
+        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9);
+    }
+
     /// <summary>Verifies the map edge is solid: with no collision layer the player cannot walk out of the map.</summary>
     [Fact]
     public void Update_MapEdgeIsSolid_PlayerCannotLeaveMap()
@@ -940,30 +1027,27 @@ public class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Walk right: the 1x1 footprint stops when its right edge reaches the map edge at x=2,
-        // so the player clamps to x = 1.0 instead of leaving the map.
+        // Walk right: the lower-half footprint stops when its right edge (feet X + 0.5) reaches
+        // the map edge at x=2, so the player's feet stop at x = 1.5 instead of leaving the map.
         engine.Player.Position = new Position(0.5, 0.5);
         engine.Input(Key.D, true);
-        for (var frame = 0; frame < 120; frame++)
-        {
-            engine.Update(FrameDt);
-        }
+        engine.Update(dt: 0.5); // feet reach X = 1.5 (footprint [1.0, 2.0], still inside the map)
+        engine.Update(dt: 0.5); // would leave the map and is reverted
 
-        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
         Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
-        Assert.True(engine.Player.Position.X + 1.0 <= 2.0 + 1e-9);
+        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9);
 
-        // Then walk down: the same rule clamps Y to 1.0 (the footprint's bottom edge at y=2).
+        // Then walk down: the same rule clamps the feet to y = 2.0 (the footprint's bottom edge,
+        // which is the feet, at the map edge y=2).
         engine.Input(Key.D, false);
         engine.Input(Key.S, true);
-        for (var frame = 0; frame < 120; frame++)
-        {
-            engine.Update(FrameDt);
-        }
+        engine.Update(dt: 0.75); // feet reach Y = 2.0 (footprint [1.5, 2.0], still inside the map)
+        engine.Update(dt: 0.1);  // would leave the map and is reverted
 
-        Assert.Equal(1.0, engine.Player.Position.X, precision: 6);
-        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
-        Assert.True(engine.Player.Position.Y + 1.0 <= 2.0 + 1e-9);
+        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(2.0, engine.Player.Position.Y, precision: 6);
+        Assert.True(engine.Player.Position.Y <= 2.0 + 1e-9);
     }
 
     // ---------------------------------------------------------------------
@@ -1498,7 +1582,9 @@ public class GameEngineTests
         Assert.Equal(new Position(0, 0), engine.Player.Position);
 
         engine.Update(FrameDt);
-        Assert.Equal(new Position(0, 0), engine.Player.Position);
+        // The clamp keeps the player's lower-half footprint in the map: the default feet start
+        // at (0, 0) and are clamped up to (0.5, 0.5).
+        Assert.Equal(new Position(0.5, 0.5), engine.Player.Position);
     }
 
     /// <summary>

--- a/tests/RPGEngine.Tests/SampleSceneTests.cs
+++ b/tests/RPGEngine.Tests/SampleSceneTests.cs
@@ -118,12 +118,16 @@ public class SampleSceneTests
         using var fixtures = FixtureAssets.MaterializeToTempDirectory();
         var engine = SampleScene.Create(fixtures.Root);
 
-        // The player is at (6, 6) tiles (= 288 px). The camera origin for a 640×480 view is
-        // (0, 1) tiles (= 48 px), so the player screen top-left = (288, 240); centre = (312, 264).
+        // The committed scene spawns the player at (6, 6), which with the middle-bottom anchor
+        // places the sprite inside the tree canopy: the above_player tree layer fully occludes it
+        // (the tree is drawn over the player, as designed). To verify the anchored render, stand
+        // the player on the clear path at (6, 8): the camera origin for a 640×480 view becomes
+        // (0, 2), so the feet are at (288, 288) px and the 48×48 sprite centre is (288, 264).
+        engine.Player.Position = new Position(6, 8);
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, frame: 1);
-        Assert.Equal(expected, bitmap.GetPixel(312, 264));
+        Assert.Equal(expected, bitmap.GetPixel(288, 264));
     }
 
     /// <summary>Verifies the villager NPC's centre pixel is the top-most part (hair1) per the fixed composition order.</summary>
@@ -133,12 +137,13 @@ public class SampleSceneTests
         using var fixtures = FixtureAssets.MaterializeToTempDirectory();
         var engine = SampleScene.Create(fixtures.Root);
 
-        // Villager world (3, 4) tiles = (144, 192) px → screen (144, 144); centre (168, 168).
+        // Villager world (3, 4) tiles with the camera origin (0, 1) → feet at (144, 144) px;
+        // the 48×48 sprite is anchored at its middle-bottom, so its centre is (144, 120).
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
         // Parts drawn: hair2 (absent), face (seed 3), body (seed 2), hair1 (seed 4, on top).
         var expected = CharacterTestHelper.SpriteColor(seed: 4, characterIndex: 2, Direction.Down, frame: 1);
-        Assert.Equal(expected, bitmap.GetPixel(168, 168));
+        Assert.Equal(expected, bitmap.GetPixel(144, 120));
     }
 
     /// <summary>Verifies the guard NPC's centre pixel is the top-most part (head) per the fixed composition order.</summary>
@@ -148,12 +153,13 @@ public class SampleSceneTests
         using var fixtures = FixtureAssets.MaterializeToTempDirectory();
         var engine = SampleScene.Create(fixtures.Root);
 
-        // Guard world (11, 8) tiles = (528, 384) px → screen (528, 336); centre (552, 360).
+        // Guard world (11, 8) tiles with the camera origin (0, 1) → feet at (528, 336) px;
+        // the 48×48 sprite is anchored at its middle-bottom, so its centre is (528, 312).
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
         // Parts drawn: face (seed 3), body (seed 2), armour (seed 7), head (seed 8, on top).
         var expected = CharacterTestHelper.SpriteColor(seed: 8, characterIndex: 3, Direction.Down, frame: 1);
-        Assert.Equal(expected, bitmap.GetPixel(552, 360));
+        Assert.Equal(expected, bitmap.GetPixel(528, 312));
     }
 
     // ---------------------------------------------------------------------
@@ -171,7 +177,12 @@ public class SampleSceneTests
         engine.LoadPartSpriteSheet("face", fixtures.PathOf(FixtureAssets.PartFace), CharacterPartType.Face);
         engine.LoadPartSpriteSheet("hair1", fixtures.PathOf(FixtureAssets.PartHair1), CharacterPartType.Hair1);
 
-        var character = new Character();
+        var character = new Character
+        {
+            // Anchor the sprite's middle-bottom at (24, 48) px so the 48×48 sprite fills the
+            // 48×48 render bitmap (top-left (0, 0), centre (24, 24)).
+            Position = new Position(0.5, 1.0),
+        };
         character.SpriteSheets.Add(new SpriteSheetRef("body", CharacterIndex: 1));
         character.SpriteSheets.Add(new SpriteSheetRef("face", CharacterIndex: 1));
         character.SpriteSheets.Add(new SpriteSheetRef("hair1", CharacterIndex: 1));
@@ -224,7 +235,10 @@ public class SampleSceneTests
         {
             engine.LoadSpriteSheet("hero", full);
         }
-        engine.Player.Position = SampleScene.PlayerPosition;
+        // The committed scene spawns the player at (6, 6), which with the middle-bottom anchor
+        // is occluded by the tree canopy; stand it on the clear path at (6, 8) so the anchored
+        // sprite is visible (camera origin (0, 2), feet (288, 288), centre (288, 264)).
+        engine.Player.Position = new Position(6, 8);
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
         engine.LoadPartSpriteSheet("villager_body", FixtureAssets.DecodePngStream(FixtureAssets.PartBody), CharacterPartType.Body);
@@ -239,12 +253,14 @@ public class SampleSceneTests
 
         using var bitmap = Render(engine, CanvasWidth, CanvasHeight);
 
+        // Player centre at (288, 264) with the player at (6, 8) and origin (0, 2).
         Assert.Equal(
             CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, frame: 1),
-            bitmap.GetPixel(312, 264));
+            bitmap.GetPixel(288, 264));
+        // Villager at (3, 4) with origin (0, 2): feet (144, 96), centre (144, 72).
         Assert.Equal(
             CharacterTestHelper.SpriteColor(seed: 4, characterIndex: 2, Direction.Down, frame: 1),
-            bitmap.GetPixel(168, 168));
+            bitmap.GetPixel(144, 72));
 
         // The fetcher resolves the external tileset and its image relative to the map URI.
         static byte[] FetchAsset(Uri uri)


### PR DESCRIPTION
Closes #50

## Summary

Implements the epic's "Sprites display origin" and "Sprites upper body collisions" features as one self-consistent change:

- **`CharacterSpriteCompositor`**: every cell (a full sheet or a composed part) is now drawn with its **middle-bottom (feet) at the anchor** (`anchorPosition`), so the sprite is rendered above and centered on where the character stands. The `Draw` parameter was renamed from `screenPosition` to `anchorPosition` and the docs/remarks updated.
- **`Character` / `Player`**: `Position` is now documented as the **feet position** (middle-bottom of the sprite, in tiles) — `(8.5, 8.5)` means the character stands with its feet at the centre of tile `(8, 8)`.
- **`GameEngine`**:
  - `Render` comments updated: a character's sprite top-left is at `(pos.X*ts − w/2, pos.Y*ts − h)` world pixels; its feet (anchor) are at `pos * ts`.
  - `PlayerFootprintOverlapsSolid` now tests **only the lower half** of the sprite anchored at the feet, so the upper body never collides with the ground.
  - `ClampPlayerToMap` clamps the **lower-half footprint** inside the map (default 48×48 sprite with 48 px tiles: `x ∈ [0.5, Map.Width − 0.5]`, `y ∈ [0.5, Map.Height]`).
  - Class remarks describe the lower-half footprint anchored at the feet.

## Tests

- Updated the camera contract, display-anchor pixel test (`Render_PlayerAt8_5_WithOriginZero_DrawsSpriteAt408Px`), clamp tests (78×108 and 48×48 sheets), collision-boundary tests (feet X = 1.5 / Y = 2.0, wall-sliding X stays 2.5, map edge), and the sample-scene pixel tests.
- Added `CharacterTests.Draw_AnchorsSpriteMiddleBottom_FeetAtPosition` (bottom-centre sits exactly at the anchor), `ClampPlayerToMap_DefaultSprite_ClampsFeetFootprint`, and two new lower-half collision tests (a solid tile in the upper-body region does not block; the same tile in the lower half blocks at feet X = 1.5).
- `dotnet build -c Release`: 0 warnings/errors. `dotnet test tests/RPGEngine.Tests -c Release`: **350 passed, 0 failed** (the story's filtered command also passes).

## Documentation

Updated `docs/api/Character.md`, `docs/api/Player.md`, `docs/api/GameEngine.md`, `docs/Architecture.md` (character bullet, rendering section, collision section) and `docs/README.md` (quick-start feet semantics).

## Note on acceptance-criterion #8 sample-scene pixels

The criterion's listed sample-scene centres (`player (288,264)`, `villager (144,168)`, `guard (528,360)`) are not consistent with the technical spec's middle-bottom anchor plus the unchanged camera. Under the spec's anchor the actual centres for the committed scene (camera origin (0,1)) are **villager (144,120)** and **guard (528,312)** — verified by probing the rendered output. The **player** at (6,6) is fully occluded by the committed `trees_above` (above-player) layer under the new anchor (the sprite now sits in the canopy), so the two player-verification tests stand the player on the clear path at (6,8) (camera origin (0,2)), where the centre is exactly **(288,264)** as the criterion states. The committed scene and the samples are otherwise unchanged (the player spawns at (6,6), which is now visually under the tree canopy — a consequence of the fixture layout, not a code regression).