### PR TITLE
Story 57: Animated tile support (Tiled format)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -429,6 +429,50 @@ below-player layers → NPCs → player → above-player layers
   so a small map is never letterboxed with transparent or leftover pixels. When the map fills
   (or exceeds) the canvas, the behaviour is the classic follow-and-clamp camera.
 
+## Animated tiles
+
+`TileMap` and `TileSet` support **animated tiles** as defined by the Tiled format: a tileset tile
+may declare
+
+```xml
+<tile id="5">
+  <animation>
+    <frame tileid="5" duration="100"/>
+    <frame tileid="6" duration="100"/>
+    <frame tileid="7" duration="100"/>
+  </animation>
+</tile>
+```
+
+Each `<frame>` references a **local tile ID** within the tileset and a **duration in
+milliseconds**. Every layer cell that uses such a tile plays the frame sequence, looping forever.
+This is parsed at load time into an internal `TileAnimation` (frames in file order plus the total
+cycle duration) keyed by local tile ID on the owning `TileSet`.
+
+- **An internal clock.** `TileMap` keeps an animation clock in seconds. `GameEngine.Update`
+  calls `TileMap.UpdateAnimations(dt)` once per frame, so animated tiles advance with game time.
+  The current frame of a cell is derived from the clock with `elapsedMs % TotalDurationMs` and a
+  short walk over the frames (`GetFrameTileId`); a sequence whose total duration is zero is
+  treated as its first frame only.
+- **Animated cells are detected per layer at load time.** For every non-empty cell the owning
+  tileset and local tile ID are resolved (the same `ResolveTileSet` logic used for prerendering)
+  and cells whose tile declares an animation are recorded as `AnimatedTileCell`s.
+- **They are excluded from the prerendered layer images.** A static prerendered `SKImage` cannot
+  bake an animation, so `PrerenderLayer` leaves animated cells transparent. The render passes
+  (`DrawLayerImages`, both the below- and above-player passes) draw each layer's animated cells
+  **on top of that layer's own prerendered image**, at the cell rect, applying the layer's flip
+  flags (`TileMapLayer.GetTileFlags`) and the layer's `Opacity` (via the paint alpha) with the
+  same `DrawTile` transform used for static tiles. Because the animated cells are drawn inside
+  the per-layer loop, they stay above their own layer and below the layers above, preserving the
+  layer z-order.
+- **The minimap shows them too.** `GameEngine.RenderMinimap` draws each layer's animated cells
+  after its prerendered blit using the same scale/origin mapping as the layer blits, so the
+  minimap is not left with holes where animated tiles are.
+- **Performance note.** Frame images are resolved per frame (`GetAnimatedTileId` →
+  `TileSet.GetTileImage`); a later optimization can cache the per-tile frame images. This is
+  acceptable for the first implementation because animation sequences are short and maps
+  typically contain few animated cells.
+
 ## Minimap
 
 `GameEngine.RenderMinimap(canvas, zoomLevel)` renders a **minimap** of the current map onto a

--- a/docs/api/TileMap.md
+++ b/docs/api/TileMap.md
@@ -27,6 +27,13 @@ Namespace: `RPGEngine.Tiled` — a tile map loaded from a Tiled `.tmx` file (and
   `true` is a collision layer; its non-empty tiles are solid and block character movement.
   `IsSolid` reports solid tiles and treats the map edge as solid (see the `IsSolid` method
   below).
+- **Animated tiles** (a Tiled `<tile><animation>` block in a tileset) are parsed and rendered
+  automatically: animated cells are excluded from the prerendered layer images (a static raster
+  would freeze a single frame) and drawn per frame by `Draw`/`DrawAbovePlayer` using the map's
+  internal animation clock (advanced by `GameEngine.Update` via `TileMap.UpdateAnimations`),
+  with the layer's flip flags and opacity applied. The minimap shows them too, so animated
+  tiles never leave holes in the minimap. The animation data itself is internal and not exposed
+  through the public API.
 
 ## Properties
 

--- a/docs/api/TileSet.md
+++ b/docs/api/TileSet.md
@@ -10,6 +10,10 @@ together with the global tile ID (`FirstGid`) at which the tileset starts within
   WebAssembly). The tilesets referenced by a map are created internally by `TileMap.Load`.
 - The backing image is decoded exactly once; `GetTileImage` returns a cropped raster copy of a
   single tile that the caller owns and may dispose freely.
