### PR TITLE
Story 55: Player.OnMove fires when a collision stops the player (diagonal all-or-nothing)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,9 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > a click mid-walk replaces the destination. `Player.OnMove` fires on every movement-state
 > transition (start / stop / direction change) with the current facing direction — including a
 > stop caused by a collision while a movement key is held (the engine reports the blocked move,
-> so `OnMove` fires with `IsMoving = false` even against a wall). See
+> so `OnMove` fires with `IsMoving = false` even against a wall). Diagonal key movement is
+> all-or-nothing (no wall-sliding): a diagonal into a wall where only one axis is free stops the
+> player entirely and reports the collision stop the same way. See
 > `docs/api/GameEngine.md` and `docs/api/Player.md`.
 
 ### Reading order

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -103,7 +103,10 @@ When the player **stops because of a collision** (the engine reports a fully blo
 a solid tile or the map edge), `OnMove` fires with `IsMoving = false` **even while the movement
 key is still held** — the stop is reported exactly once, and holding the key against the same
 wall does not raise the event again. The reported direction is the direction the player tried to
-move in (the player turns to face the wall).
+move in (the player turns to face the wall). Diagonal movement is **all-or-nothing** (no
+wall-sliding): a diagonal is applied only when both axes are free, so a diagonal into a wall
+where only one axis is free stops the player entirely and fires `OnMove` with `IsMoving = false`
+once — the free axis never slides while reporting movement.
 
 ```csharp
 var player = new Player();

--- a/src/RPGEngine/Core/MovementCollisionResolver.cs
+++ b/src/RPGEngine/Core/MovementCollisionResolver.cs
@@ -3,13 +3,18 @@ using RPGEngine.Tiled;
 namespace RPGEngine;
 
 /// <summary>
-/// Resolves a character's displacement against the map's solid tiles with
-/// <em>per-axis slide-to-boundary clamping</em>: for each axis the full requested
-/// displacement is applied when the resulting collision footprint (the fixed 1×1 tile
-/// lower-body box of the player, see <see cref="GameEngine.PlayerFootprintOverlapsSolid"/>) is
-/// clear; otherwise the axis is clamped to the <em>closest legal position</em> on that axis, so
-/// the leading edge of the footprint stops exactly at the near edge of the first blocking solid
-/// tile (or at the map edge, which <see cref="TileMap.IsSolid"/> treats as solid).
+/// Resolves a character's displacement against the map's solid tiles. A <em>cardinal</em>
+/// (single-axis) move uses <em>per-axis slide-to-boundary clamping</em> (see <see cref="Resolve"/>):
+/// for each axis the full requested displacement is applied when the resulting collision
+/// footprint (the fixed 1×1 tile lower-body box of the player, see
+/// <see cref="GameEngine.PlayerFootprintOverlapsSolid"/>) is clear; otherwise the axis is clamped
+/// to the <em>closest legal position</em> on that axis, so the leading edge of the footprint stops
+/// exactly at the near edge of the first blocking solid tile (or at the map edge, which
+/// <see cref="TileMap.IsSolid"/> treats as solid). A <em>diagonal</em> (both-axis) move is
+/// <em>all-or-nothing</em> (see <see cref="ResolveDiagonal"/>): it is applied only when the full
+/// displacement is clear on <em>both</em> axes, otherwise the character stays put — a diagonal
+/// into a wall where only one axis is free stops the character entirely instead of sliding along
+/// the free axis.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -25,14 +30,23 @@ namespace RPGEngine;
 /// blocks movement), exactly like <see cref="TileMap.IsAreaSolid"/>.
 /// </para>
 /// <para>
-/// Each axis is clamped independently and the result of the X axis feeds the Y axis
-/// (axis-separated movement preserved): the horizontal displacement is resolved first, then the
-/// vertical displacement starts from the clamped horizontal result. This keeps wall-sliding
-/// natural (a blocked axis clamps to the boundary while the free axis still moves) and prevents
-/// diagonal corner-cutting. Unlike a revert-the-whole-step rule, the clamp always moves the
-/// leading edge exactly onto the boundary, so the feet stop exactly at the solid tile's edge
-/// (matching click-to-move) with no one-frame-step gap and no floating-point overshoot
-/// accumulation. <see cref="GameEngine.ClampPlayerToMap"/> remains the post-move safety net.
+/// For a <em>cardinal</em> move each axis is clamped independently and the result of the X axis
+/// feeds the Y axis (axis-separated movement preserved): the horizontal displacement is resolved
+/// first, then the vertical displacement starts from the clamped horizontal result. Unlike a
+/// revert-the-whole-step rule, the clamp always moves the leading edge exactly onto the boundary,
+/// so the feet stop exactly at the solid tile's edge (matching click-to-move) with no
+/// one-frame-step gap and no floating-point overshoot accumulation.
+/// <see cref="GameEngine.ClampPlayerToMap"/> remains the post-move safety net.
+/// </para>
+/// <para>
+/// A <em>diagonal</em> move is <em>all-or-nothing</em> (<see cref="ResolveDiagonal"/>): the
+/// player moves diagonally only when the full displacement is clear on both axes. When either
+/// axis is blocked — e.g. a wall or the map edge on the X axis while Y is free — the player
+/// stops entirely (no wall-sliding along the free axis), so the engine can report a collision
+/// stop. This prevents diagonal corner-cutting and makes the player's movement state honest:
+/// pressing a diagonal pair against a wall keeps the player idle rather than reporting endless
+/// movement along the free axis. Cardinal moves keep the slide-to-boundary clamp, so a straight
+/// move into a wall still stops exactly at the boundary.
 /// </para>
 /// <para>
 /// The per-axis gained-range scan assumes the starting footprint is legal (never overlapping a
@@ -82,6 +96,62 @@ internal static class MovementCollisionResolver
         }
 
         return resolved;
+    }
+
+    /// <summary>
+    /// Resolves a <em>diagonal</em> displacement with <em>all-or-nothing</em> semantics: the full
+    /// requested displacement is applied only when the destination footprint is clear on
+    /// <em>both</em> axes; otherwise the starting position is returned (the move is fully
+    /// blocked). This disables wall-sliding for diagonal movement — a diagonal into a wall where
+    /// only one axis is free stops the character entirely instead of sliding along the free axis,
+    /// so the engine can report a collision stop (<c>IsMoving = false</c>). Cardinal moves keep
+    /// the per-axis slide-to-boundary clamping of <see cref="Resolve"/>, so a straight move into
+    /// a wall still stops exactly at the boundary.
+    /// </summary>
+    /// <param name="from">The starting feet position, in tiles.</param>
+    /// <param name="dx">The requested horizontal displacement, in tiles (non-zero for a diagonal).</param>
+    /// <param name="dy">The requested vertical displacement, in tiles (non-zero for a diagonal).</param>
+    /// <param name="map">The map whose solid tiles (and edge) block movement.</param>
+    /// <param name="halfWidth">The half-width of the collision footprint (<c>hw</c>), in tiles.</param>
+    /// <param name="heightAboveFeet">The height the collision footprint extends above the feet, in tiles.</param>
+    /// <returns>
+    /// The full requested destination position when both axes are clear; otherwise
+    /// <paramref name="from"/> unchanged. When the starting footprint is already illegal, a
+    /// destination that clears the overlap (escaping the wall) is returned, mirroring
+    /// <see cref="Resolve"/>.
+    /// </returns>
+    internal static Position ResolveDiagonal(Position from, double dx, double dy, TileMap map, double halfWidth, double heightAboveFeet)
+    {
+        var destination = new Position(from.X + dx, from.Y + dy);
+
+        // An illegal starting footprint (e.g. left embedded in a wall by an external teleport):
+        // the gained-range scans below cannot detect the already-overlapped tile, so fall back to
+        // the destination-footprint check. A destination that clears the overlap (escaping the
+        // wall) is allowed; a destination that still overlaps a solid tile is refused (never move
+        // deeper into or through a wall), mirroring Resolve's safety net.
+        if (FootprintOverlaps(from, map, halfWidth, heightAboveFeet))
+        {
+            return FootprintOverlaps(destination, map, halfWidth, heightAboveFeet) ? from : destination;
+        }
+
+        // A legal starting footprint: the diagonal move is all-or-nothing. It is applied only when
+        // the full displacement is clear on BOTH axes - the per-axis gained-range scans below
+        // detect any newly-entered solid column or row along the whole displacement, so a large
+        // diagonal step cannot tunnel through a thin wall either. When either axis is blocked, the
+        // move is refused entirely rather than sliding along the free axis, so the player stops at
+        // the first position where one axis is blocked (one diagonal step short of the boundary).
+        var horizontalClear = ClampHorizontal(from, dx, map, halfWidth, heightAboveFeet) == from.X + dx;
+        var verticalClear = ClampVertical(from, dy, map, halfWidth, heightAboveFeet, xAfterX: from.X) == from.Y + dy;
+
+        // Re-validate the destination footprint as a safety net (a legal start whose axes both
+        // scan clear can still land on an overlapping tile through axis interaction), mirroring
+        // Resolve.
+        if (horizontalClear && verticalClear && !FootprintOverlaps(destination, map, halfWidth, heightAboveFeet))
+        {
+            return destination;
+        }
+
+        return from;
     }
 
     /// <summary>

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -85,18 +85,22 @@ namespace RPGEngine;
 /// The box is independent of the rendered sprite size, so a 1-tile-wide corridor always fits
 /// regardless of the spritesheet's cell size, and the feet always stop exactly at the solid
 /// tile's edge whether the tile is below, above or beside the player. Clamping keeps that
-/// 1×1 box inside the map. This blocks the player at solid tiles, keeps wall-sliding natural
-/// and prevents diagonal corner-cutting; and because a blocked axis slides to the exact boundary
-/// instead of reverting the whole step, the feet stop exactly at the solid tile's edge, matching
-/// click-to-move ("colliding with its feet") with no one-frame-step gap and no floating-point
-/// overshoot accumulation. The resolver re-validates the resulting footprint as a safety net and
+/// 1×1 box inside the map. This blocks the player at solid tiles and prevents diagonal
+/// corner-cutting; a <em>cardinal</em> move slides a blocked axis to the exact boundary (the feet
+/// stop exactly at the solid tile's edge, matching click-to-move ("colliding with its feet"),
+/// with no one-frame-step gap and no floating-point overshoot accumulation), while a
+/// <em>diagonal</em> move is <em>all-or-nothing</em>: it is applied only when the full
+/// displacement is clear on both axes, so a diagonal into a wall where only one axis is free
+/// stops the player entirely instead of sliding along the free axis. The resolver re-validates
+/// the resulting footprint as a safety net and
 /// refuses a displacement that would still overlap a solid tile (only possible when the starting
 /// footprint was already illegal, e.g. embedded in a wall), so key movement never moves the
 /// player through a solid tile. The auto-walk (see <see cref="Click(double, double)"/>) resolves
 /// each displacement the same way, so it never crosses a solid corner either: a blocked auto-walk
 /// step cancels the walk instead of moving the player into the wall. When a move
 /// is <em>fully blocked</em> (no net displacement after the axis-separated resolution, e.g.
-/// walking straight into a wall or into a corner), the engine reports a <em>collision stop</em>
+/// walking straight into a wall, into a corner, or a diagonal whose single free axis is also
+/// stopped), the engine reports a <em>collision stop</em>
 /// to the player (<see cref="Player.ReportBlockedMove(Direction)"/>), so <see cref="Player.OnMove"/>
 /// fires with <see cref="PlayerMoveEventArgs.IsMoving"/> set to <see langword="false"/> even
 /// while the movement key is held against the wall. See <c>docs/Architecture.md</c> for the
@@ -153,8 +157,8 @@ public sealed class GameEngine : IDisposable
     // x in [pos.X - 0.5, pos.X + 0.5] and y in [pos.Y - 1.0, pos.Y] in tiles. The box is
     // independent of the rendered sprite size, so a 1-tile-wide corridor always fits regardless
     // of the spritesheet's cell size, and the feet always stop exactly at the solid tile's edge.
-    internal const double CollisionBoxHalfWidth = 0.25;
-    internal const double CollisionBoxHeightAboveFeet = 0.5;
+    internal const double CollisionBoxHalfWidth = 0.5;
+    internal const double CollisionBoxHeightAboveFeet = 1.0;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameEngine"/> class with default state: a
@@ -1048,21 +1052,22 @@ public sealed class GameEngine : IDisposable
 
     /// <summary>
     /// Moves the player in <paramref name="direction"/> by <c>BaseSpeed * dt</c> tiles and, when
-    /// a map is set, resolves collisions against the map's solid tiles using
-    /// <em>axis-separated movement with per-axis slide-to-boundary clamping</em>: the horizontal
-    /// displacement is applied first and, if the player's collision footprint (the fixed 1×1
-    /// tile lower-body box anchored at the feet, see <see cref="PlayerFootprintOverlapsSolid"/>)
-    /// would overlap a solid tile or leave the map (the map edge is solid, see
-    /// <see cref="Tiled.TileMap.IsSolid"/>), it slides to the <em>closest legal position on that
-    /// axis</em> so the leading edge stops exactly at the near edge of the first blocking solid
-    /// tile (or at the map edge); the vertical displacement is then applied the same way,
-    /// starting from the horizontal result. This keeps wall-sliding natural (a blocked axis
-    /// clamps to the boundary while the other axis still moves) and prevents diagonal
-    /// corner-cutting (each axis is resolved independently). Because a blocked axis slides to the
-    /// exact boundary instead of reverting the whole step, the feet stop exactly at the solid
-    /// tile's edge, matching click-to-move ("colliding with its feet") with no one-frame-step gap
-    /// and no floating-point overshoot accumulation. Without a map the displacement is applied
-    /// directly, matching <see cref="Character.Move(Direction, double, double)"/>.
+    /// a map is set, resolves collisions against the map's solid tiles. A <em>cardinal</em>
+    /// (single-axis) move uses <em>per-axis slide-to-boundary clamping</em> (see
+    /// <see cref="MovementCollisionResolver.Resolve"/>): if the player's collision footprint
+    /// (the fixed 1×1 tile lower-body box anchored at the feet, see
+    /// <see cref="PlayerFootprintOverlapsSolid"/>) would overlap a solid tile or leave the map
+    /// (the map edge is solid, see <see cref="Tiled.TileMap.IsSolid"/>), the axis slides to the
+    /// <em>closest legal position</em> so the leading edge stops exactly at the near edge of the
+    /// first blocking solid tile (or at the map edge). A <em>diagonal</em> (both-axis) move is
+    /// <em>all-or-nothing</em> (see <see cref="MovementCollisionResolver.ResolveDiagonal"/>):
+    /// it is applied only when the full displacement is clear on both axes, otherwise the player
+    /// stays put — a diagonal into a wall where only one axis is free stops the player entirely
+    /// instead of sliding along the free axis. Because a blocked cardinal axis slides to the exact
+    /// boundary instead of reverting the whole step, the feet stop exactly at the solid tile's
+    /// edge, matching click-to-move ("colliding with its feet") with no one-frame-step gap and no
+    /// floating-point overshoot accumulation. Without a map the displacement is applied directly,
+    /// matching <see cref="Character.Move(Direction, double, double)"/>.
     /// </summary>
     /// <param name="direction">The direction to face and move towards.</param>
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
@@ -1078,8 +1083,8 @@ public sealed class GameEngine : IDisposable
     /// so <see cref="Player.OnMove"/> fires with <see cref="PlayerMoveEventArgs.IsMoving"/>
     /// set to <see langword="false"/> even while the movement key stays held; a move that
     /// actually displaced the player is reported as movement through
-    /// <see cref="Player.ReportMovement(Direction)"/> as before (a diagonal slide along a wall
-    /// still counts as movement because the free axis changed the position).
+    /// <see cref="Player.ReportMovement(Direction)"/> as before (a diagonal move whose full
+    /// displacement was clear counts as movement because both axes changed the position).
     /// NPCs are not moved by the engine (they have no AI yet), so collision resolution only
     /// applies to the player here; the public <see cref="Tiled.TileMap.IsSolid"/> API is
     /// available for future NPC logic.
@@ -1097,15 +1102,28 @@ public sealed class GameEngine : IDisposable
         {
             Player.Position += delta;
         }
+        else if (delta.X != 0 && delta.Y != 0)
+        {
+            // A diagonal move is all-or-nothing: it is applied only when the full displacement is
+            // clear on both axes, so the player never slides along the free axis into a wall (a
+            // diagonal into a wall where only one axis is free stops the player entirely). A
+            // blocked diagonal leaves the position unchanged, so the fully-blocked collision stop
+            // is reported below (Player.Position == before -> ReportBlockedMove).
+            Player.Position = MovementCollisionResolver.ResolveDiagonal(
+                Player.Position,
+                delta.X,
+                delta.Y,
+                Map,
+                halfWidth: CollisionBoxHalfWidth,
+                heightAboveFeet: CollisionBoxHeightAboveFeet);
+        }
         else
         {
-            // Resolve the displacement with per-axis slide-to-boundary clamping: each axis moves
-            // by the full requested displacement when the destination footprint is clear,
-            // otherwise it slides to the closest legal position on that axis (the leading edge
-            // of the fixed 1x1 tile lower-body box stops exactly at the near edge of the first
-            // blocking solid tile or at the map edge). The horizontal result feeds the vertical
-            // axis (axis-separated movement preserved), which is what makes diagonal movement
-            // slide along a wall on the free axis.
+            // A cardinal (single-axis) move keeps the per-axis slide-to-boundary clamping: each
+            // axis moves by the full requested displacement when the destination footprint is
+            // clear, otherwise it slides to the closest legal position on that axis (the leading
+            // edge of the fixed 1x1 tile lower-body box stops exactly at the near edge of the
+            // first blocking solid tile or at the map edge).
             Player.Position = MovementCollisionResolver.Resolve(
                 Player.Position,
                 delta.X,
@@ -1125,8 +1143,8 @@ public sealed class GameEngine : IDisposable
         }
         else
         {
-            // The player actually displaced: report movement as before (a diagonal slide along
-            // a wall still counts as movement because the free axis changed the position).
+            // The player actually displaced: report movement as before (a diagonal whose full
+            // displacement was clear counts as movement because both axes changed the position).
             Player.ReportMovement(direction);
         }
     }

--- a/tests/RPGEngine.Tests/Core/MovementCollisionResolverTests.cs
+++ b/tests/RPGEngine.Tests/Core/MovementCollisionResolverTests.cs
@@ -234,6 +234,90 @@ public class MovementCollisionResolverTests
         Assert.Equal(1.5, result.Y, precision: 9);
     }
 
+    /// <summary>
+    /// Verifies a diagonal move where one axis is blocked is fully refused: the starting position
+    /// is returned (no sliding along the free axis) - a diagonal into a wall where only one axis
+    /// is free stops the character entirely.
+    /// </summary>
+    [Fact]
+    public void ResolveDiagonal_OneAxisBlocked_ReturnsStart()
+    {
+        using var fixture = CollisionMapFixture(6, 6, SolidColumn(6, column: 3));
+        using var map = TileMap.Load(fixture.MapPath);
+
+        // Start flush against the wall's left edge (feet x = 2.5, box right edge at x = 3.0);
+        // moving up-right, the X displacement is blocked while Y is free. All-or-nothing: the
+        // move is refused entirely rather than sliding up along the wall.
+        var start = new Position(2.5, 4.0);
+        var result = MovementCollisionResolver.ResolveDiagonal(
+            start, 1.0 / 30, -1.0 / 30, map, HalfWidth, HeightAboveFeet);
+
+        Assert.Equal(start, result);
+    }
+
+    /// <summary>
+    /// Verifies a diagonal move whose full displacement is clear on both axes applies the full
+    /// displacement (the destination is returned unchanged).
+    /// </summary>
+    [Fact]
+    public void ResolveDiagonal_BothAxesFree_ReturnsDestination()
+    {
+        using var fixture = CollisionMapFixture(6, 6, SolidColumn(6, column: 4));
+        using var map = TileMap.Load(fixture.MapPath);
+
+        var result = MovementCollisionResolver.ResolveDiagonal(
+            new Position(1.5, 3.0), 0.5, -0.5, map, HalfWidth, HeightAboveFeet);
+
+        Assert.Equal(2.0, result.X, precision: 9);
+        Assert.Equal(2.5, result.Y, precision: 9);
+    }
+
+    /// <summary>
+    /// Verifies a large diagonal step toward a solid column is refused entirely (the starting
+    /// position is returned): the gained-range scan detects the solid column along the whole
+    /// displacement, so the step neither tunnels through the wall nor partially slides along the
+    /// free axis.
+    /// </summary>
+    [Fact]
+    public void ResolveDiagonal_LargeStep_TowardSolidColumn_RefusedWithoutSliding()
+    {
+        using var fixture = CollisionMapFixture(6, 6, SolidColumn(6, column: 4));
+        using var map = TileMap.Load(fixture.MapPath);
+
+        // A 2.5-tile right / 2.0-tile up step from (1.5, 3.0): the right edge would enter the
+        // solid column at x = 4, so the whole diagonal move is refused - the free Y axis does
+        // not move either.
+        var start = new Position(1.5, 3.0);
+        var result = MovementCollisionResolver.ResolveDiagonal(
+            start, 2.5, -2.0, map, HalfWidth, HeightAboveFeet);
+
+        Assert.Equal(start, result);
+    }
+
+    /// <summary>
+    /// Verifies a diagonal move from an already-illegal start that clears the overlap (escaping
+    /// away from the wall) is allowed, so an embedded player is never permanently stuck.
+    /// </summary>
+    [Fact]
+    public void ResolveDiagonal_FromIllegalStart_EscapeAwayFromWall_Allowed()
+    {
+        using var fixture = CollisionMapFixture(6, 6, SolidColumn(6, column: 2));
+        using var map = TileMap.Load(fixture.MapPath);
+
+        // An illegal start: the box [1.5, 2.5] already overlaps the solid column [2,3) at row 2.
+        var start = new Position(2.0, 2.5);
+        Assert.True(map.IsAreaSolid(2.0 - 0.5, 2.5 - 1.0, 1.0, 1.0), "sanity: the start is illegal");
+
+        // Moving down-right far enough clears the overlap in one step (the box's left edge must
+        // pass the column's right edge at x = 3.0, so the rightward displacement must be at least
+        // 1.5 tiles; a smaller step would keep the overlap and be refused, never moving deeper).
+        var result = MovementCollisionResolver.ResolveDiagonal(
+            start, 1.6, 0.6, map, HalfWidth, HeightAboveFeet);
+
+        Assert.False(map.IsAreaSolid(result.X - 0.5, result.Y - 1.0, 1.0, 1.0), "The escaped footprint must be legal.");
+        Assert.True(result.X > start.X && result.Y > start.Y, "The player should move down-right (escape).");
+    }
+
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs
@@ -161,11 +161,13 @@ public class GameEngineCollisionOnMoveTests
     }
 
     /// <summary>
-    /// Verifies a diagonal move into a wall slides along the free axis: the player keeps moving
-    /// (its position changes each frame), so no (false, ...) stop event fires mid-slide.
+    /// Verifies a diagonal move into a wall where only one axis is free stops the player
+    /// entirely (diagonal movement is all-or-nothing: no wall-sliding along the free axis). The
+    /// blocked move is reported once with IsMoving = false and nothing more fires while the keys
+    /// stay held.
     /// </summary>
     [Fact]
-    public void Update_DiagonalSlideIntoWall_DoesNotReportStopMidSlide()
+    public void Update_DiagonalIntoWall_StopsEntirelyAndFiresOnMoveFalseOnce()
     {
         // 5x5 map: a "walls" collision layer with a solid column at x=3 for every row.
         var gids = new uint[25];
@@ -179,7 +181,8 @@ public class GameEngineCollisionOnMoveTests
         ConfigurePlayerSprite(engine, seed: 1);
 
         // Start flush against the left edge of the wall column: moving UpRight, the X
-        // displacement is blocked while Y is free, so the player slides straight up along it.
+        // displacement is blocked while Y is free. Diagonal movement is all-or-nothing, so the
+        // player stops entirely instead of sliding straight up along the wall.
         engine.Player.Position = new Position(2.5, 4.0);
 
         var events = new List<PlayerMoveEventArgs>();
@@ -193,14 +196,108 @@ public class GameEngineCollisionOnMoveTests
             engine.Update(FrameDt);
         }
 
-        // The player slid up along the wall: X never moved into it, Y decreased.
+        // The player never moved: fully blocked on the first frame (X blocked, Y free - no slide).
         Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
-        Assert.True(engine.Player.Position.Y < 4.0);
+        Assert.Equal(4.0, engine.Player.Position.Y, precision: 6);
 
-        // The slide is still movement: the start fired (true, UpRight) and no stop event fired
-        // mid-slide (the position changed every frame).
-        Assert.Contains(new PlayerMoveEventArgs(true, Direction.UpRight), events);
-        Assert.DoesNotContain(events, e => !e.IsMoving);
+        // The blocked diagonal was reported exactly once: the player was idle facing Down, so
+        // the (false, UpRight) fires as a direction change while blocked, and nothing more while
+        // W+D stay held.
+        Assert.Equal(new[] { new PlayerMoveEventArgs(false, Direction.UpRight) }, events);
+    }
+
+    /// <summary>
+    /// Verifies a diagonal move that becomes blocked mid-walk stops the player entirely and
+    /// reports IsMoving = false exactly once: (true, UpRight) fires while both axes are free and
+    /// the player moves, then exactly one (false, UpRight) fires when one axis is blocked, and
+    /// nothing more while the keys stay held (the free axis never slides).
+    /// </summary>
+    [Fact]
+    public void Update_DiagonalMovement_StopsEntirelyWhenOneAxisBlocked()
+    {
+        // 5x5 map: a "walls" collision layer with a solid column at x=3 for every row.
+        var gids = new uint[25];
+        for (var y = 0; y < 5; y++)
+        {
+            gids[(y * 5) + 3] = 1;
+        }
+
+        using var fixture = CreateCollisionMapFixture(5, 5, gids);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+
+        // Start in open space: moving UpRight is free until the box's right edge reaches the
+        // wall column, at which point the X axis becomes blocked while Y is still free. The
+        // player must stop entirely rather than sliding up along the wall.
+        engine.Player.Position = new Position(1.5, 4.0);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.W, true);
+        engine.Input(Key.D, true);
+
+        for (var frame = 0; frame < 120; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The player moved up-right while both axes were free but never entered the wall, and
+        // stopped entirely once the X axis became blocked (no slide: Y stays put after the stop).
+        var stopped = engine.Player.Position;
+        Assert.True(stopped.X > 1.5, "The player moved right before stopping.");
+        Assert.True(stopped.Y < 4.0, "The player moved up before stopping.");
+        Assert.True(stopped.X + 0.5 <= 3.0 + 1e-9, "The footprint must never overlap the solid column.");
+
+        // Exact sequence: (true, UpRight) on start, then exactly one (false, UpRight) when one
+        // axis became blocked, and nothing more while W+D stay held.
+        Assert.Equal(
+            new[]
+            {
+                new PlayerMoveEventArgs(true, Direction.UpRight),
+                new PlayerMoveEventArgs(false, Direction.UpRight),
+            },
+            events);
+
+        // A subsequent frame with the same keys fires nothing and does not move the player.
+        events.Clear();
+        engine.Update(FrameDt);
+        Assert.Empty(events);
+        Assert.Equal(stopped, engine.Player.Position);
+    }
+
+    /// <summary>
+    /// Verifies a diagonal move whose full displacement is clear on both axes moves the player
+    /// diagonally: OnMove fires (true, UpRight) once on start, the position changes on both
+    /// axes each frame, and no (false, ...) stop event fires mid-move.
+    /// </summary>
+    [Fact]
+    public void Update_DiagonalMovement_BothAxesFree_MovesDiagonally()
+    {
+        // A 5x5 map with no collision layer: only the map edge is solid, far away from the path.
+        using var fixture = CreateFilledMapFixture(5, 5);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(1.5, 3.0);
+
+        var events = new List<PlayerMoveEventArgs>();
+        engine.Player.OnMove += (_, e) => events.Add(e);
+
+        engine.Input(Key.W, true);
+        engine.Input(Key.D, true);
+
+        for (var frame = 0; frame < 30; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // Both axes are free the whole way: the player moved up-right.
+        Assert.True(engine.Player.Position.X > 1.5, "The player must move right.");
+        Assert.True(engine.Player.Position.Y < 3.0, "The player must move up.");
+
+        // Movement only: (true, UpRight) on start, and no stop event (the position changed
+        // every frame).
+        Assert.Equal(new[] { new PlayerMoveEventArgs(true, Direction.UpRight) }, events);
     }
 
     /// <summary>
@@ -220,8 +317,10 @@ public class GameEngineCollisionOnMoveTests
         var events = new List<PlayerMoveEventArgs>();
         engine.Player.OnMove += (_, e) => events.Add(e);
 
-        // Walk up-left into the top-left corner of the map: both axes are eventually blocked by
-        // the map edge at (0.5, 1.0) (the fixed 1x1 box's top edge at the top map edge).
+        // Walk up-left into the top-left corner of the map. Diagonal movement is all-or-nothing:
+        // the player moves while both axes are free and stops entirely at the first position
+        // where either axis is blocked (the Y axis blocks first, one diagonal step short of the
+        // top map edge, because a diagonal cannot take a partial step onto the boundary).
         engine.Input(Key.W, true);
         engine.Input(Key.A, true);
 
@@ -230,11 +329,15 @@ public class GameEngineCollisionOnMoveTests
             engine.Update(FrameDt);
         }
 
-        // The player is fully blocked in the top-left corner region: the fixed 1x1 lower-body
-        // box never leaves the map (feet x in [0.5, 1.5], y in [1.0, 2.0]), and a further frame
-        // leaves both the position and the events unchanged.
+        // The player is fully blocked in the top-left corner region. All-or-nothing diagonal
+        // movement stops the player at the first position where either axis is blocked (here the
+        // Y axis, one diagonal step short of the top map edge, since a diagonal cannot take a
+        // partial step onto the boundary): the fixed 1x1 lower-body box never leaves the map (feet
+        // x in [0.5, 1.5], y in [1.0, 2.0]), and a further frame leaves both the position and the
+        // events unchanged.
         var blockedPosition = engine.Player.Position;
-        Assert.True(blockedPosition.X < 1.0 && blockedPosition.Y <= 1.0 + 1e-9, "The player must end near the top-left corner.");
+        Assert.True(blockedPosition.X >= 0.5 - 1e-9 && blockedPosition.X < 1.1, "The player must be stopped in the top-left corner region.");
+        Assert.True(blockedPosition.Y >= 1.0 - 1e-9 && blockedPosition.Y < 1.1, "The player must be stopped near the top map edge.");
 
         // Exact sequence: (true, UpLeft) when the walk started, then exactly one (false, UpLeft)
         // when both axes became blocked, and nothing more while W+A stay held.

--- a/tests/RPGEngine.Tests/GameEngineCollisionTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineCollisionTests.cs
@@ -177,9 +177,9 @@ public partial class GameEngineTests
         Assert.Equal(Direction.Down, engine.Player.Direction);
     }
 
-    /// <summary>Verifies a player moving diagonally into a vertical wall slides along the wall on the free axis (axis-separated movement).</summary>
+    /// <summary>Verifies a player moving diagonally into a vertical wall stops entirely: diagonal movement is all-or-nothing, so the blocked X axis stops the player instead of sliding up along the wall on the free Y axis.</summary>
     [Fact]
-    public void Update_PlayerMovesDiagonallyIntoWall_SlidesAlongWall()
+    public void Update_PlayerMovesDiagonallyIntoWall_StopsEntirely()
     {
         // 5x5 map: a "walls" collision layer with a solid column at x=3 for every row.
         var gids = new uint[25];
@@ -194,7 +194,8 @@ public partial class GameEngineTests
 
         // Start flush against the left edge of the wall column (x=3): the fixed 1x1 box spans
         // [2,3) horizontally at feet x=2.5. Moving UpRight, the X displacement is blocked by the
-        // wall while Y is free, so the player slides straight up along the wall.
+        // wall while Y is free; diagonal movement is all-or-nothing, so the player stays put
+        // instead of sliding straight up along the wall.
         engine.Player.Position = new Position(2.5, 4.0);
         engine.Input(Key.W, true);
         engine.Input(Key.D, true);
@@ -204,10 +205,10 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // X never moves into the wall: it stays at exactly 2.5 (the feet at the wall's left edge).
+        // The player never moved: X stays at the wall's left edge (2.5) and Y stays at 4.0 (no
+        // sliding along the free axis).
         Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
-        // Y slides up along the wall: one second at 2 tiles/s diagonally = 2 * sqrt(0.5) ~ 1.414.
-        Assert.Equal(4.0 - (2 * Math.Sqrt(0.5)), engine.Player.Position.Y, precision: 6);
+        Assert.Equal(4.0, engine.Player.Position.Y, precision: 6);
     }
 
     /// <summary>Verifies tiles drawn from a normal (non-collision) layer never block: the player walks across them freely.</summary>


### PR DESCRIPTION
Closes #55

Implements the QA-refusal feedback on story 55: **diagonal wall-sliding is disabled**. A diagonal move is now *all-or-nothing* — it is applied only when the full displacement is clear on **both** axes; a diagonal into a wall where only one axis is free stops the player entirely and reports `IsMoving = false` (via `Player.ReportBlockedMove`), exactly once while the movement keys stay held.

(PR content will be finalized after syncing the branch with `main`.)