### PR TITLE
Story 54: Minimap black background

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -412,7 +412,7 @@ and it reuses the same prerendered layer images the main render path uses.
   - `> 1` zooms in: the map is drawn larger than the canvas and the view pans around the
     player's dot, clamped to the map edges — the same follow-and-clamp behaviour as the main
     camera.
-  - `0 < zoomLevel < 1` zooms out further (the map is drawn smaller with larger blank margins).
+  - `0 < zoomLevel < 1` zooms out further (the map is drawn smaller with larger black margins).
   - `<= 0` throws `ArgumentOutOfRangeException`.
 - **Layout.** The base fit scale is
   `baseFit = min(canvasWidth / Map.PixelWidth, canvasHeight / Map.PixelHeight)` and the effective
@@ -424,9 +424,11 @@ and it reuses the same prerendered layer images the main render path uses.
   **source** rect is the visible region ∩ layer bounds (in map pixels) and the **dest** rect is
   the same region scaled by `scale` and offset by the centering/pan origin. Dots outside the
   visible region are skipped.
-- **Background.** The method does **not** clear the canvas and never draws into the unused area
-  — "unused space is left blank", and the host owns the minimap background (e.g. a translucent
-  panel behind the minimap).
+- **Background.** When a map is set the method first clears the whole canvas to **black** (like
+  the main camera in `Render`), then draws the map and dots on top, so a map smaller than the
+  canvas is centered on a black background and the unused margins are black — the minimap's
+  background matches the main camera's black background. With no map it is a no-op and the canvas
+  is left untouched.
 
 The minimap's camera is the same follow + clamp + center model as the main camera
 (`ComputeCameraOrigin`), expressed in map pixels instead of tiles: per axis,

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,8 +109,9 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > **Minimap:** `engine.RenderMinimap(canvas, zoomLevel)` draws the map's prerendered layers plus a
 > green dot for the player and a yellow dot for each NPC onto a separate surface. `zoomLevel`
 > `1.0` fits the whole map (the default); `> 1` zooms in around the player's dot (clamped to the
-> map edges, like the main camera); `0 < zoomLevel < 1` zooms out further. It does not clear its
-> canvas — the host owns the minimap background (see `docs/api/GameEngine.md`).
+> map edges, like the main camera); `0 < zoomLevel < 1` zooms out further. When a map is set it
+> clears its canvas to **black** first (like the main camera), so the unused margins are black
+> (see `docs/api/GameEngine.md`).
 >
 > **Click-to-move (optional demo):** after at least one `Render` (so the engine knows the canvas
 > size), the host can pass a mouse click to `engine.Click(surfaceX, surfaceY)` and the player

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -57,8 +57,8 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   prerendered tile layers, a green dot for the player and a yellow dot for each NPC.
   `zoomLevel` `1.0` fits the whole map to the canvas; values above `1` zoom in and pan around
   the player's dot (clamped to the map edges, like the main camera); values between `0` and `1`
-  zoom out further. The minimap does not clear its canvas and leaves the unused margins blank,
-  so the host owns the minimap background.
+  zoom out further. When a map is set the minimap clears its canvas to **black** first (like
+  `Render`) and draws the map and dots on top, so the unused margins are black.
 - The engine is **`IDisposable`**: it owns the assigned map and disposes it when `Map` is
   replaced or when the engine itself is disposed (a `TileMap` is disposable because it
   prerenders each tile layer into an `SKImage` on load).
@@ -216,7 +216,7 @@ the same convention as `Render`.
 **Zoom semantics** (`zoomLevel`, relative to the "fit the whole map" view):
 
 - `1.0` (the default) **fits the entire map** into the canvas, centered, with the aspect ratio
-  preserved and the unused margins left blank.
+  preserved and the unused margins left black.
 - `> 1` **zooms in**: the map is drawn larger than the canvas and the view pans around the
   player's dot, clamped to the map edges (like the main camera).
 - `0 < zoomLevel < 1` zooms out further.
