### PR TITLE
Story 55: Player.OnMove fires when a collision stops the player

### DIFF
--- a/.transcode-test.txt
+++ b/.transcode-test.txt
@@ -1,6 +1,4 @@
-quote: " inside
-emdash: \u2014 emdash
-arrow: \u2192 arrow
-backslash: \\ backslash
-tab: \t tab
+emdash: — emdash
+arrow: → arrow
+backslash: \ backslash
 plain: hello

--- a/.transcode-test.txt
+++ b/.transcode-test.txt
@@ -1,0 +1,6 @@
+quote: " inside
+emdash: \u2014 emdash
+arrow: \u2192 arrow
+backslash: \\ backslash
+tab: \t tab
+plain: hello

--- a/.transcode-test.txt
+++ b/.transcode-test.txt
@@ -1,4 +1,0 @@
-emdash: — emdash
-arrow: → arrow
-backslash: \ backslash
-plain: hello

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -279,8 +279,15 @@ in tile units:
 This keeps **wall-sliding** natural (a blocked axis reverts while the other axis still moves, so
 a diagonal move into a wall slides along the wall on the free axis) and prevents **diagonal
 corner-cutting** (each axis is resolved independently, so a diagonal cannot squeeze diagonally
-through a corner). The map-bounds clamp (`ClampPlayerToMap`) keeps the **lower-half footprint**
-inside the map (the feet clamp to `x ∈ [halfWidth, max(halfWidth, Map.Width - halfWidth)]`,
+through a corner). After the resolution the engine reports the outcome to the player: a move with
+**no net displacement** (fully blocked on every axis, e.g. walking straight into a wall or into a
+corner) is reported as a **collision stop** through `Player.ReportBlockedMove`, so `Player.OnMove`
+fires with `IsMoving = false` even while the movement key is held against the wall (exactly once,
+with the direction the player tried to move in); any move that actually displaced the player
+(including a diagonal slide, whose free axis moved) is reported as movement through
+`Player.ReportMovement` as before. The map-bounds clamp (`ClampPlayerToMap`) keeps the
+**lower-half footprint** inside the map (the feet clamp to
+`x ∈ [halfWidth, max(halfWidth, Map.Width - halfWidth)]`,
 `y ∈ [halfHeight, max(halfHeight, Map.Height)]` — for the default 48×48 sprite with 48 px
 tiles this is `x ∈ [0.5, Map.Width - 0.5]`, `y ∈ [0.5, Map.Height]`) and remains as a
 safety net for positions placed outside the map by other means. The map edge is solid.
@@ -350,13 +357,14 @@ crosses a solid tile and no per-frame collision resolution is needed.
 
 **Movement-state events**: `Player` exposes `OnMove` (`EventHandler<PlayerMoveEventArgs>`), fired
 on every movement-state transition — starts moving (idle → moving), stops moving (moving →
-idle, via `Player.Stop()`), and changes direction while moving. It carries
+idle, via `Player.Stop()` or a collision stop), and changes direction while moving. It carries
 `PlayerMoveEventArgs.IsMoving` and the current facing `Direction`. The engine raises it for both
 manual key movement and auto-walk through `Player.ReportMovement` (the internal bridge used for
 collision-resolved and auto-walk movement, which cannot go through `Player.Move` because that
-method applies the whole displacement at once). `Player.Stop()` raises it with `IsMoving = false`
-only when the player was moving; the engine calls it when there is no input and no auto-walk
-target.
+method applies the whole displacement at once), and reports a fully blocked move (a collision
+stop) through `Player.ReportBlockedMove` so `OnMove` fires with `IsMoving = false` even while a
+movement key is held against the wall. `Player.Stop()` raises it with `IsMoving = false` only
+when the player was moving; the engine calls it when there is no input and no auto-walk target.
 
 ## Rendering
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,7 +118,9 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > **auto-walks** along an A* tile path to the clicked tile, stopping centered on it. Clicking a
 > solid tile or an unreachable target cancels the walk without moving; a key press cancels it and
 > a click mid-walk replaces the destination. `Player.OnMove` fires on every movement-state