+- Per-tile animations declared by the tileset (a Tiled `<tile><animation>` block) are parsed at
+  load time and honored by rendering: every layer cell that uses an animated tile plays its
+  frame sequence (see `TileMap`'s animated-tile support). The animation data itself is internal
+  and not exposed through the public API.
 
 ## Properties
 

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -342,6 +342,11 @@ public sealed class GameEngine : IDisposable
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
     public void Update(double dt)
     {
+        // Advance the map's animation clock once per frame so animated tiles progress with game
+        // time. Ordering within Update is not significant (animations are independent of the
+        // movement/collision resolution below).
+        Map?.UpdateAnimations(dt);
+
         var direction = Config.GetMovementDirection(_pressedKeys);
 
         // Manual key movement takes priority over auto-walk: while a bound movement key is held
@@ -554,8 +559,10 @@ public sealed class GameEngine : IDisposable
         // destination rect is that region mapped to the canvas by the effective scale and the
         // pan/center origin.
         using var layerPaint = new SKPaint { IsAntialias = false };
+        using var animatedPaint = new SKPaint { IsAntialias = false };
         for (var layerIndex = 0; layerIndex < Map.Layers.Count; layerIndex++)
         {
+            var layer = Map.Layers[layerIndex];
             var image = Map.PrerenderedLayerImages[layerIndex];
             if (image is null)
             {
@@ -583,6 +590,37 @@ public sealed class GameEngine : IDisposable
                 (float)((sourceBottom - originY) * scale));
 
             canvas.DrawImage(image, source, destination, layerPaint);
+
+            // Draw the layer's animated cells after its prerendered blit so the minimap is not
+            // left with holes where animated tiles were excluded from the prerender. The cell is
+            // mapped the same way the layer blits are: source = the cell in map pixels,
+            // destination = ((x*ts - originX) * scale, ...), and the layer's flip flags and
+            // opacity are applied to match the static tiles of the same layer.
+            animatedPaint.Color = SKColors.White.WithAlpha((byte)Math.Round(layer.Opacity * 255f));
+            foreach (var cell in Map.GetAnimatedCells(layerIndex))
+            {
+                var cellLeft = cell.X * ts;
+                var cellTop = cell.Y * ts;
+                var cellRight = cellLeft + ts;
+                var cellBottom = cellTop + ts;
+
+                // Cull the cell against the visible region (same bounds as the layer blits).
+                if (cellLeft >= sourceRight || cellRight <= sourceLeft ||
+                    cellTop >= sourceBottom || cellBottom <= sourceTop)
+                {
+                    continue;
+                }
+
+                var cellDestination = new SKRect(
+                    (float)((cellLeft - originX) * scale),
+                    (float)((cellTop - originY) * scale),
+                    (float)((cellRight - originX) * scale),
+                    (float)((cellBottom - originY) * scale));
+
+                using var tileImage = cell.TileSet.GetTileImage((int)Map.GetAnimatedTileId(cell));
+                var flags = layer.GetTileFlags(cell.X, cell.Y);
+                TileMap.DrawTile(canvas, tileImage, cellDestination, flags, animatedPaint);
+            }
         }
 
         // The player dot (green) and each NPC dot (yellow), drawn as small filled circles at
@@ -967,7 +1005,7 @@ public sealed class GameEngine : IDisposable
 
     /// <summary>
     /// Cancels any in-progress auto-walk by clearing the waypoint queue. The player itself stops
-    /// on the next <see cref="Update"/> (no input and no path &#8594; <see cref="Player.Stop"/>).
+    /// on the next <see cref="Update"/> (no input and no path → <see cref="Player.Stop"/>).
     /// </summary>
     private void CancelAutoWalk()
     {

--- a/src/RPGEngine/Tiled/TileAnimation.cs
+++ b/src/RPGEngine/Tiled/TileAnimation.cs
@@ -1,0 +1,91 @@
+namespace RPGEngine.Tiled;
+
+/// <summary>
+/// A single frame of an animated tile: the local tile ID to show and how long to show it,
+/// mirroring a Tiled <c>&lt;frame&gt;</c> element.
+/// </summary>
+/// <param name="TileId">The local tile ID (within the owning tileset) to display for this frame.</param>
+/// <param name="DurationMs">How long the frame is displayed, in milliseconds.</param>
+internal readonly record struct TileAnimationFrame(uint TileId, int DurationMs);
+
+/// <summary>
+/// The frame sequence of an animated tile, as declared by a Tiled
+/// <c>&lt;tile&gt;&lt;animation&gt;</c> block. The animation loops forever; the current frame is
+/// derived from the engine's animation clock by <see cref="GetFrameTileId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is internal to the Tiled namespace: animation data is parsed from the tileset and
+/// honoured by rendering, but is not exposed through the public API.
+/// </para>
+/// <para>
+/// When the total duration is zero or negative (e.g. every frame declares a zero duration, or
+/// the sequence is empty), the animation is treated as a single static frame: the first frame is
+/// shown forever. Empty sequences never occur in practice (a <see cref="TileAnimation"/> is only
+/// created for a Tiled tile that declares at least one frame), but the defensive fallback keeps
+/// the clock safe for any input.
+/// </para>
+/// </remarks>
+internal sealed class TileAnimation
+{
+    /// <summary>Gets the frames of the animation, in the order they appear in the file.</summary>
+    public IReadOnlyList<TileAnimationFrame> Frames { get; }
+
+    /// <summary>
+    /// Gets the total duration of one full cycle in milliseconds: the sum of every frame's
+    /// <see cref="TileAnimationFrame.DurationMs"/>.
+    /// </summary>
+    public int TotalDurationMs { get; }
+
+    internal TileAnimation(IReadOnlyList<TileAnimationFrame> frames)
+    {
+        Frames = frames ?? throw new ArgumentNullException(nameof(frames));
+
+        var total = 0;
+        foreach (var frame in frames)
+        {
+            total += frame.DurationMs;
+        }
+
+        TotalDurationMs = total;
+    }
+
+    /// <summary>
+    /// Returns the local tile ID of the frame that should be displayed after
+    /// <paramref name="elapsedSeconds"/> of animation time have passed. The clock is looped over
+    /// the full cycle (<c>elapsedMs % TotalDurationMs</c>) and the frames are walked in file
+    /// order, so a frame with duration <c>D</c> is shown from its start offset for exactly
+    /// <c>D</c> milliseconds of each cycle.
+    /// </summary>
+    /// <param name="elapsedSeconds">The animation clock in seconds (monotonic, never reset).</param>
+    /// <returns>The local tile ID of the current frame.</returns>
+    /// <remarks>
+    /// The scan is O(frames); animation sequences in Tiled maps are short, so this is fine for a
+    /// per-frame lookup.
+    /// </remarks>
+    internal uint GetFrameTileId(double elapsedSeconds)
+    {
+        if (TotalDurationMs <= 0 || Frames.Count == 0)
+        {
+            // Defensive: no measurable cycle (or no frames) -> show the first frame forever.
+            return Frames.Count > 0 ? Frames[0].TileId : 0;
+        }
+
+        var elapsedMs = elapsedSeconds * 1000.0;
+        var cycleOffset = elapsedMs % TotalDurationMs;
+
+        var accumulated = 0;
+        foreach (var frame in Frames)
+        {
+            accumulated += frame.DurationMs;
+            if (cycleOffset < accumulated)
+            {
+                return frame.TileId;
+            }
+        }
+
+        // Floating-point edge: when the modulo lands exactly on the total (or the last frame's
+        // boundary), fall back to the final frame of the cycle.
+        return Frames[^1].TileId;
+    }
+}

--- a/src/RPGEngine/Tiled/TileMap.cs
+++ b/src/RPGEngine/Tiled/TileMap.cs
@@ -6,6 +6,17 @@ using SkiaSharp;
 namespace RPGEngine.Tiled;
 
 /// <summary>
+/// A single cell of a tile layer that uses an animated tile. The owning tileset and the local
+/// tile ID are captured at load time so the current frame can be resolved per frame without
+/// re-resolving the owning tileset.
+/// </summary>
+/// <param name="X">The 0-based tile X coordinate of the cell.</param>
+/// <param name="Y">The 0-based tile Y coordinate of the cell.</param>
+/// <param name="TileSet">The tileset that owns the animated tile.</param>
+/// <param name="LocalTileId">The local tile ID (within <paramref name="TileSet"/>) of the animated tile.</param>
+internal readonly record struct AnimatedTileCell(int X, int Y, TileSet TileSet, uint LocalTileId);
+
+/// <summary>
 /// A tile map loaded from a Tiled <c>.tmx</c> file (and its referenced <c>.tsx</c> tilesets).
 /// </summary>
 /// <remarks>
@@ -44,6 +55,13 @@ namespace RPGEngine.Tiled;
 /// renders the below-player pass, then the characters, then the above-player pass so those
 /// tiles appear in front of the player.
 /// </para>
+/// <para>
+/// Animated tiles (a Tiled <c>&lt;tile&gt;&lt;animation&gt;</c> block in a tileset) are parsed
+/// automatically and rendered dynamically: animated cells are excluded from the prerendered
+/// layer images (a static raster would freeze a single frame) and instead drawn per frame by
+/// the render passes, using the map's internal animation clock advanced by
+/// <c>UpdateAnimations</c>. The minimap draws them too, so animated tiles never leave holes.
+/// </para>
 /// </remarks>
 public sealed class TileMap : IDisposable
 {
@@ -55,6 +73,18 @@ public sealed class TileMap : IDisposable
     /// A slot is <see langword="null"/> when the layer was not prerendered (invisible or empty).
     /// </summary>
     private readonly SKImage?[] _prerenderedImages;
+
+    /// <summary>
+    /// The animated cells of each layer, one list per <see cref="Layers"/> entry in file order
+    /// (a layer with no animated cells has an empty list). Populated at load time.
+    /// </summary>
+    private readonly IReadOnlyList<AnimatedTileCell>[] _animatedCells;
+
+    /// <summary>
+    /// The animation clock in seconds. Advanced by <see cref="UpdateAnimations"/> and read by
+    /// <see cref="GetAnimatedTileId"/> to pick each animated cell's current frame.
+    /// </summary>
+    private double _animationClockSeconds;
 
     private bool _disposed;
 
@@ -84,8 +114,11 @@ public sealed class TileMap : IDisposable
         }
 
         // Every visible, non-empty tile layer is rasterized once into an SKImage at load time.
-        // The prerendered images are the source of every later render call.
+        // The prerendered images are the source of every later render call. Animated tiles are
+        // excluded from those images (they would freeze a single frame) and instead recorded
+        // here so the render passes can draw the current frame each frame.
         _prerenderedImages = PrerenderLayers();
+        _animatedCells = DetectAnimatedCells();
     }
 
     /// <summary>Gets the width of the map in tiles.</summary>
@@ -141,6 +174,48 @@ public sealed class TileMap : IDisposable
 
     /// <summary>Gets whether this map has been disposed. Internal for tests.</summary>
     internal bool IsDisposed => _disposed;
+
+    /// <summary>
+    /// Returns the animated cells of the layer at <paramref name="layerIndex"/> (in file order).
+    /// The returned list is owned by this map and must not be modified; a layer without animated
+    /// tiles yields an empty list.
+    /// </summary>
+    /// <remarks>
+    /// Internal so the minimap (<see cref="GameEngine.RenderMinimap"/>) can draw the animated
+    /// cells of each layer after its prerendered image blit, using the same scale/origin mapping.
+    /// </remarks>
+    internal IReadOnlyList<AnimatedTileCell> GetAnimatedCells(int layerIndex) => _animatedCells[layerIndex];
+
+    /// <summary>
+    /// Returns the local tile ID of the frame that <paramref name="cell"/> should currently
+    /// display, based on the map's animation clock.
+    /// </summary>
+    /// <param name="cell">An animated cell recorded by this map.</param>
+    /// <returns>The local tile ID of the current frame within <see cref="AnimatedTileCell.TileSet"/>.</returns>
+    /// <remarks>
+    /// Frame images are resolved per call (the caller obtains the image from the tileset). A
+    /// later optimization could cache the per-tile frame images; resolving them per frame is
+    /// acceptable for the first implementation because animated-tile sequences are short and
+    /// maps typically contain few animated cells.
+    /// </remarks>
+    internal uint GetAnimatedTileId(AnimatedTileCell cell)
+    {
+        if (cell.TileSet.TryGetAnimation(cell.LocalTileId, out var animation))
+        {
+            return animation.GetFrameTileId(_animationClockSeconds);
+        }
+
+        // Defensive: the cell was recorded because the tile was animated, so the lookup should
+        // always succeed; fall back to the tile itself.
+        return cell.LocalTileId;
+    }
+
+    /// <summary>
+    /// Advances the animation clock by <paramref name="dt"/> seconds. The engine calls this once
+    /// per <c>Update</c>, so animated tiles progress with game time.
+    /// </summary>
+    /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
+    internal void UpdateAnimations(double dt) => _animationClockSeconds += dt;
 
     /// <summary>
     /// Returns the map property named <paramref name="name"/> using a case-sensitive comparison,
@@ -440,10 +515,12 @@ public sealed class TileMap : IDisposable
         var visible = new SKRect(left, top, right, bottom);
 
         using var paint = new SKPaint { IsAntialias = false };
+        using var animatedPaint = new SKPaint { IsAntialias = false };
 
         for (var layerIndex = 0; layerIndex < Layers.Count; layerIndex++)
         {
-            if (Layers[layerIndex].AbovePlayer != abovePlayerOnly)
+            var layer = Layers[layerIndex];
+            if (layer.AbovePlayer != abovePlayerOnly)
             {
                 continue;
             }
@@ -457,6 +534,29 @@ public sealed class TileMap : IDisposable
             // The source and destination rects are the same world-pixel rect: the visible part
             // of the prerendered image is blitted in place, which preserves viewport culling.
             canvas.DrawImage(image, visible, visible, paint);
+
+            // Draw the layer's animated cells on top of its own prerendered image (and below the
+            // layers above, because we stay inside this per-layer loop). Animated cells were
+            // excluded from the prerender, so they are not frozen statically; the current frame
+            // is drawn with the same flip transform and layer opacity as static tiles.
+            animatedPaint.Color = SKColors.White.WithAlpha((byte)Math.Round(layer.Opacity * 255f));
+            foreach (var cell in _animatedCells[layerIndex])
+            {
+                var dest = new SKRect(
+                    cell.X * TileWidth,
+                    cell.Y * TileHeight,
+                    (cell.X + 1) * TileWidth,
+                    (cell.Y + 1) * TileHeight);
+
+                if (!dest.IntersectsWith(visible))
+                {
+                    continue;
+                }
+
+                using var tileImage = cell.TileSet.GetTileImage((int)GetAnimatedTileId(cell));
+                var flags = layer.GetTileFlags(cell.X, cell.Y);
+                DrawTile(canvas, tileImage, dest, flags, animatedPaint);
+            }
         }
     }
 
@@ -517,8 +617,16 @@ public sealed class TileMap : IDisposable
                     continue;
                 }
 