@@ -226,13 +226,14 @@ The base fit scale is `min(canvasWidth / Map.PixelWidth, canvasHeight / Map.Pixe
 effective scale is `baseFit * zoomLevel`. When the whole scaled map fits, it is centered; when
 zoomed in, the visible region (`canvasWidth / scale` × `canvasHeight / scale` map pixels) is
 centered on the player's position in map pixels (`Player.Position * ts`) and clamped inside the
-map bounds. With no map it is a **no-op** (the canvas is left untouched). The method does **not**
-clear the canvas and never draws into the unused area — the host owns the minimap background — and
-it is a pure render (it never mutates engine state).
+map bounds. With no map it is a **no-op** (the canvas is left untouched). When a map is set it
+first **clears the canvas to black** (like `Render`), then draws the map and dots on top, so a map
+smaller than the canvas is centered on a black background and the unused margins are black. It is
+a pure render (it never mutates engine state).
 
 ```csharp
 // Default fit: the whole map is drawn into the minimap canvas, centered, aspect preserved; the
-// unused margins stay blank (the host owns the minimap background).
+// unused margins are black (the minimap clears its canvas to black when a map is set).
 using var minimap = new SKBitmap(240, 240);
 using (var canvas = new SKCanvas(minimap))
 {

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -100,8 +100,9 @@ namespace RPGEngine;
 /// for each NPC in <see cref="Characters"/>. A <c>zoomLevel</c> of <c>1.0</c> fits the whole
 /// map into the minimap canvas; values above <c>1</c> zoom in and the view pans around the
 /// player's dot, clamped to the map edges like the main camera; values between <c>0</c> and
-/// <c>1</c> zoom out further. The minimap does not clear its canvas and leaves the unused
-/// margins blank, so the host owns the minimap background.
+/// <c>1</c> zoom out further. When a map is set the minimap clears its canvas to black first
+/// (like <see cref="Render"/>), then draws the map and the dots on top, so the unused margins
+/// are black.
 /// </para>
 /// </remarks>
 public sealed class GameEngine : IDisposable
@@ -423,8 +424,9 @@ public sealed class GameEngine : IDisposable
 
     /// <summary>
     /// Draws a minimap of the current map onto <paramref name="canvas"/>, a surface separate from
-    /// the main game canvas. It renders the map's prerendered tile layers (both below- and
-    /// above-player layers, in file order bottom → top — a minimap shows the
+    /// the main game canvas. When <see cref="Map"/> is set it first clears the whole canvas to
+    /// black (like <see cref="Render"/>), then renders the map's prerendered tile layers (both below-
+    /// and above-player layers, in file order bottom → top — a minimap shows the
     /// full picture), a green dot for the player and a yellow dot for each NPC in
     /// <see cref="Characters"/>. The canvas size is read from the canvas clip bounds, the same
     /// convention as <see cref="Render"/>.
@@ -456,8 +458,9 @@ public sealed class GameEngine : IDisposable
     /// like the main camera).
     /// </para>
     /// <para>
-    /// The method does not clear the canvas and does not draw into the unused margins —
-    /// &quot;unused space is left blank&quot; and the host owns the minimap background. It is a
+    /// When <see cref="Map"/> is set the method first clears the whole canvas to black (like
+    /// <see cref="Render"/>), so a map smaller than the canvas is centered on a black background
+    /// and the unused margins are black, then draws the map and the dots on top. It is a
     /// pure render: it never mutates engine state.
     /// </para>
     /// </remarks>
@@ -471,6 +474,10 @@ public sealed class GameEngine : IDisposable
             // No map: draw nothing and leave the canvas untouched.
             return;
         }
+
+        // When a map is set the whole canvas is cleared to black first: this is the black
+        // background behind/around a map that is smaller than the canvas, mirroring Render.
+        canvas.Clear(SKColors.Black);
 
         var bounds = canvas.LocalClipBounds;
         var canvasWidth = Math.Max(0, bounds.Width);
@@ -505,7 +512,7 @@ public sealed class GameEngine : IDisposable
         // the desired origin centres the player in the visible region, is clamped so the region
         // stays inside the map, and when the map is smaller than the visible region on an axis
         // the origin is shifted by half the difference so the map is centered on that axis (the