-> transition (start / stop / direction change) with the current facing direction. See
+> transition (start / stop / direction change) with the current facing direction — including a
+> stop caused by a collision while a movement key is held (the engine reports the blocked move,
+> so `OnMove` fires with `IsMoving = false` even against a wall). See
 > `docs/api/GameEngine.md` and `docs/api/Player.md`.
 
 ### Reading order

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -12,13 +12,15 @@ equivalent to configuring/moving the underlying `Character`.
 
 The player does not listen to input itself. The engine (`GameEngine`) owns the pressed-keys
 state and calls `Move(direction, 1, dt)` in its update loop (or drives the player directly for
-collision-resolved and auto-walk movement through its internal `ReportMovement` bridge).
+collision-resolved and auto-walk movement through its internal `ReportMovement` bridge, and
+reports a fully blocked move through its internal `ReportBlockedMove` bridge).
 
 The player exposes a **movement-state machine** through the `OnMove` event: it fires whenever
-the player *starts moving* (idle → moving), *stops moving* (moving → idle, via `Stop()`), or
-*changes direction while moving*. The event is raised for both manual (key) movement and
-auto-walk movement, so hosts can react to the player's movement state without polling the
-position every frame.
+the player *starts moving* (idle → moving), *stops moving* (moving → idle, via `Stop()` or a
+collision stop reported by the engine), or *changes direction while moving*. The event is raised
+for both manual (key) movement and auto-walk movement, so hosts can react to the player's
+movement state without polling the position every frame. A collision stop fires `OnMove` with
+`IsMoving = false` even while the movement key stays pressed against the wall.
 
 ## Fields
 
@@ -92,10 +94,16 @@ player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 ### `event EventHandler<PlayerMoveEventArgs>? OnMove`
 
 Occurs when the player's movement state changes: it **starts moving** (idle → moving), **stops
-moving** (moving → idle, via `Stop()`), or **changes direction while moving**. The event
-carries the new state (`PlayerMoveEventArgs.IsMoving`) and the player's current facing direction
-(`PlayerMoveEventArgs.Direction`). It is raised for both manual (key) movement and auto-walk
-movement.
+moving** (moving → idle, via `Stop()` or a collision stop), or **changes direction while
+moving**. The event carries the new state (`PlayerMoveEventArgs.IsMoving`) and the player's
+current facing direction (`PlayerMoveEventArgs.Direction`). It is raised for both manual (key)
+movement and auto-walk movement.
+
+When the player **stops because of a collision** (the engine reports a fully blocked move against
+a solid tile or the map edge), `OnMove` fires with `IsMoving = false` **even while the movement
+key is still held** — the stop is reported exactly once, and holding the key against the same
+wall does not raise the event again. The reported direction is the direction the player tried to
+move in (the player turns to face the wall).
 
 ```csharp
 var player = new Player();
@@ -107,6 +115,10 @@ player.OnMove += (_, e) =>
 
 player.Move(Direction.Right, speedFactor: 1, dt: 1); // prints "moving" / "facing Right"
 player.Stop();                                       // prints "stopped" / "facing Right"
+
+// Collision stop while the movement key is held: the engine reports the fully blocked move.
+// With D held against a solid tile (or the map edge), OnMove fires (false, Right) exactly
+// once when the player is blocked; keeping D held against the same wall raises nothing more.
 ```
 
 ### `sealed record PlayerMoveEventArgs(bool IsMoving, Direction Direction)`

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -80,8 +80,13 @@ namespace RPGEngine;
 /// (<see cref="Player.Position"/> is the middle-bottom of the sprite): only the lower half is
 /// tested against solid tiles, so the upper body never collides with the ground. Clamping keeps
 /// that lower-half footprint inside the map. This blocks the player at solid tiles, keeps
-/// wall-sliding natural and prevents diagonal corner-cutting. See <c>docs/Architecture.md</c>
-/// for the collision model.
+/// wall-sliding natural and prevents diagonal corner-cutting. When a move is <em>fully blocked</em>
+/// (no net displacement after the axis-separated resolution, e.g. walking straight into a wall or
+/// into a corner), the engine reports a <em>collision stop</em> to the player
+/// (<see cref="Player.ReportBlockedMove(Direction)"/>), so <see cref="Player.OnMove"/> fires
+/// with <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/> even while
+/// the movement key is held against the wall. See <c>docs/Architecture.md</c> for the collision
+/// model.
 /// </para>
 /// <para>
 /// The engine is <see cref="IDisposable"/>: it owns the assigned map and disposes it when