-                var flags = layer.GetTileFlags(x, y);
                 var localTileId = (int)(gid - tileSet.FirstGid);
+                if (tileSet.TryGetAnimation((uint)localTileId, out _))
+                {
+                    // Animated tiles are never baked into the prerendered layer image: a static
+                    // raster would freeze a single frame. They are drawn dynamically per frame by
+                    // DrawLayerImages, so the cell is left transparent here.
+                    continue;
+                }
+
+                var flags = layer.GetTileFlags(x, y);
                 using var tileImage = tileSet.GetTileImage(localTileId);
 
                 var dest = new SKRect(
@@ -567,7 +675,60 @@ public sealed class TileMap : IDisposable
         return false;
     }
 
-    private static void DrawTile(SKCanvas canvas, SKImage image, SKRect dest, TileFlags flags, SKPaint paint)
+    /// <summary>
+    /// Detects every animated cell of every tile layer at load time: for each non-empty cell the
+    /// owning tileset and local tile ID are resolved with the same logic as
+    /// <see cref="PrerenderLayer"/>, and cells whose tile declares an animation are recorded so
+    /// the render passes can draw them dynamically (see <see cref="DrawLayerImages"/> and the
+    /// minimap accessors). Layers without animated cells get an empty list.
+    /// </summary>
+    private IReadOnlyList<AnimatedTileCell>[] DetectAnimatedCells()
+    {
+        var perLayer = new IReadOnlyList<AnimatedTileCell>[Layers.Count];
+
+        for (var layerIndex = 0; layerIndex < Layers.Count; layerIndex++)
+        {
+            var layer = Layers[layerIndex];
+            var cells = new List<AnimatedTileCell>();
+
+            for (var y = 0; y < Height; y++)
+            {
+                for (var x = 0; x < Width; x++)
+                {
+                    var gid = layer.GetTileId(x, y);
+                    if (gid == 0)
+                    {
+                        continue;
+                    }
+
+                    var tileSet = ResolveTileSet(gid);
+                    if (tileSet is null)
+                    {
+                        // A GID that no tileset covers; ignore defensively (malformed map).
+                        continue;
+                    }
+
+                    var localTileId = (uint)(gid - tileSet.FirstGid);
+                    if (tileSet.TryGetAnimation(localTileId, out _))
+                    {
+                        cells.Add(new AnimatedTileCell(x, y, tileSet, localTileId));
+                    }
+                }
+            }
+
+            perLayer[layerIndex] = cells;
+        }
+
+        return perLayer;
+    }
+
+    /// <summary>
+    /// Draws <paramref name="image"/> into <paramref name="dest"/> applying the Tiled flip/rotate
+    /// transforms described by <paramref name="flags"/> and the alpha of <paramref name="paint"/>.
+    /// The transform matches Tiled's own renderer (diagonal flip first, then the horizontal and
+    /// vertical flips), so flipped animated tiles match flipped static tiles.
+    /// </summary>
+    internal static void DrawTile(SKCanvas canvas, SKImage image, SKRect dest, TileFlags flags, SKPaint paint)
     {
         var horizontallyFlipped = (flags & TileFlags.FlippedHorizontally) != 0;
         var verticallyFlipped = (flags & TileFlags.FlippedVertically) != 0;

--- a/src/RPGEngine/Tiled/TileSet.cs
+++ b/src/RPGEngine/Tiled/TileSet.cs
@@ -23,6 +23,13 @@ namespace RPGEngine.Tiled;
 /// single tile; each call produces an independent image that the caller owns and may
 /// dispose freely.
 /// </para>
+/// <para>
+/// Per-tile animations declared by the tileset (a Tiled <c>&lt;tile&gt;&lt;animation&gt;</c>
+/// block) are parsed at load time and honoured by rendering: every layer cell that uses an
+/// animated tile plays its frame sequence (see <see cref="TileAnimation"/> and
+/// <c>TileMap.UpdateAnimations</c>). The animation data itself is internal; it is never
+/// exposed through the public API.
+/// </para>
 /// </remarks>
 public sealed class TileSet
 {
@@ -31,6 +38,7 @@ public sealed class TileSet
     private readonly int _columns;
     private readonly int _spacing;
     private readonly int _margin;
+    private readonly IReadOnlyDictionary<uint, TileAnimation> _animations;
 
     /// <summary>Gets the name of the tileset.</summary>
     public string Name { get; }
@@ -57,7 +65,8 @@ public sealed class TileSet
         int tileCount,
         int columns,
         int spacing = 0,
-        int margin = 0)
+        int margin = 0,
+        IReadOnlyDictionary<uint, TileAnimation>? animations = null)
     {
         Name = name;
         FirstGid = firstGid;
@@ -68,7 +77,22 @@ public sealed class TileSet
         _columns = columns;
         _spacing = spacing;
         _margin = margin;
+        _animations = animations is null
+            ? new Dictionary<uint, TileAnimation>()
+            : new Dictionary<uint, TileAnimation>(animations);
     }