-        // leftover canvas is left blank).
+        // leftover canvas is black, cleared before drawing).
         var maxOriginX = Math.Max(0, mapWidth - visibleWidth);
         var maxOriginY = Math.Max(0, mapHeight - visibleHeight);
         var centerOffsetX = Math.Max(0, (canvasWidth - scaledWidth) / (2.0 * scale));

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -163,7 +163,8 @@ public class DocsExamplesTests
     // docs/api/GameEngine.md: the RenderMinimap example. The minimap renders
     // the map's prerendered layers plus a green player dot and yellow NPC dots
     // on a separate canvas; zoomLevel 1.0 fits the whole map, > 1 zooms in
-    // around the player's dot (clamped to the map edges).
+    // around the player's dot (clamped to the map edges). When a map is set
+    // the canvas is cleared to black first, so the unused margins are black.
     // ---------------------------------------------------------------------
     /// <summary>
     /// Verifies the RenderMinimap doc example: the default fit draws the whole map and the dots
@@ -181,7 +182,7 @@ public class DocsExamplesTests
         engine.Characters.Add(new Character { Position = new Position(3.5, 1.5) });
 
         // Default fit: the whole map is drawn into the minimap canvas, centered, aspect preserved;
-        // the unused margins stay blank (the host owns the minimap background).
+        // the unused margins are black (the minimap clears its canvas to black when a map is set).
         using var minimap = new SKBitmap(240, 240);
         using (var canvas = new SKCanvas(minimap))
         {
@@ -195,7 +196,7 @@ public class DocsExamplesTests
         Assert.NotEqual(0, minimap.GetPixel(120, 90).Alpha);   // a tile pixel inside the map
         Assert.Equal(SKColors.Green, minimap.GetPixel(30, 90));  // player dot (0.5,0.5) -> (30,90)
         Assert.Equal(SKColors.Yellow, minimap.GetPixel(210, 150)); // NPC dot (3.5,1.5) -> (210,150)
-        Assert.Equal(0, minimap.GetPixel(120, 5).Alpha);       // top margin blank
+        Assert.Equal(SKColors.Black, minimap.GetPixel(120, 5)); // top margin black
 
         // Zoomed in: the view is centered on the player's dot and clamps at the map edges.
         using var zoomed = new SKBitmap(240, 240);

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -1056,16 +1056,17 @@ public class GameEngineTests
     // green dot for the player and a yellow dot for each NPC, onto a canvas
     // separate from the main game canvas. zoomLevel 1.0 fits the whole map
     // centered with the aspect preserved; > 1 zooms in around the player's
-    // dot with the same edge clamp as the main camera; the canvas is not
-    // cleared and unused margins stay blank. The method is pure (it never
-    // mutates engine state), a null map is a no-op, and zoomLevel <= 0 throws
-    // ArgumentOutOfRangeException.
+    // dot with the same edge clamp as the main camera; when a map is set the
+    // canvas is cleared to black first, so the unused margins are black. The
+    // method is pure (it never mutates engine state), a null map is a no-op,
+    // and zoomLevel <= 0 throws ArgumentOutOfRangeException.
     // ---------------------------------------------------------------------
 
     /// <summary>
     /// Verifies the default zoom fits the whole (non-square) map into the canvas, centered with
-    /// the aspect ratio preserved, leaves the unused margins blank, and shows every distinct
-    /// tile color of a two-color map plus both dots at their scaled positions.
+    /// the aspect ratio preserved, leaves the unused margins black (the minimap clears its
+    /// canvas to black when a map is set), and shows every distinct tile color of a two-color
+    /// map plus both dots at their scaled positions.
     /// </summary>
     [Fact]
     public void RenderMinimap_DefaultZoom_FitsWholeMapCenteredWithBlankMargins()
@@ -1110,12 +1111,12 @@ public class GameEngineTests
         // The map is centered vertically with ~50 px margins above and below (it fills the 400 px
         // width), so it is not stretched to fill the 300 px canvas. Sample well inside each
         // region to avoid the rasterizer's sub-pixel edge rows.
-        Assert.Equal(0, bitmap.GetPixel(200, 20).Alpha);   // top margin blank
-        Assert.Equal(0, bitmap.GetPixel(200, 40).Alpha);   // top margin blank
+        Assert.Equal(SKColors.Black, bitmap.GetPixel(200, 20));   // top margin black
+        Assert.Equal(SKColors.Black, bitmap.GetPixel(200, 40));   // top margin black
         Assert.NotEqual(0, bitmap.GetPixel(200, 60).Alpha);  // map interior (top half)
         Assert.NotEqual(0, bitmap.GetPixel(200, 240).Alpha); // map interior (bottom half)
-        Assert.Equal(0, bitmap.GetPixel(200, 260).Alpha);  // bottom margin blank
-        Assert.Equal(0, bitmap.GetPixel(200, 280).Alpha);  // bottom margin blank
+        Assert.Equal(SKColors.Black, bitmap.GetPixel(200, 260));  // bottom margin black
+        Assert.Equal(SKColors.Black, bitmap.GetPixel(200, 280));  // bottom margin black
     }
 
     /// <summary>