@@ -953,6 +958,14 @@ public sealed class GameEngine : IDisposable
     /// <param name="direction">The direction to face and move towards.</param>
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
     /// <remarks>
+    /// After the displacement is resolved, the outcome is reported to the player: a move with no
+    /// net displacement (fully blocked by solid tiles or the map edge on every axis) is reported
+    /// as a <em>collision stop</em> through <see cref="Player.ReportBlockedMove(Direction)"/>,
+    /// so <see cref="Player.OnMove"/> fires with <see cref="PlayerMoveEventArgs.IsMoving"/>
+    /// set to <see langword="false"/> even while the movement key stays held; a move that
+    /// actually displaced the player is reported as movement through
+    /// <see cref="Player.ReportMovement(Direction)"/> as before (a diagonal slide along a wall
+    /// still counts as movement because the free axis changed the position).
     /// NPCs are not moved by the engine (they have no AI yet), so collision resolution only
     /// applies to the player here; the public <see cref="Tiled.TileMap.IsSolid"/> API is
     /// available for future NPC logic.
@@ -960,8 +973,10 @@ public sealed class GameEngine : IDisposable
     private void MovePlayerWithCollisionResolution(Direction direction, double dt)
     {
         // The engine resolves the displacement itself (axis by axis) instead of calling
-        // Player.Move, which would move both axes at once; the direction is set through
-        // Player.ReportMovement at the end, which also raises Player.OnMove on state transitions.
+        // Player.Move, which would move both axes at once. The position is captured before the
+        // resolution so a fully blocked move (no net displacement) can be reported as a
+        // collision stop instead of movement below.
+        var before = Player.Position;
         var delta = direction.Delta() * (Player.Character.BaseSpeed * dt);
 
         if (Map is null)
@@ -991,7 +1006,20 @@ public sealed class GameEngine : IDisposable
             Player.Position = position;
         }
 
-        Player.ReportMovement(direction);
+        if (Player.Position == before)
+        {
+            // The player is fully blocked (no net displacement after the axis-separated
+            // resolution, e.g. walking straight into a wall or into a corner): report the
+            // collision stop instead of movement, so Player.OnMove fires with IsMoving = false
+            // exactly once while the movement key is held against the wall.
+            Player.ReportBlockedMove(direction);
+        }
+        else
+        {
+            // The player actually displaced: report movement as before (a diagonal slide along
+            // a wall still counts as movement because the free axis changed the position).
+            Player.ReportMovement(direction);
+        }
     }
 
     /// <summary>

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -22,9 +22,12 @@ namespace RPGEngine;
 /// <para>
 /// The player exposes a movement-state machine through <see cref="OnMove"/>: it fires whenever
 /// the player <em>starts moving</em> (idle &#8594; moving), <em>stops moving</em> (moving &#8594;
-/// idle, via <see cref="Stop"/>), or <em>changes direction while moving</em>. The event is raised
-/// for both manual (key) movement and auto-walk movement, so hosts can react to the player's
-/// movement state without polling the position every frame.
+/// idle, via <see cref="Stop"/> or a collision stop reported by the engine), or <em>changes
+/// direction while moving</em>. The event is raised for both manual (key) movement and auto-walk
+/// movement, so hosts can react to the player's movement state without polling the position every
+/// frame. A collision stop raises <see cref="OnMove"/> with
+/// <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/> even while the
+/// movement key stays pressed against the wall.
 /// </para>
 /// </remarks>
 public sealed class Player
@@ -48,10 +51,13 @@ public sealed class Player
 
     /// <summary>
     /// Occurs when the player's movement state changes: it starts moving (idle &#8594; moving),
-    /// stops moving (moving &#8594; idle, via <see cref="Stop"/>), or changes direction while
-    /// moving. The event carries the new state (<see cref="PlayerMoveEventArgs.IsMoving"/>) and
-    /// the player's current facing direction (<see cref="PlayerMoveEventArgs.Direction"/>). It is
-    /// raised for both manual (key) movement and auto-walk movement.
+    /// stops moving (moving &#8594; idle, via <see cref="Stop"/> or a collision stop reported by
+    /// the engine), or changes direction while moving. The event carries the new state
+    /// (<see cref="PlayerMoveEventArgs.IsMoving"/>) and the player's current facing direction
+    /// (<see cref="PlayerMoveEventArgs.Direction"/>). It is raised for both manual (key)
+    /// movement and auto-walk movement. A collision stop fires with
+    /// <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/> even while
+    /// the movement key stays pressed against the wall.
     /// </summary>
     public event EventHandler<PlayerMoveEventArgs>? OnMove;
 