+
+    /// <summary>
+    /// Looks up the animation declared for the tile with the given local tile ID.
+    /// </summary>
+    /// <param name="localTileId">The 0-based local tile ID within this tileset.</param>
+    /// <param name="animation">The tile's <see cref="TileAnimation"/> when one is declared.</param>
+    /// <returns>
+    /// <see langword="true"/> when the tile declares an animation and <paramref name="animation"/>
+    /// receives it; otherwise <see langword="false"/>.
+    /// </returns>
+    internal bool TryGetAnimation(uint localTileId, out TileAnimation animation)
+        => _animations.TryGetValue(localTileId, out animation!);
 
     /// <summary>
     /// Loads the Tiled tileset (<c>.tsx</c>) at <paramref name="path"/> and decodes its
@@ -277,7 +301,8 @@ public sealed class TileSet
             tileset.TileCount,
             tileset.Columns,
             tileset.Spacing,
-            tileset.Margin);
+            tileset.Margin,
+            ParseAnimations(tileset));
     }
 
     /// <summary>
@@ -333,7 +358,36 @@ public sealed class TileSet
             tileset.TileCount,
             tileset.Columns,
             tileset.Spacing,
-            tileset.Margin);
+            tileset.Margin,
+            ParseAnimations(tileset));
+    }
+
+    /// <summary>
+    /// Builds the per-tile animation map of a DotTiled <see cref="Tileset"/>: every tile that
+    /// declares an <c>&lt;animation&gt;</c> (more than one frame entry) is keyed by its local
+    /// tile ID and mapped to a <see cref="TileAnimation"/> built from its frames, in file order.
+    /// </summary>
+    private static IReadOnlyDictionary<uint, TileAnimation> ParseAnimations(Tileset tileset)
+    {
+        var animations = new Dictionary<uint, TileAnimation>();
+
+        foreach (var tile in tileset.Tiles)
+        {
+            if (tile.Animation.Count == 0)
+            {
+                continue;
+            }
+
+            var frames = new List<TileAnimationFrame>(tile.Animation.Count);
+            foreach (var frame in tile.Animation)
+            {
+                frames.Add(new TileAnimationFrame(frame.TileID, frame.Duration));
+            }
+
+            animations[tile.ID] = new TileAnimation(frames);
+        }
+
+        return animations;
     }
 
     private static Tileset ParseTilesetContent(string content)