@@ -1275,7 +1276,7 @@ public class GameEngineTests
         // centered with 50 px margins; the map is still drawn (e.g. its center is a map pixel).
         using var bitmap = RenderMinimap(engine, 200, 200, zoomLevel: 0.5);
         Assert.NotEqual(0, bitmap.GetPixel(100, 100).Alpha);
-        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha); // the margin stays blank
+        Assert.Equal(SKColors.Black, bitmap.GetPixel(0, 0)); // the margin is black
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes #54 — gives the minimap a **black background like the normal map**.

### Engine (`GameEngine.RenderMinimap`)
- When `Map != null`, the canvas is now cleared to black first (`canvas.Clear(SKColors.Black)`), mirroring `Render`. A map smaller than the canvas is centered on a black background and the unused margins are **black** instead of transparent.
- The `Map == null` behavior is unchanged: a no-op, the canvas is left untouched (the `RenderMinimap_NoMap_LeavesCanvasUntouched` contract is preserved).
- The minimap dot drawing, layer blitting, and zoom/clamp math are **untouched** — only the canvas backdrop changed.
- Updated the method's XML doc and the class-level `<remarks>`: the minimap clears its canvas to black when a map is set, draws the map and the dots on top, and the unused margins are black. The method is still a pure render and the zoom validation is unchanged.

### Tests
- `RenderMinimap_DefaultZoom_FitsWholeMapCenteredWithBlankMargins`: margin assertions changed from `Alpha == 0` to `== SKColors.Black`; the map-interior and both-dot assertions are unchanged.
- `RenderMinimap_SmallPositiveZoom_IsAccepted`: the margin assertion is now black; the map-interior assertion is unchanged.
- `RenderMinimap_NoMap_LeavesCanvasUntouched` keeps passing unchanged (orange backdrop survives).
- Non-regression: `RenderMinimap_Dots_AtScaledPositions`, `RenderMinimap_ZoomIn_ShowsSubRegionAndClampsToMapEdges`, `RenderMinimap_DotOutsideVisibleRegion_IsNotDrawn`, `RenderMinimap_NonPositiveZoom_ThrowsArgumentOutOfRangeException` and `RenderMinimap_DoesNotMutateEngineState_MainRenderUnchanged` all pass; the main `Render` output is bit-for-bit unchanged.
- `DocsExamplesTests.RenderMinimap_Example_DefaultFitAndZoom` updated to match the new doc example (top margin black).

### Documentation
- `docs/api/GameEngine.md`: class remarks + `RenderMinimap` section (including the example comments) now state the minimap clears its canvas to **black** when a map is set and the unused margins are black ("host owns the minimap background / margins stay blank" wording removed).
- `docs/Architecture.md`: minimap section — black background, matching the main camera's black background.
- `docs/README.md`: the minimap callout mentions the black background (no longer "host owns the background").

### Verification
- `dotnet build -c Release`: **0 warnings / 0 errors**.
- `dotnet test tests/RPGEngine.Tests -c Release`: **350/350 passed**.
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~GameEngineTests"`: **60/60 passed**.