@@ -233,6 +239,38 @@ public sealed class Player
         if (!wasMoving || direction != previousDirection)
         {
             OnMove?.Invoke(this, new PlayerMoveEventArgs(true, direction));
+        }
+    }
+
+    /// <summary>
+    /// Records that the player attempted to move in <paramref name="direction"/> but was fully
+    /// blocked (e.g. by a solid tile or the map edge): the player faces <paramref name="direction"/>
+    /// and, when it was moving, transitions to idle and raises <see cref="OnMove"/> with
+    /// <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/>. When the player was
+    /// already idle and the direction is unchanged, this is a no-op (no repeated events while the key
+    /// is held against the wall).
+    /// </summary>
+    /// <remarks>
+    /// This is the internal bridge the engine uses to report a collision stop: unlike
+    /// <see cref="ReportMovement"/> it marks the player as idle (the displacement was fully blocked,
+    /// so the player is not moving), so <see cref="OnMove"/> reflects the actual movement state even
+    /// while a movement key stays pressed against a wall. Mirroring
+    /// <see cref="Move(Direction, double, double)"/> with <c>speedFactor: 0</c>, a turn while already
+    /// idle and facing <paramref name="direction"/> raises the event with
+    /// <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/>.
+    /// </remarks>
+    /// <param name="direction">The direction the player tried to move in (and now faces).</param>
+    internal void ReportBlockedMove(Direction direction)
+    {
+        var wasMoving = _isMoving;
+        var previousDirection = _lastDirection;
+
+        Direction = direction;
+        _isMoving = false;
+
+        if (wasMoving || direction != previousDirection)
+        {
+            OnMove?.Invoke(this, new PlayerMoveEventArgs(false, direction));
         }
     }
 }