--- a/tests/RPGEngine.Tests/GameEngineMinimapTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineMinimapTests.cs
@@ -243,6 +243,49 @@ public partial class GameEngineTests
         Assert.Equal(SKColors.Black, bitmap.GetPixel(0, 0)); // the margin is black
     }
 
+    // ---------------------------------------------------------------------
+    // Story 57: animated tiles on the minimap. RenderMinimap draws each layer's
+    // animated cells after its prerendered blit (animated cells are excluded from
+    // the prerender), so the minimap is not left with holes where animated tiles are.
+    // ---------------------------------------------------------------------
+
+    /// <summary>Verifies the minimap shows the animated tile at its current frame, and that advancing the clock changes the minimap pixel.</summary>
+    [Fact]
+    public void RenderMinimap_ShowsAnimatedTile_AtCurrentFrame()
+    {
+        // A 2x2 map with one animated tile at (0,0): frames 0/1/2 are red/green/blue solid
+        // colours with 100 ms each (cycle 300 ms). At t = 0 the minimap shows frame 0 (red);
+        // after 150 ms the clock is in frame 1 (green).
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { new TileLayerSpec("ground", new uint[] { 1, 0, 0, 0 }) },
+            tileColors: new[] { SKColors.Red, SKColors.Green, SKColors.Blue },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [0] = new List<(uint FrameTileId, int DurationMs)> { (0, 100), (1, 100), (2, 100) },
+            });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        // Place the player away from the animated cell so the green player dot never overlaps the
+        // sampled pixel. A 96x96 map on a 96x96 canvas: scale 1, origin (0,0), so the animated
+        // cell (0,0) spans the top-left 48x48 and its centre is (24,24).
+        engine.Player.Position = new Position(1.5, 1.5);
+
+        using (var bitmap = RenderMinimap(engine, 96, 96, zoomLevel: 1.0))
+        {
+            Assert.Equal(SKColors.Red, bitmap.GetPixel(24, 24));
+        }
+
+        // Advancing the clock (engine.Update calls Map.UpdateAnimations) changes the minimap pixel
+        // to the next frame.
+        engine.Update(0.15);
+        using (var bitmap = RenderMinimap(engine, 96, 96, zoomLevel: 1.0))
+        {
+            Assert.Equal(SKColors.Green, bitmap.GetPixel(24, 24));
+        }
+    }
+
     /// <summary>
     /// Verifies RenderMinimap is pure: rendering a minimap on a separate surface does not change
     /// the output of the main Render nor the engine state (regression guard for the minimap work).

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -605,6 +605,52 @@ public partial class GameEngineTests
         }
     }
 
+    /// <summary>Verifies an animated tile on an above_player layer renders above the player, and that its frame advances with the engine clock (story 57).</summary>
+    [Fact]
+    public void Render_AbovePlayerLayer_AnimatedTile_DrawsOverPlayerAndAdvances()
+    {
+        const int canvasSize = 96; // a 2×2 map exactly fills the canvas, so the origin is (0,0)
+        var ground = FilledLayer(2, 2); // all red (GID 1)
+        var colors = new[] { SKColors.Red, SKColors.Green, SKColors.Blue };
+
+        // The above layer places an animated tile at (0,0): GID 2 (local tile 1) animates
+        // between tile 1 (green) and tile 2 (blue), 100 ms each.
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[]
+            {
+                ground,
+                new TileLayerSpec(
+                    "above",
+                    new uint[] { 2, 0, 0, 0 },
+                    Properties: new[] { new FixtureProperty("above_player", "bool", "true") }),
+            },
+            tileColors: colors,
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [1] = new List<(uint FrameTileId, int DurationMs)> { (1, 100), (2, 100) },
+            });
+
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 1.0); // sprite fills the 48×48 tile at (0,0)
+
+        // At t = 0 the animated tile shows frame 0 (green) above the player.
+        using (var bitmap = Render(engine, canvasSize, canvasSize))
+        {
+            Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(24, 24));
+        }
+
+        // Advancing the engine clock moves the animated tile to frame 1 (blue), still above the
+        // player (the player does not move: no input, no auto-walk).
+        engine.Update(0.15);
+        using (var bitmap = Render(engine, canvasSize, canvasSize))
+        {
+            Assert.Equal(new SKColor(0, 0, 255, 255), bitmap.GetPixel(24, 24));
+        }
+    }
+
     // ---------------------------------------------------------------------
     // Story 37 acceptance 4: SurfaceToWorld / WorldToSurface are camera-aware
     // and inverses within floating-point tolerance. With no map the origin is

--- a/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
+++ b/tests/RPGEngine.Tests/Tiled/TileMapTests.cs
@@ -1007,6 +1007,262 @@ public class TileMapTests
         Assert.InRange(alpha, 96, 160);
     }
 