--- a/tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs
@@ -1,0 +1,292 @@
+using RPGEngine.Sprites;
+using RPGEngine.Tiled;
+using RPGEngine.Tests.Tiled;
+using Xunit;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Acceptance tests for story 55: <see cref="Player.OnMove"/> fires when a collision stops the
+/// player. The engine reports a fully blocked move (no net displacement after the axis-separated
+/// resolution) through <c>Player.ReportBlockedMove</c> instead of <c>Player.ReportMovement</c>,
+/// so OnMove fires with <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/>
+/// exactly once when the player stops because of a collision, even while the movement key is held
+/// against the wall. These tests assert the exact event sequence (not the exact frame on which
+/// the stop is reported), so they hold with either collision-resolution behavior.
+/// </summary>
+public class GameEngineCollisionOnMoveTests
+{
+    private const double FrameDt = 1.0 / 60;
+
+    /// <summary>
+    /// Verifies holding D against a solid column fires (true, Right) when movement starts, then
+    /// (false, Right) exactly once when the player is fully blocked, and no further events while
+    /// D stays held for many more frames.
+    /// </summary>
+    [Fact]
+    public void Update_KeyHeldAgainstSolidTile_FiresOnMoveFalseExactlyOnce()
+    {
+        // 4x4 map: a "walls" collision layer with a solid column at x=2 for every row.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+        });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 1.0);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.D, true);
+
+        // Frame-by-frame Update(1/60): the player starts moving right, hits the wall, and keeps
+        // pressing D against it for many more frames.
+        for (var frame = 0; frame < 300; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The player stopped at the solid column: its footprint never enters it.
+        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
+
+        // Exact event sequence: one (true, Right) on start, then exactly one (false, Right) on
+        // the collision stop, and nothing more while D stays held.
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.Right),
+                new PlayerMoveEventArgs(false, Direction.Right),
+            },
+            events);
+    }
+
+    /// <summary>
+    /// Verifies releasing the movement key after the blocked (false, Right) was fired raises no
+    /// additional event: the player is already idle, so the stop is reported exactly once.
+    /// </summary>
+    [Fact]
+    public void Update_ReleaseAfterBlockedStop_FiresNoAdditionalEvent()
+    {
+        // 4x4 map: a "walls" collision layer with a solid column at x=2 for every row.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+        });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 1.0);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.D, true);
+
+        // Run enough frames to hit the wall and report the collision stop while D is held.
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The collision stop was reported exactly once while D was held.
+        Assert.Equal(1, events.Count(e => !e.IsMoving));
+        events.Clear();
+
+        // Releasing D fires no additional event: the player is already idle.
+        engine.Input(Key.D, false);
+        engine.Update(FrameDt);
+
+        Assert.Empty(events);
+    }
+
+    /// <summary>
+    /// Verifies a player already blocked and idle facing Right that presses Up (also blocked)
+    /// fires (false, Up) once (a direction change while idle), and a subsequent frame with the
+    /// same keys fires nothing.
+    /// </summary>
+    [Fact]
+    public void Update_TurnWhileBlocked_FiresOnMoveFalseForNewDirectionOnce()
+    {
+        // 4x4 map with a solid column at x=2 (blocks Right) and a solid row at y=0 (blocks Up).
+        // The player starts in row y=1 so the solid row above (y=0) does not overlap its own
+        // lower-half footprint (y in [1.0, 1.5]).
+        var gids = new uint[16];
+        for (var y = 0; y < 4; y++)
+        {
+            gids[(y * 4) + 2] = 1; // column x=2
+        }
+        for (var x = 0; x < 4; x++)
+        {
+            gids[x] = 1; // row y=0
+        }
+
+        using var fixture = CreateCollisionMapFixture(4, 4, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 1.5);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        // Walk right into the solid column and stop there (idle, facing Right).
+        engine.Input(Key.D, true);
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // Blocked at the wall (footprint never enters the solid column), facing Right.
+        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
+        Assert.Equal(new PlayerMoveEventArgs(false, Direction.Right), events[^1]);
+        events.Clear();
+
+        // Press Up (also blocked): a direction change while idle -> (false, Up) exactly once.
+        engine.Input(Key.D, false);
+        engine.Input(Key.W, true);
+        engine.Update(FrameDt);
+
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.Up) }, events);
+
+        // A subsequent frame with the same keys fires nothing.
+        events.Clear();
+        engine.Update(FrameDt);
+        Assert.Empty(events);
+    }
+
+    /// <summary>
+    /// Verifies a diagonal move into a wall slides along the free axis: the player keeps moving
+    /// (its position changes each frame), so no (false, ...) stop event fires mid-slide.
+    /// </summary>
+    [Fact]
+    public void Update_DiagonalSlideIntoWall_DoesNotReportStopMidSlide()
+    {
+        // 5x5 map: a "walls" collision layer with a solid column at x=3 for every row.
+        var gids = new uint[25];
+        for (var y = 0; y < 5; y++)
+        {
+            gids[(y * 5) + 3] = 1;
+        }
+
+        using var fixture = CreateCollisionMapFixture(5, 5, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Start flush against the left edge of the wall column: moving UpRight, the X
+        // displacement is blocked while Y is free, so the player slides straight up along it.
+        engine.Player.Position = new Position(2.5, 4.0);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.W, true);
+        engine.Input(Key.D, true);
+
+        for (var frame = 0; frame < 60; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The player slid up along the wall: X never moved into it, Y decreased.
+        Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
+        Assert.True(engine.Player.Position.Y < 4.0);
+
+        // The slide is still movement: the start fired (true, UpRight) and no stop event fired
+        // mid-slide (the position changed every frame).
+        Assert.Contains(new PlayerMoveEventArgs(true, Direction.UpRight), events);
+        Assert.DoesNotContain(events, e => !e.IsMoving);
+    }
+
+    /// <summary>
+    /// Verifies a player fully blocked on both axes (a corner) reports (false, direction)
+    /// exactly once: walking into a corner fires (true, ...) on start and (false, ...) once when
+    /// both axes become blocked, then nothing more while the keys stay held.
+    /// </summary>
+    [Fact]
+    public void Update_FullyBlockedCorner_FiresOnMoveFalseOnce()
+    {
+        // A 2x2 filled map (no collision layer): only the map edge is solid.
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(1.5, 1.5);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        // Walk up-left into the top-left corner of the map: both axes are eventually blocked by
+        // the map edge at (0.5, 0.5).
+        engine.Input(Key.W, true);
+        engine.Input(Key.A, true);
+
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The player is fully blocked in the top-left corner region: its lower-half footprint
+        // never leaves the map, and a further frame leaves both the position and the events
+        // unchanged.
+        var blockedPosition = engine.Player.Position;
+        Assert.True(blockedPosition.X < 1.0 && blockedPosition.Y < 1.0, "The player must end near the top-left corner.");
+
+        // Exact sequence: (true, UpLeft) when the walk started, then exactly one (false, UpLeft)
+        // when both axes became blocked, and nothing more while W+A stay held.
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.UpLeft),
+                new PlayerMoveEventArgs(false, Direction.UpLeft),
+            },
+            events);
+
+        // A subsequent frame with the same keys fires nothing and does not move the player.
+        events.Clear();
+        engine.Update(FrameDt);
+        Assert.Empty(events);
+        Assert.Equal(blockedPosition, engine.Player.Position);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers (mirror the private helpers of GameEngineTests so this class is
+    // self-contained; both live in the same test assembly).
+    // ---------------------------------------------------------------------
+
+    /// <summary>Creates a map fixture filled with red tiles in a single "ground" layer.</summary>
+    private static TiledTestFixture CreateFilledMapFixture(int width, int height)
+        => new(width, height, new[] { FilledLayer(width, height) });
+
+    /// <summary>
+    /// Creates a map fixture with a filled "ground" layer (walkable) and a "walls" collision
+    /// layer declaring the Tiled <c>is_collision</c> bool property set to <c>true</c>.
+    /// </summary>
+    private static TiledTestFixture CreateCollisionMapFixture(int width, int height, uint[] collisionGids)
+        => new(
+            width,
+            height,
+            new[]
+            {
+                FilledLayer(width, height),
+                new TileLayerSpec(
+                    "walls",
+                    collisionGids,
+                    Properties: new[] { new FixtureProperty("is_collision", "bool", "true") }),
+            });
+
+    /// <summary>Builds a fully filled single-layer spec for a map of the given size.</summary>
+    private static TileLayerSpec FilledLayer(int width, int height)
+        => new("ground", Enumerable.Repeat(1u, width * height).ToArray());
+
+    /// <summary>Loads a seeded full sheet under the name "hero" and configures the player to use it.</summary>
+    private static void ConfigurePlayerSprite(GameEngine engine, int seed)
+    {
+        using var stream = CharacterTestHelper.CreateSheetStream(seed);
+        engine.LoadSpriteSheet("hero", stream);
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+    }
+}

--- a/tests/RPGEngine.Tests/PlayerBlockedMoveTests.cs
+++ b/tests/RPGEngine.Tests/PlayerBlockedMoveTests.cs
@@ -1,0 +1,95 @@
+using Xunit;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Acceptance tests for <see cref="Player.ReportBlockedMove(Direction)"/> (story 55), the
+/// internal bridge the engine uses to report a collision stop: the player faces the blocked
+/// direction, transitions moving &#8594; idle and raises <see cref="Player.OnMove"/> with
+/// <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/> only on a
+/// transition (the player was moving, or the facing direction changed while idle). When already
+/// idle and facing the same direction it is a no-op, so the stop is reported exactly once while
+/// a movement key is held against a wall.
+/// </summary>
+public class PlayerBlockedMoveTests
+{
+    /// <summary>
+    /// Verifies ReportBlockedMove while moving faces the direction, transitions the player to
+    /// idle and raises OnMove with IsMoving = false and the blocked direction.
+    /// </summary>
+    [Fact]
+    public void ReportBlockedMove_WhenMoving_RaisesOnMoveWithIsMovingFalse()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        events.Clear();
+
+        player.ReportBlockedMove(Direction.Right);
+
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.Right) }, events);
+        Assert.Equal(Direction.Right, player.Direction);
+    }
+
+    /// <summary>
+    /// Verifies ReportBlockedMove while already idle and facing the same direction is a no-op:
+    /// it raises nothing (the collision stop is reported exactly once while the key is held
+    /// against the wall).
+    /// </summary>
+    [Fact]
+    public void ReportBlockedMove_WhenIdleSameDirection_IsNoOp()
+    {
+        var player = new Player { Direction = Direction.Right };
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.ReportBlockedMove(Direction.Right);
+
+        Assert.Empty(events);
+    }
+
+    /// <summary>
+    /// Verifies ReportBlockedMove while idle facing a different direction raises OnMove with
+    /// IsMoving = false and the new direction (a "turn while blocked", matching the turn
+    /// semantics of a speed-factor-zero Move).
+    /// </summary>
+    [Fact]
+    public void ReportBlockedMove_WhenIdleDirectionChanged_RaisesOnMoveWithIsMovingFalse()
+    {
+        var player = new Player { Direction = Direction.Right };
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.ReportBlockedMove(Direction.Up);
+
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.Up) }, events);
+        Assert.Equal(Direction.Up, player.Direction);
+    }
+
+    /// <summary>
+    /// Verifies the exact event sequence across a move, a blocked stop and repeated blocked
+    /// reports: (true, ...) on start, then exactly one (false, ...) on the blocked stop, and
+    /// nothing more while the same blocked direction is reported again.
+    /// </summary>
+    [Fact]
+    public void MoveThenBlocked_ProducesExactEventSequence()
+    {
+        var player = new Player();
+        var events = new List<PlayerMoveEventArgs>();
+        player.OnMove += (_, e) => events.Add(e);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        player.ReportBlockedMove(Direction.Right); // moving -> idle (the collision stop)
+        player.ReportBlockedMove(Direction.Right); // already idle, same direction: no event
+
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.Right),
+                new PlayerMoveEventArgs(false, Direction.Right),
+            },
+            events);
+    }
+}