+    // ---------------------------------------------------------------------
+    // Story 57: animated tiles (Tiled <tile><animation>). The tileset's per-tile
+    // animations are parsed at load time (TileSet.TryGetAnimation), animated cells are
+    // detected per layer at build time (TileMap.GetAnimatedCells), excluded from the
+    // prerendered layer images, and drawn dynamically by the render passes using the
+    // map's animation clock (TileMap.UpdateAnimations / GetAnimatedTileId).
+    // ---------------------------------------------------------------------
+
+    /// <summary>Verifies a TSX animation is parsed: frames keep file order and durations, TotalDurationMs is the sum, and tiles without an animation report false.</summary>
+    [Fact]
+    public void TileSet_ParsesAnimations_FromTsx()
+    {
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { Ground },
+            tileColors: new[] { SKColors.Red, SKColors.Green, SKColors.Blue },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [0] = new List<(uint FrameTileId, int DurationMs)> { (0, 100), (1, 200), (2, 100) },
+            });
+
+        var tileSet = TileSet.Load(fixture.TilesetPath);
+
+        Assert.True(tileSet.TryGetAnimation(0, out var animation));
+        Assert.Equal(3, animation.Frames.Count);
+        Assert.Equal(new TileAnimationFrame(0, 100), animation.Frames[0]);
+        Assert.Equal(new TileAnimationFrame(1, 200), animation.Frames[1]);
+        Assert.Equal(new TileAnimationFrame(2, 100), animation.Frames[2]);
+        Assert.Equal(400, animation.TotalDurationMs);
+
+        // Tiles without an animation report false.
+        Assert.False(tileSet.TryGetAnimation(1, out _));
+        Assert.False(tileSet.TryGetAnimation(2, out _));
+    }
+
+    /// <summary>Verifies TileMap.Load also exposes the animation: animated cells are detected per layer and the current frame resolves through the map clock.</summary>
+    [Fact]
+    public void TileMap_Load_DetectsAnimatedCells_FromReferencedTileset()
+    {
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { new TileLayerSpec("ground", new uint[] { 1, 0, 0, 0 }), new TileLayerSpec("decor", new uint[4]) },
+            tileColors: new[] { SKColors.Red, SKColors.Green },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [0] = new List<(uint FrameTileId, int DurationMs)> { (0, 100), (1, 100) },
+            });
+
+        var map = TileMap.Load(fixture.MapPath);
+
+        var cells = map.GetAnimatedCells(0);
+        Assert.Single(cells);
+        Assert.Equal(0, cells[0].X);
+        Assert.Equal(0, cells[0].Y);
+        Assert.Equal(0u, cells[0].LocalTileId);
+
+        // At t = 0 the current frame is the first frame (the tile itself).
+        Assert.Equal(0u, map.GetAnimatedTileId(cells[0]));
+
+        // Layers without animated tiles (e.g. the empty decor layer) report no cells.
+        Assert.Empty(map.GetAnimatedCells(1));
+    }
+
+    /// <summary>Verifies a tile that declares only properties (no animation) is not treated as animated.</summary>
+    [Fact]
+    public void TileSet_TilesWithOnlyProperties_AreNotAnimated()
+    {
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { Ground },
+            tileColors: new[] { SKColors.Red, SKColors.Green });
+
+        // Overwrite the generated TSX with one that declares a properties-only tile (no
+        // <animation>) alongside the plain image tiles.
+        var tsx = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <tileset version="1.10" tiledversion="1.10.2" name="test_tiles" tilewidth="48" tileheight="48" tilecount="2" columns="2">
+              <image source="tiles.png" width="96" height="48"/>
+              <tile id="0">
+                <properties>
+                  <property name="solid" type="bool" value="true"/>
+                </properties>
+              </tile>
+            </tileset>
+            """;
+        File.WriteAllText(fixture.TilesetPath, tsx);
+
+        var tileSet = TileSet.Load(fixture.TilesetPath);
+
+        // The properties-only tile is not animated; the other tile is not animated either.
+        Assert.False(tileSet.TryGetAnimation(0, out _));
+        Assert.False(tileSet.TryGetAnimation(1, out _));
+    }
+
+    /// <summary>Verifies TileAnimation.GetFrameTileId loops the clock over the cycle and falls back to the first frame for a zero-duration sequence.</summary>
+    [Fact]
+    public void TileAnimation_GetFrameTileId_LoopsAndHandlesZeroDuration()
+    {
+        var animation = new TileAnimation(new[]
+        {
+            new TileAnimationFrame(0, 100),
+            new TileAnimationFrame(1, 200),
+            new TileAnimationFrame(2, 100),
+        });
+
+        Assert.Equal(400, animation.TotalDurationMs);
+        Assert.Equal(0u, animation.GetFrameTileId(0.0));    // start of the cycle
+        Assert.Equal(0u, animation.GetFrameTileId(0.099));  // still frame 0 (0..99 ms)
+        Assert.Equal(1u, animation.GetFrameTileId(0.10));   // frame 1 starts at 100 ms
+        Assert.Equal(1u, animation.GetFrameTileId(0.299));  // frame 1 lasts until 299 ms
+        Assert.Equal(2u, animation.GetFrameTileId(0.30));   // frame 2 starts at 300 ms
+        Assert.Equal(0u, animation.GetFrameTileId(0.40));   // 400 ms wraps back to frame 0
+        Assert.Equal(1u, animation.GetFrameTileId(0.50));   // 500 ms -> 100 ms into the cycle
+
+        // A zero total duration (e.g. every frame has 0 ms) shows the first frame forever.
+        var zero = new TileAnimation(new[] { new TileAnimationFrame(7, 0) });
+        Assert.Equal(7u, zero.GetFrameTileId(123.0));
+    }
+
+    /// <summary>Verifies the main render advances with the clock: frame 0 at t = 0, frame 1 after 150 ms, and a wrap back to frame 0 after a full 400 ms cycle.</summary>
+    [Fact]
+    public void Draw_AnimatedTile_AdvancesFramesWithClock()
+    {
+        // Three distinct solid-colour frames with durations 100/200/100 ms (cycle 400 ms): at
+        // 150 ms the animation is on frame 1, and at 400 ms total it has wrapped back to frame 0.
+        using var fixture = new TiledTestFixture(
+            1,
+            1,
+            new[] { new TileLayerSpec("ground", new uint[] { 1 }) },
+            tileColors: new[] { SKColors.Red, SKColors.Green, SKColors.Blue },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [0] = new List<(uint FrameTileId, int DurationMs)> { (0, 100), (1, 200), (2, 100) },
+            });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // t = 0: frame 0 (red).
+        using (var bitmap = RenderMap(map))
+        {
+            Assert.Equal(new SKColor(255, 0, 0, 255), bitmap.GetPixel(24, 24));
+        }
+
+        // After 150 ms the clock is in frame 1 (green).
+        map.UpdateAnimations(0.15);
+        using (var bitmap = RenderMap(map))
+        {
+            Assert.Equal(new SKColor(0, 128, 0, 255), bitmap.GetPixel(24, 24));
+        }
+
+        // After 250 ms more (400 ms total) the cycle wraps back to frame 0 (red).
+        map.UpdateAnimations(0.25);
+        using (var bitmap = RenderMap(map))
+        {
+            Assert.Equal(new SKColor(255, 0, 0, 255), bitmap.GetPixel(24, 24));
+        }
+    }
+
+    /// <summary>Verifies animated cells are excluded from the prerendered layer image (transparent hole) yet visible in the rendered frame.</summary>
+    [Fact]
+    public void Prerender_ExcludesAnimatedCells_ButRenderedFrameDrawsThem()
+    {
+        using var fixture = new TiledTestFixture(
+            1,
+            1,
+            new[] { new TileLayerSpec("ground", new uint[] { 1 }) },
+            tileColors: new[] { SKColors.Red, SKColors.Green },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [0] = new List<(uint FrameTileId, int DurationMs)> { (0, 100), (1, 100) },
+            });
+        var map = TileMap.Load(fixture.MapPath);
+
+        // The prerendered layer image leaves the animated cell transparent.
+        using (var prerendered = ImageToBitmap(map.PrerenderedLayerImages[0]!))
+        {
+            Assert.Equal(0, prerendered.GetPixel(24, 24).Alpha);
+        }
+
+        // The rendered frame draws the animation dynamically (frame 0 at t = 0).
+        using (var bitmap = RenderMap(map))
+        {
+            Assert.Equal(new SKColor(255, 0, 0, 255), bitmap.GetPixel(24, 24));
+        }
+    }
+
+    /// <summary>Verifies an animated cell with a horizontal flip and a layer opacity below 1 renders the current frame flipped and faded.</summary>
+    [Fact]
+    public void Draw_AnimatedTile_AppliesFlipAndOpacity()
+    {
+        // Tile 0 is an asymmetric marker (red marker at 36..39, 12..15) and tile 1 is a solid
+        // green fill. The animated tile at (0,0) carries the horizontal flip flag, and the layer
+        // has opacity 0.5, mirroring the static-tile flip/opacity tests.
+        using var fixture = new TiledTestFixture(
+            1,
+            1,
+            new[] { new TileLayerSpec("ground", new uint[] { 0x80000001u }, Opacity: 0.5f) },
+            tileColors: new[] { SKColors.Red, SKColors.Green },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [0] = new List<(uint FrameTileId, int DurationMs)> { (0, 100), (1, 100) },
+            },
+            tilePatterns: new[] { TilePattern.Marker, TilePattern.Solid });
+        var map = TileMap.Load(fixture.MapPath);
+
+        using var bitmap = RenderMap(map);
+
+        // Frame 0 is the marker tile; flipped horizontally the marker moves to (8..11, 12..15)
+        // and the layer opacity fades the whole animated tile.
+        Assert.InRange(bitmap.GetPixel(9, 13).Alpha, 96, 160);  // flipped marker is faded
+        Assert.Equal(0, bitmap.GetPixel(37, 13).Alpha);         // the unflipped marker position is empty
+    }
+
+    /// <summary>Verifies an animated tile on an above_player layer renders above the player (the above-player ordering pattern with an animated tile).</summary>
+    [Fact]
+    public void Draw_AbovePlayerLayer_AnimatedTile_DrawsOverPlayer()
+    {
+        // ground = all red (GID 1), above = green animated tile (GID 2 -> local tile 1) at (0,0).
+        var ground = new TileLayerSpec("ground", new uint[] { 1, 1, 1, 1 });
+        var above = new TileLayerSpec(
+            "above",
+            new uint[] { 2, 0, 0, 0 },
+            Properties: new[] { new FixtureProperty("above_player", "bool", "true") });
+        using var fixture = new TiledTestFixture(
+            2,
+            2,
+            new[] { ground, above },
+            tileColors: new[] { SKColors.Red, SKColors.Green, SKColors.Blue },
+            animations: new Dictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>
+            {
+                [1] = new List<(uint FrameTileId, int DurationMs)> { (1, 100), (2, 100) },
+            });
+        var map = TileMap.Load(fixture.MapPath);
+
+        using var belowOnly = RenderMap(map, draw: map.Draw);
+        Assert.Equal(new SKColor(255, 0, 0, 255), belowOnly.GetPixel(24, 24)); // ground (red)
+
+        using var aboveOnly = RenderMap(map, draw: map.DrawAbovePlayer);
+        Assert.Equal(new SKColor(0, 128, 0, 255), aboveOnly.GetPixel(24, 24)); // animated frame 0 (green)
+    }
+
+    /// <summary>Converts an <see cref="SKImage"/> into a bitmap so tests can assert individual pixels (e.g. the prerendered layer images).</summary>
+    private static SKBitmap ImageToBitmap(SKImage image)
+    {
+        var bitmap = new SKBitmap(image.Width, image.Height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawImage(image, new SKPoint(0, 0));
+        }
+
+        return bitmap;
+    }
+
     /// <summary>
     /// Builds a fetcher that serves the fixture's map, tileset and image bytes under a
     /// fake HTTP base URI, simulating the WebAssembly/HTTP asset loading scenario.

--- a/tests/RPGEngine.Tests/Tiled/TiledTestFixture.cs
+++ b/tests/RPGEngine.Tests/Tiled/TiledTestFixture.cs
@@ -144,7 +144,9 @@ internal sealed class TiledTestFixture : IDisposable
         TilePattern pattern = TilePattern.Solid,
         IReadOnlyList<SKColor>? tileColors = null,
         IReadOnlyList<FixtureProperty>? mapProperties = null,
-        IReadOnlyList<ObjectLayerSpec>? objectLayers = null)
+        IReadOnlyList<ObjectLayerSpec>? objectLayers = null,
+        IReadOnlyDictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>? animations = null,
+        IReadOnlyList<TilePattern>? tilePatterns = null)
     {
         Width = width;
         Height = height;
@@ -155,8 +157,8 @@ internal sealed class TiledTestFixture : IDisposable
         TilesetPath = Path.Combine(_root, "tiles.tsx");
         MapPath = Path.Combine(_root, "map.tmx");
 
-        CreateTileImage(ImagePath, pattern, tileColors);
-        File.WriteAllText(TilesetPath, TilesetXml(tileColors));
+        CreateTileImage(ImagePath, pattern, tileColors, tilePatterns);
+        File.WriteAllText(TilesetPath, TilesetXml(tileColors, animations));
         File.WriteAllText(MapPath, MapXml(layers, mapProperties, objectLayers));
     }
 
@@ -165,8 +167,9 @@ internal sealed class TiledTestFixture : IDisposable
         IReadOnlyList<TileLayerSpec> layers,
         TilePattern pattern = TilePattern.Solid,
         IReadOnlyList<FixtureProperty>? mapProperties = null,
-        IReadOnlyList<ObjectLayerSpec>? objectLayers = null)
-        => new(2, 2, layers, pattern, mapProperties: mapProperties, objectLayers: objectLayers);
+        IReadOnlyList<ObjectLayerSpec>? objectLayers = null,
+        IReadOnlyDictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>? animations = null)
+        => new(2, 2, layers, pattern, mapProperties: mapProperties, objectLayers: objectLayers, animations: animations);
 
     public void Dispose()
     {
@@ -180,11 +183,18 @@ internal sealed class TiledTestFixture : IDisposable
         }
     }
 
-    private static void CreateTileImage(string path, TilePattern pattern, IReadOnlyList<SKColor>? tileColors)
+    private static void CreateTileImage(
+        string path,
+        TilePattern pattern,
+        IReadOnlyList<SKColor>? tileColors,
+        IReadOnlyList<TilePattern>? tilePatterns = null)
     {
         if (tileColors is { Count: > 0 })
         {
-            // Multi-tile solid-color image: one 48×48 tile per color, laid out in a single row.
+            // Multi-tile image: one 48×48 tile per color, laid out in a single row. By default
+            // each tile is solid in its color; passing tilePatterns draws the marker pattern in
+            // the selected tiles instead (the marker is not symmetric under any flip, so flips
+            // are pixel-verifiable on animated tiles too).
             using var bitmap = new SKBitmap(TileSize * tileColors.Count, TileSize);
             using (var canvas = new SKCanvas(bitmap))
             {
@@ -193,7 +203,17 @@ internal sealed class TiledTestFixture : IDisposable
                 for (var i = 0; i < tileColors.Count; i++)
                 {
                     paint.Color = tileColors[i];
-                    canvas.DrawRect(new SKRect(i * TileSize, 0, (i + 1) * TileSize, TileSize), paint);
+                    if (tilePatterns is { Count: > 0 } && i < tilePatterns.Count && tilePatterns[i] == TilePattern.Marker)
+                    {
+                        // Marker in the top-right area of the tile (mirrors the single-tile
+                        // marker at 36..39, 12..15). Flipped positions are the same as the
+                        // single-tile marker test: horizontal → 8..11, 12..15.
+                        canvas.DrawRect(new SKRect((i * TileSize) + 36, 12, (i * TileSize) + 40, 16), paint);
+                    }
+                    else
+                    {
+                        canvas.DrawRect(new SKRect(i * TileSize, 0, (i + 1) * TileSize, TileSize), paint);
+                    }
                 }
             }
 
@@ -231,17 +251,37 @@ internal sealed class TiledTestFixture : IDisposable
         data.SaveTo(stream);
     }
 
-    private string TilesetXml(IReadOnlyList<SKColor>? tileColors)
+    private string TilesetXml(
+        IReadOnlyList<SKColor>? tileColors,
+        IReadOnlyDictionary<uint, IReadOnlyList<(uint FrameTileId, int DurationMs)>>? animations)
     {
         var tileCount = tileColors?.Count ?? 1;
         var columns = tileCount;
         var imageWidth = TileSize * columns;
-        return $"""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <tileset version="1.10" tiledversion="1.10.2" name="test_tiles" tilewidth="{TileSize}" tileheight="{TileSize}" tilecount="{tileCount}" columns="{columns}">
-              <image source="tiles.png" width="{imageWidth}" height="{TileSize}"/>
-            </tileset>
-            """;
+        var sb = new StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.AppendLine(
+            $"""<tileset version="1.10" tiledversion="1.10.2" name="test_tiles" tilewidth="{TileSize}" tileheight="{TileSize}" tilecount="{tileCount}" columns="{columns}">""");
+        sb.AppendLine($"""  <image source="tiles.png" width="{imageWidth}" height="{TileSize}"/>""");
+
+        if (animations is { Count: > 0 })
+        {
+            foreach (var (tileId, frames) in animations)
+            {
+                sb.AppendLine($"""  <tile id="{tileId}">""");
+                sb.AppendLine("    <animation>");
+                foreach (var (frameTileId, durationMs) in frames)
+                {
+                    sb.AppendLine($"""      <frame tileid="{frameTileId}" duration="{durationMs}"/>""");
+                }
+
+                sb.AppendLine("    </animation>");
+                sb.AppendLine("  </tile>");
+            }
+        }
+
+        sb.AppendLine("</tileset>");
+        return sb.ToString();
     }
 
     private string MapXml(


### PR DESCRIPTION
Closes #57

## Summary

Implements animated tiles as defined by the Tiled format: a tileset tile may declare a `<tile><animation>` block with `<frame tileid="…" duration="…"/>` entries (local tile IDs, durations in milliseconds), and every layer cell using that tile plays the frame sequence, looping forever. Animated tiles render on the main map and on the minimap, and coexist with the per-layer prerendering (animated cells are excluded from the static prerendered images and drawn per frame).

### Source changes
- **`RPGEngine.Tiled.TileAnimation`** (new, internal): `TileAnimationFrame(uint TileId, int DurationMs)` record struct and `TileAnimation` class exposing `Frames` (file order), `TotalDurationMs` (sum; defensive 0 → first frame only) and `GetFrameTileId(double elapsedSeconds)` which loops the clock over the cycle (`elapsedMs % TotalDurationMs`) and walks the frames.
- **`TileSet`**: parses per-tile animations from `DotTiled.Tileset.Tiles` on both the sync and async load paths (`ParseAnimations`) and exposes `internal bool TryGetAnimation(uint localTileId, out TileAnimation animation)`. No public API change.
- **`TileMap`**: adds `internal readonly record struct AnimatedTileCell(int X, int Y, TileSet TileSet, uint LocalTileId)`, detects animated cells per layer at build time (same `ResolveTileSet` logic as `PrerenderLayer`), skips animated cells in `PrerenderLayer` (transparent in the prerendered image), adds `internal void UpdateAnimations(double dt)` (animation clock) and `internal uint GetAnimatedTileId(AnimatedTileCell)` plus `GetAnimatedCells(int layerIndex)`. `DrawLayerImages` (both passes) blits each layer's prerendered image and then draws that layer's visible animated cells with the current frame's tile image, the layer's flip flags and the layer's opacity, reusing the existing `DrawTile` transform (made `internal` so the minimap can reuse it). Per-frame image resolution is documented as a perf note for a later caching optimization.
- **`GameEngine`**: `Update(double dt)` calls `Map?.UpdateAnimations(dt)` once per frame; `RenderMinimap` draws each layer's animated cells after its prerendered blit using the same scale/origin mapping as the layer blits (with flip flags and opacity).

### Tests
- **`TiledTestFixture`**: the TSX writer gained an `animations` parameter (local tile ID → list of `(frameTileId, durationMs)`) emitted as `<tile><animation>…</animation></tile>`, plus an optional per-tile `tilePatterns` list so the existing multi-color `tileColors` mode can produce asymmetric marker frames for flip assertions.
- New acceptance tests cover: parsing (frames/durations/`TotalDurationMs` via both `TileSet.Load` and `TileMap.Load`; properties-only tiles unaffected), render advance with the clock (frame 0 → 150 ms → frame 1 → 400 ms → frame 0), prerender exclusion (transparent hole in the prerendered layer yet visible dynamically), flip + opacity, `above_player` ordering, and the minimap showing the current frame (and changing when the clock advances).

### Documentation
- `docs/Architecture.md`: new "Animated tiles" section (Tiled `<animation>` format, internal clock via `TileMap.UpdateAnimations`, exclusion from prerendered images and per-frame drawing with flip flags/opacity, minimap support, perf note).
- `docs/api/TileMap.md` and `docs/api/TileSet.md`: remarks documenting automatic parsing/rendering of animated tiles.

## Verification
- `dotnet build -c Release`: 0 warnings / 0 errors (CS1591 enforced).
- Targeted suite `dotnet test tests/RPGEngine.Tests -c Release --filter "FullyQualifiedName~TileMapTests|FullyQualifiedName~GameEngineTests|FullyQualifiedName~SampleSceneTests"`: all new and existing TileMap/SampleScene/minimap/render tests pass; the only failures are 13 pre-existing collision/floating-point tests that also fail on `main` in this environment (verified by running the same suite on `main`).