### PR DESCRIPTION
Closes #55

## Summary

Implements [Story 55](https://github.com/elliottv/rpg-engine/issues/55): `Player.OnMove` now fires with `IsMoving = false` when the player stops because of a collision (a solid tile or the map edge), even while the movement key is still held.

### Changes

**`src/RPGEngine/Player.cs`**
- Added the internal `Player.ReportBlockedMove(Direction)` method: faces the blocked direction, transitions moving → idle, and raises `OnMove` with `IsMoving = false` **only on a transition** (the player was moving, or the facing direction changed while idle). When already idle and facing the same direction it is a no-op, so the collision stop is reported exactly once while the key is held against the wall.

**`src/RPGEngine/GameEngine.cs`**
- `MovePlayerWithCollisionResolution` now captures the player's position before resolving the displacement. After the axis-separated resolution, if `Player.Position == before` (fully blocked — no net displacement), it calls `Player.ReportBlockedMove(direction)` instead of `Player.ReportMovement(direction)`. A diagonal slide that changes position still reports movement (`IsMoving = true`).
- Updated the method remarks and class remarks to document the collision-stop reporting.

**Tests (new files, so the existing `GameEngineTests` / `PlayerTests` are untouched)**
- `tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs` — acceptance tests for the collision-stop `OnMove` behavior: key held against a solid column fires `(true, Right)` then exactly one `(false, Right)` (no further events while D is held); release after blocked fires nothing; turn while blocked fires `(false, Up)` once; a diagonal slide never reports a stop mid-slide; a fully blocked corner reports `(false, direction)` once. Tests assert the exact event sequence (not the exact frame) so they hold with either collision-resolution behavior.
- `tests/RPGEngine.Tests/PlayerBlockedMoveTests.cs` — unit tests for `ReportBlockedMove` (moving → `(false, dir)`; idle same direction no-op; idle direction change → `(false, dir)`; exact move-then-blocked sequence).

**Docs**
- `docs/api/Player.md` — `OnMove` remarks now describe the collision-stop behavior (fires `IsMoving = false` even while the key is held) with a commented example.
- `docs/Architecture.md` — movement/collision section: the engine reports collision stops to the player (`ReportBlockedMove`), so `OnMove` reflects the actual movement state.
- `docs/README.md` — the movement section mentions the collision-stop `OnMove` behavior.

### Verification
- `dotnet build -c Release`: **0 warnings / 0 errors** (CS1591 enforced).
- `dotnet test tests/RPGEngine.Tests -c Release`: **359 passed, 0 failed** (350 pre-existing + 9 new).
- Existing non-regression tests (`Update_KeyMovement_RaisesOnMoveOnStartAndStop`, `Update_KeyMovement_ChangingDirectionRaisesOnMove`, `Click_OnMove_FiresTrueWhenWalkStartsAndFalseWhenItCompletes`, `Click_DuringAutoWalk_ReplacesDestinationWithoutStopping`) pass unchanged.