### PR TITLE
Story 64: Collision-resolved autonomous movement for every character (StartMoving)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -203,8 +203,8 @@ guard.SpriteSheets.Add(new SpriteSheetRef("guard_head", CharacterIndex: 3));
 
 ## Movement and input
 
-There are **two ways a character moves**, and both go through the same `Character.Update(dt)`
-(internal) called by the engine's update loop every frame:
+There are **two ways a character moves**, and both go through the same `Character.Update(dt, map)`
+(internal, `map` nullable) called by the engine's update loop every frame:
 
 1. **Engine key input (the player).** `GameEngine.Update` combines every held bound key into a
    single **8-direction vector**: each key that is bound to a movement direction (via
@@ -217,22 +217,29 @@ There are **two ways a character moves**, and both go through the same `Characte
    resolved (and collision-checked) by the engine itself, then handed to `Player.ReportMovement`.
 2. **Autonomous movement (`Character.StartMoving` / `StopMoving`).** A host starts a character
    (typically an NPC in `GameEngine.Characters`) with `StartMoving(direction)`, which faces it
-   and sets `IsMoving = true`. While `IsMoving`, every `Character.Update(dt)` moves the character
-   towards its current `Direction` by `BaseSpeed * dt` tiles — exactly like the player while a
-   movement key is held — until `StopMoving()` is called. The engine's update loop calls
-   `Update(dt)` on every character each frame, so a started character moves automatically with no
-   per-frame host code.
+   and sets `IsMoving = true`. While `IsMoving`, every `Character.Update(dt, map)` moves the
+   character towards its current `Direction` by `BaseSpeed * dt` tiles — exactly like the player
+   while a movement key is held — until `StopMoving()` is called. The engine's update loop calls
+   `Update(dt, map)` on every character each frame (supplying the current map), so a started
+   character moves automatically with no per-frame host code.
 
-**Autonomous movement is not collision-resolved by the engine** (collision resolution applies to
-the player only), so hosts that drive NPCs with `StartMoving` are responsible for keeping them in
-bounds themselves. Also, do not combine `StartMoving` on the player's character with the engine's
-key-driven player movement: `GameEngine.Update` calls `Player.Character.Update(dt)` each frame,
-so both displacements would add up. `StartMoving`/`StopMoving` target characters the host drives
-itself (NPCs in `GameEngine.Characters`).
+**Autonomous movement is collision-resolved exactly like the player's key-driven movement**: the
+engine passes the map to every character's `Update`, so a started character's displacement is
+resolved against the map's solid tiles and the map edge with the same footprint and the same
+per-axis slide-to-boundary (cardinal) / all-or-nothing (diagonal) semantics as the player (see
+`MovementCollisionResolver.ResolveDisplacement`). NPCs therefore stop at walls and at the map
+edge instead of walking through the world; a fully blocked character simply stays put (and its
+walk cycle snaps to the standing frame). Do not combine `StartMoving` on the player's character
+with the engine's key-driven player movement: `GameEngine.Update` calls
+`Player.Character.Update(dt, map)` each frame, so both displacements would add up.
+`StartMoving`/`StopMoving` target characters the host drives itself (NPCs in
+`GameEngine.Characters`). The one-shot `Move(...)` displacement stays a raw, non-resolved
+displacement (only the `StartMoving`/`Update` path is collision-resolved).
 
-The walk-cycle animation detects movement the same way for both paths: `Character.Update(dt)`
+The walk-cycle animation detects movement the same way for both paths: `Character.Update(dt, map)`
 compares `Position` to the previous update's position, so the cycle advances while a character is
-moving (however it is being driven) and snaps back to the standing frame as soon as it stops.
+moving (however it is being driven) and snaps back to the standing frame as soon as it stops —
+including when a fully blocked character is resolved to the same position.
 
 Movement speeds are in **tiles per second**; a move of one second at the default speed
 (`Player.DefaultBaseSpeed == 2`) travels exactly **2 tiles** (96 px with 48 px tiles).
@@ -261,18 +268,21 @@ has a non-empty tile (GID != 0) at that cell. The **map edge is solid**: `IsSoli
 a map has no collision layer, every in-bounds cell is walkable. Non-collision layers never block
 (a tile drawn from a normal layer is walkable even if it visually overlaps the character).
 
-The engine resolves the player's movement with **axis-separated movement** against a footprint
-in tile units:
+The engine resolves every character's movement (the player's key-driven and auto-walk movement
+and every character's autonomous `StartMoving`/`Update` path) with **axis-separated movement**
+against a footprint in tile units:
 
-- The footprint is the **fixed 1×1 tile (48×48 px) lower-body box** of the player sprite,
-  **anchored at the feet** (`Position` is the sprite's middle-bottom, and the middle of the feet
-  sits at the bottom-centre of the box — `(24, 48)` when the box's origin is its upper-left).
-  The rectangle is `x ∈ [pos.X - 0.5, pos.X + 0.5]`, `y ∈ [pos.Y - 1.0, pos.Y]` in tiles,
-  **independent of the rendered sprite size**: a taller/wider spritesheet never widens or raises
-  the box, so a **1-tile-wide corridor always fits** (the previous sprite-derived footprint could
-  be wider than 1 tile for larger sprites, which stopped the player before the corridor entrance),
-  and the feet always stop at the solid tile's edge whether the tile is below, above or beside the
-  player. For the default 48×48 sprite the box covers the whole body.
+- The footprint is the **fixed 0.5×0.5-tile (24×24 px at 48 px tiles) lower-body box** of a
+  character sprite, **anchored at the feet** (`Position` is the sprite's middle-bottom, and the
+  middle of the feet sits at the bottom-centre of the box — `(12, 24)` when the box's origin is
+  its upper-left). The rectangle is `x ∈ [pos.X - 0.25, pos.X + 0.25]`,
+  `y ∈ [pos.Y - 0.5, pos.Y]` in tiles, **independent of the rendered sprite size**: a
+  taller/wider spritesheet never widens or raises the box, so a **1-tile-wide corridor always
+  fits** (the previous sprite-derived footprint could be wider than 1 tile for larger sprites,
+  which stopped the player before the corridor entrance), and the feet always stop at the solid
+  tile's edge whether the tile is below, above or beside the character. The player and every NPC
+  share this footprint (the constants live on `MovementCollisionResolver`, the footprint
+  authority).
 - `TileMap.IsAreaSolid(x, y, width, height)` (internal) tests the tiles overlapped by that
   tile-unit rectangle: the bounds are floored to the containing cells, and a rectangle that ends
   exactly on a tile boundary does not count the next tile.
@@ -282,7 +292,7 @@ in tile units:
   is clear the full requested displacement is applied; otherwise the axis slides to the
   **closest legal position on that axis**, so the leading edge of the footprint stops **exactly**
   at the near edge of the first blocking solid tile (or at the map edge, which is solid). With
-  the 1×1 box (half-width `hw = 0.5`, height above the feet `heightAboveFeet = 1.0`), the exact
+  the 0.5×0.5 box (half-width `hw = 0.25`, height above the feet `heightAboveFeet = 0.5`), the exact
   boundaries are: moving **right**, the right edge stops at `x = c - hw` (first solid gained
   column `c`; the right map edge is `c = Width`); moving **left**, the left edge stops at
   `x = c + 1 + hw` (last solid gained column `c`; the left map edge is `c = -1`); moving **down**,
@@ -309,15 +319,19 @@ or into a corner) is reported as a **collision stop** through `Player.ReportBloc
 (exactly once, with the direction the player tried to move in); any move that actually displaced
 the player (including a diagonal slide, whose free axis moved) is reported as movement through
 `Player.ReportMovement` as before. The map-bounds clamp (`ClampPlayerToMap`) keeps the **fixed
-1×1 box** inside the map (the feet clamp to
-`x ∈ [0.5, max(0.5, Map.Width - 0.5)]`,
-`y ∈ [1.0, max(1.0, Map.Height)]`) and remains as a safety net for positions placed outside the
-map by other means. The map edge is solid.
+0.5×0.5 box** inside the map for the player (the feet clamp to
+`x ∈ [0.25, max(0.25, Map.Width - 0.25)]`,
+`y ∈ [0.5, max(0.5, Map.Height)]`) and remains as the player-only post-move safety net for
+positions placed outside the map by other means; NPCs are kept in bounds by the solid map edge
+through their resolved autonomous movement (see `TileMap.IsSolid`). The map edge is solid.
 
-NPCs are not moved by the engine (they have no AI yet), so collision resolution currently only
-applies to the player; the public `TileMap.IsSolid` API is available for future NPC logic.
-Per-tile collision shapes other than full-cell solidity, dynamic (runtime-mutable) collision
-layers and one-way platforms are out of scope for this story.
+Autonomous movement of **every** character (the `StartMoving`/`Update` path) is collision-resolved
+against the map's solid tiles and the map edge exactly like the player's key-driven movement, via
+`MovementCollisionResolver.ResolveDisplacement` — NPCs added to `GameEngine.Characters` with
+`StartMoving` stop at walls and at the map edge instead of walking through the world.
+Character-vs-character collision (characters blocking each other), per-tile collision shapes other
+than full-cell solidity, dynamic (runtime-mutable) collision layers and one-way platforms are out
+of scope for this story.
 
 ## Pathfinding
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,9 +102,12 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > the current one.
 >
 > **Collision layers:** a tile layer declaring the Tiled `is_collision` boolean custom property
-> set to `true` contains **solid** tiles that block the player (see `docs/Architecture.md`); the
+> set to `true` contains **solid** tiles that block characters (see `docs/Architecture.md`); the
 > map edge is solid (characters cannot leave the map), and tiles drawn from non-collision layers
-> never block.
+> never block. The player's key-driven and auto-walk movement, and every NPC moved with
+> `Character.StartMoving` (added to `GameEngine.Characters`), are collision-resolved against the
+> solid tiles and the map edge with the same fixed 0.5×0.5-tile lower-body footprint, so NPCs
+> stop at walls and at the map edge instead of walking through the world.
 >
 > **Minimap:** `engine.RenderMinimap(canvas, zoomLevel)` draws the map's prerendered layers plus a
 > green dot for the player and a yellow dot for each NPC onto a separate surface. `zoomLevel`

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -17,6 +17,11 @@ spritesheet references used to render it.
   draw time. A `SpriteSheetRef` whose `CharacterIndex` is outside 1..8 is rejected when used.
 - All world coordinates are in tiles. Pixels are produced only at the canvas boundary (the
   engine multiplies by the map's tile size when rendering).
+- Autonomous movement started with `StartMoving` (the `Update` path) is **collision-resolved**
+  against the map's solid tiles and the map edge when the engine supplies a map — exactly like
+  the player's key-driven movement — so NPCs stop at walls and at the map edge instead of
+  walking through the world. The one-shot `Move(...)` displacement stays a raw displacement
+  (only the `StartMoving`/`Update` path is resolved).
 
 ## Properties
 
@@ -54,12 +59,15 @@ var character = new Character { BaseSpeed = 2 };
 
 Gets whether the character is currently moving **autonomously** — started with
 `StartMoving(direction)` and not yet stopped with `StopMoving()`. While `true`, every
-`Update(dt)` moves the character towards its current `Direction` by `BaseSpeed * dt` tiles.
+`Update(dt)` moves the character towards its current `Direction` by `BaseSpeed * dt` tiles. When
+the engine supplies a map, that displacement is collision-resolved against the map's solid tiles
+and the map edge exactly like the player's key-driven movement; a fully blocked character simply
+stays put (and its walk cycle snaps back to the standing frame).
 
 This is independent of the engine's key-driven player movement: it targets characters the host
 drives itself (e.g. NPCs in `GameEngine.Characters`). Do **not** combine `StartMoving` on the
 player's character with the engine's key-driven player movement — `GameEngine.Update` calls
-`Player.Character.Update(dt)` each frame, so both displacements would add up.
+`Player.Character.Update(dt, map)` each frame, so both displacements would add up.
 
 ```csharp
 var npc = new Character { BaseSpeed = 2 };
@@ -126,13 +134,11 @@ Starts **autonomous movement**: the character faces `direction` and moves toward
 `Update(dt)` — exactly like the player does while a movement key is held — until
 `StopMoving()` is called. The character starts moving on the *next* `Update`: this method only
 sets the facing direction and the `IsMoving` state, and never changes `Position` itself. The
-engine's update loop calls `Update(dt)` on every character each frame, so a started character
-moves automatically.
-
-Autonomous movement is **not** collision-resolved by the engine (collision resolution applies
-to the player only), so hosts that move NPCs with `StartMoving` are responsible for keeping
-them in bounds themselves. Do not combine `StartMoving` on the player's character with the
-engine's key-driven player movement.
+engine's update loop calls `Update(dt, map)` on every character each frame (supplying the map),
+so a started character moves automatically. The autonomous displacement is collision-resolved
+against the map's solid tiles and the map edge when the engine supplies a map, exactly like the
+player's key-driven movement; a fully blocked character simply stays put. Do not combine
+`StartMoving` on the player's character with the engine's key-driven player movement.
 
 ```csharp
 var npc = new Character { BaseSpeed = 2, Position = new Position(3, 4) };
@@ -184,6 +190,7 @@ npc.StopMoving();                 // stays put; walk cycle snaps to the standing
 npc.StartMoving(Direction.Left);  // turns around and starts moving left
 ```
 
-> Note: `Character.Update(dt)` is internal — hosts do not call it directly. The engine calls it
-> on the player and every NPC in `GameEngine.Characters` each frame, which is what makes a
-> started character move automatically.
+> Note: `Character.Update(dt, map)` is internal — hosts do not call it directly. The engine calls
+> it on the player and every NPC in `GameEngine.Characters` each frame (supplying the current
+> map), which is what makes a started character move automatically and collide with the world
+> like the player. `Move(...)` remains a raw one-shot displacement that is not collision-resolved.

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -50,24 +50,27 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   auto-walk does not advance (manual key movement takes priority). A `Click` always replaces the
   path unless the new target is invalid (solid / no path), in which case it cancels the walk.
   See [Architecture](../Architecture.md).
-- When a map is set, the player's displacement is resolved with **axis-separated movement and
-  per-axis slide-to-boundary clamping** against the map's solid tiles (layers declaring the Tiled
-  `is_collision` bool property): each axis is applied in turn and, when the player's collision
-  footprint would overlap a solid tile or leave the map (the map edge is solid), it slides to
-  the **closest legal position on that axis** — so the leading edge of the footprint stops
-  **exactly** at the near edge of the first blocking solid tile (or at the map edge). The
-  footprint is the **fixed 1×1 tile (48×48 px) lower-body box anchored at the feet**
-  (`Position` is the middle-bottom of the sprite; the middle of the feet sits at the bottom-centre
-  of the box, `(24, 48)` when the box's origin is its upper-left). The box is independent of the
-  rendered sprite size, so a 1-tile-wide corridor always fits and the feet stop exactly at the
-  solid tile's edge in every direction — below, above or beside the player; the map-bounds clamp
-  keeps that 1×1 box inside the map. Because a blocked axis slides to the exact boundary instead
-  of reverting the whole step, the feet stop exactly at the solid tile's edge, matching
-  click-to-move, with no one-frame-step gap and no floating-point overshoot accumulation. As a
-  safety net the resolver refuses a displacement whose resulting footprint would still overlap a
-  solid tile (only possible when the starting footprint was already illegal, e.g. embedded in a
-  wall), so key movement never moves the player through a solid tile. See
-  [Architecture](../Architecture.md).
+- When a map is set, every character's displacement is resolved with **axis-separated movement
+  and per-axis slide-to-boundary clamping** against the map's solid tiles (layers declaring the
+  Tiled `is_collision` bool property): each axis is applied in turn and, when a character's
+  collision footprint would overlap a solid tile or leave the map (the map edge is solid), it
+  slides to the **closest legal position on that axis** — so the leading edge of the footprint
+  stops **exactly** at the near edge of the first blocking solid tile (or at the map edge). The
+  footprint is the **fixed 0.5×0.5-tile (24×24 px at 48 px tiles) lower-body box anchored at
+  the feet** (`Position` is the middle-bottom of the sprite; the middle of the feet sits at the
+  bottom-centre of the box, `(12, 24)` when the box's origin is its upper-left). The box is
+  independent of the rendered sprite size, so a 1-tile-wide corridor always fits and the feet stop
+  exactly at the solid tile's edge in every direction — below, above or beside the character.
+  The player's key-driven and auto-walk movement and every character's autonomous movement
+  (`StartMoving`/`Update`, e.g. NPCs in `Characters`) are resolved with the same shared resolver,
+  so NPCs stop at walls and at the map edge instead of walking through the world; the player-only
+  map-bounds clamp keeps that 0.5×0.5 box inside the map as a post-move safety net. Because a
+  blocked axis slides to the exact boundary instead of reverting the whole step, the feet stop
+  exactly at the solid tile's edge, matching click-to-move, with no one-frame-step gap and no
+  floating-point overshoot accumulation. As a safety net the resolver refuses a displacement whose
+  resulting footprint would still overlap a solid tile (only possible when the starting footprint
+  was already illegal, e.g. embedded in a wall), so movement never moves a character through a
+  solid tile. See [Architecture](../Architecture.md).
 - A minimap can be rendered on a separate surface with `RenderMinimap`: it draws the map's
   prerendered tile layers, a green dot for the player and a yellow dot for each NPC.
   `zoomLevel` `1.0` fits the whole map to the canvas; values above `1` zoom in and pan around
@@ -107,6 +110,11 @@ engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
 Gets the mutable list of NPC characters present in the game world. The player is never in this
 list (it is rendered separately, on top).
+
+The engine's update loop calls `Character.Update(dt, Map)` on every NPC each frame, so an NPC
+started with `StartMoving` moves autonomously and its displacement is **collision-resolved**
+against the map's solid tiles and the map edge exactly like the player's key-driven movement —
+an NPC stops at walls and at the map edge instead of walking through the world.
 
 ```csharp
 var npc = new Character { Position = new Position(3, 4) };
@@ -162,8 +170,10 @@ collisions against the map's solid tiles with axis-separated movement when a map
 Otherwise, when an auto-walk path is queued (from `Click`), the player walks toward the center
 of the next waypoint tile at `BaseSpeed`, popping waypoints as they are reached and calling
 `Player.Stop()` when the path completes. When there is no key input and no auto-walk target the
-player stops. The player is then clamped inside the map and the walk-cycle animation of the
-player and every NPC advances.
+player stops. The player is then clamped inside the map, and the walk-cycle animation of the
+player and every NPC advances. Every NPC's autonomous movement (started with `StartMoving`) is
+resolved against the map's solid tiles and the map edge like the player's key-driven movement, so
+NPCs stop at walls and at the map edge instead of walking through the world.
 
 ```csharp
 engine.Update(dt: 1.0 / 60);

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -1,4 +1,5 @@
 using RPGEngine.Sprites;
+using RPGEngine.Tiled;
 using SkiaSharp;
 
 namespace RPGEngine;
@@ -28,14 +29,16 @@ namespace RPGEngine;
 /// the engine resolves in <c>GameEngine.Update</c>) or by this class's autonomous state machine
 /// (<see cref="StartMoving"/>/<see cref="StopMoving"/> and <see cref="IsMoving"/>, suitable
 /// for any character, e.g. NPCs). While <see cref="IsMoving"/> is <see langword="true"/>, every
-/// <see cref="Update(double)"/> moves the character towards its current <see cref="Direction"/>
-/// by <c>BaseSpeed * dt</c> tiles. Autonomous movement is <em>not</em> collision-resolved by the
-/// engine (collision resolution applies to the player only), so hosts that move NPCs with
-/// <see cref="StartMoving"/> are responsible for keeping them in bounds themselves.
+/// <see cref="Update(double, TileMap)"/> moves the character towards its current
+/// <see cref="Direction"/> by <c>BaseSpeed * dt</c> tiles. When the engine supplies a map (as it
+/// does for every character in <c>GameEngine.Update</c>), the autonomous displacement is
+/// collision-resolved against the map's solid tiles exactly like the player's key-driven
+/// movement (see <see cref="MovementCollisionResolver.ResolveDisplacement(RPGEngine.Position, double, double, TileMap, double, double)"/>),
+/// so NPCs stop at solid tiles and at the map edge instead of walking through the world.
 /// </para>
 /// <para>
 /// Do not combine <see cref="StartMoving"/> on the player's character with the engine's
-/// key-driven player movement: <c>GameEngine.Update</c> calls <c>Player.Character.Update(dt)</c>
+/// key-driven player movement: <c>GameEngine.Update</c> calls <c>Player.Character.Update(dt, map)</c>
 /// each frame, so both displacements would add up. <see cref="StartMoving"/>/<see cref="StopMoving"/>
 /// target characters the host drives itself (NPCs in <c>GameEngine.Characters</c>).
 /// </para>
@@ -81,12 +84,13 @@ public sealed class Character
     /// <see cref="StartMoving"/> and not yet stopped with <see cref="StopMoving"/>).
     /// </summary>
     /// <remarks>
-    /// While <see langword="true"/>, every <see cref="Update(double)"/> moves the character
-    /// towards its current <see cref="Direction"/> by <c>BaseSpeed * dt</c> tiles. This is
-    /// independent of the engine's key-driven player movement: it targets characters the host
-    /// drives itself (e.g. NPCs in <c>GameEngine.Characters</c>). Do not combine it with the
-    /// engine's key-driven player movement on the player's character, or the two displacements
-    /// would add up.
+    /// While <see langword="true"/>, every <see cref="Update(double, TileMap)"/> moves the character
+    /// towards its current <see cref="Direction"/> by <c>BaseSpeed * dt</c> tiles. When the engine
+    /// supplies a map, that displacement is collision-resolved against the map's solid tiles and
+    /// the map edge, exactly like the player's key-driven movement. This is independent of the
+    /// engine's key-driven player movement: it targets characters the host drives itself (e.g.
+    /// NPCs in <c>GameEngine.Characters</c>). Do not combine it with the engine's key-driven
+    /// player movement on the player's character, or the two displacements would add up.
     /// </remarks>
     public bool IsMoving { get; private set; }
 
@@ -114,7 +118,7 @@ public sealed class Character
 
     /// <summary>
     /// Gets the current walk-cycle animation frame (0..2). The middle frame (1) is the standing
-    /// frame. The frame advances on a time/speed basis (see <see cref="Update(double)"/>). This
+    /// frame. The frame advances on a time/speed basis (see <see cref="Update(double, TileMap)"/>). This
     /// accessor is internal so tests can verify animation advancement.
     /// </summary>
     internal int AnimationFrame => _animationFrame;
@@ -134,6 +138,13 @@ public sealed class Character
     /// character only turns to face <paramref name="direction"/> without moving.</param>
     /// <param name="dt">The elapsed time in seconds (defaults to 1, so calling
     /// <c>Move(d, factor)</c> moves <c>BaseSpeed * factor</c> tiles, i.e. per-second semantics).</param>
+    /// <remarks>
+    /// <see cref="Move(Direction, double, double)"/> is a raw one-shot displacement: it applies
+    /// the displacement directly and is <em>not</em> collision-resolved against the map's solid
+    /// tiles (only the autonomous <see cref="StartMoving"/>/<see cref="Update(double, TileMap)"/>
+    /// path is resolved, per the engine's movement model). Hosts using <c>Move</c> for a
+    /// one-shot displacement are responsible for keeping the character in bounds themselves.
+    /// </remarks>
     public void Move(Direction direction, double speedFactor = 1, double dt = 1)
     {
         Direction = direction;
@@ -157,16 +168,19 @@ public sealed class Character
 
     /// <summary>
     /// Starts autonomous movement: the character faces <paramref name="direction"/> and moves
-    /// towards it on every <see cref="Update(double)"/> until <see cref="StopMoving"/> is
+    /// towards it on every <see cref="Update(double, TileMap)"/> until <see cref="StopMoving"/> is
     /// called.
     /// </summary>
     /// <param name="direction">The direction to face and move towards.</param>
     /// <remarks>
-    /// The character starts moving on the <em>next</em> <see cref="Update(double)"/>: this
+    /// The character starts moving on the <em>next</em> <see cref="Update(double, TileMap)"/>: this
     /// method only sets the facing direction and the <see cref="IsMoving"/> state and never
     /// changes <see cref="Position"/> itself. The engine's update loop calls
-    /// <see cref="Update(double)"/> on every character each frame, so a started character moves
-    /// automatically. Autonomous movement is not collision-resolved by the engine.
+    /// <see cref="Update(double, TileMap)"/> on every character each frame (supplying the map), so a
+    /// started character moves automatically. The autonomous displacement is collision-resolved
+    /// against the map's solid tiles and the map edge when a map is supplied, exactly like the
+    /// player's key-driven movement; a fully blocked character simply stays put (and its walk
+    /// cycle snaps back to the standing frame).
     /// </remarks>
     public void StartMoving(Direction direction)
     {
@@ -177,34 +191,48 @@ public sealed class Character
     /// <summary>
     /// Stops autonomous movement started with <see cref="StartMoving"/>. The character stays
     /// where it is and the walk-cycle animation snaps back to the standing frame on the next
-    /// <see cref="Update(double)"/>.
+    /// <see cref="Update(double, TileMap)"/>.
     /// </summary>
     public void StopMoving() => IsMoving = false;
 
     /// <summary>
     /// Advances the simulation of the character by <paramref name="dt"/> seconds. When
     /// <see cref="IsMoving"/> is <see langword="true"/> the character first moves towards its
-    /// current <see cref="Direction"/> by <c>BaseSpeed * dt</c> tiles; the walk-cycle animation
-    /// is then advanced based on elapsed time and movement speed. If the character moved since
-    /// the previous update, the animation accumulator is advanced by <paramref name="dt"/> and
-    /// the number of whole frames due (scaled by <see cref="BaseSpeed"/> and
-    /// <see cref="AnimationCycleSpeed"/>) are stepped, keeping the remainder for the next
-    /// update. If the character did not move, the animation snaps back to the standing frame and
-    /// the accumulator is reset. Called by the engine's update loop once per frame.
+    /// current <see cref="Direction"/> by <c>BaseSpeed * dt</c> tiles; when a map is supplied the
+    /// displacement is resolved against the map's solid tiles and the map edge exactly like the
+    /// player's key-driven movement (see
+    /// <see cref="MovementCollisionResolver.ResolveDisplacement(RPGEngine.Position, double, double, TileMap, double, double)"/>),
+    /// so a fully blocked character stays put. The walk-cycle animation is then advanced based on
+    /// elapsed time and movement speed. If the character moved since the previous update, the
+    /// animation accumulator is advanced by <paramref name="dt"/> and the number of whole frames
+    /// due (scaled by <see cref="BaseSpeed"/> and <see cref="AnimationCycleSpeed"/>) are stepped,
+    /// keeping the remainder for the next update. If the character did not move, the animation
+    /// snaps back to the standing frame and the accumulator is reset. Called by the engine's
+    /// update loop once per frame.
     /// </summary>
     /// <param name="dt">The elapsed time in seconds.</param>
+    /// <param name="map">The map whose solid tiles (and edge) resolve the autonomous
+    /// displacement. When <see langword="null"/> (no map), the displacement is applied raw.</param>
     /// <remarks>
     /// The existing animation logic detects movement via <c>Position != _lastUpdatePosition</c>,
     /// so the walk cycle advances while the character is moving (whether driven by
     /// <see cref="StartMoving"/> or by the engine's key input) and snaps to the standing frame
-    /// once it stops. Autonomous movement applied here is <em>not</em> collision-resolved by the
-    /// engine (collision resolution applies to the player only).
+    /// once it stops (including when a fully blocked character is resolved to the same position).
+    /// Autonomous movement is collision-resolved when the engine supplies a map; without a map the
+    /// displacement is applied raw, preserving the historical behavior for hosts that drive
+    /// characters without an engine map.
     /// </remarks>
-    internal void Update(double dt)
+    internal void Update(double dt, TileMap? map = null)
     {
         if (IsMoving)
         {
-            Position += Direction.Delta() * (BaseSpeed * dt);
+            var delta = Direction.Delta() * (BaseSpeed * dt);
+            Position = map is null
+                ? Position + delta
+                : MovementCollisionResolver.ResolveDisplacement(
+                    Position, delta.X, delta.Y, map,
+                    MovementCollisionResolver.CollisionBoxHalfWidth,
+                    MovementCollisionResolver.CollisionBoxHeightAboveFeet);
         }
 
         var moved = Position != _lastUpdatePosition;

--- a/src/RPGEngine/Core/MovementCollisionResolver.cs
+++ b/src/RPGEngine/Core/MovementCollisionResolver.cs
@@ -6,28 +6,34 @@ namespace RPGEngine;
 /// Resolves a character's displacement against the map's solid tiles. A <em>cardinal</em>
 /// (single-axis) move uses <em>per-axis slide-to-boundary clamping</em> (see <see cref="Resolve"/>):
 /// for each axis the full requested displacement is applied when the resulting collision
-/// footprint (the fixed 1×1 tile lower-body box of the player, see
-/// <see cref="GameEngine.PlayerFootprintOverlapsSolid"/>) is clear; otherwise the axis is clamped
-/// to the <em>closest legal position</em> on that axis, so the leading edge of the footprint stops
-/// exactly at the near edge of the first blocking solid tile (or at the map edge, which
-/// <see cref="TileMap.IsSolid"/> treats as solid). A <em>diagonal</em> (both-axis) move is
-/// <em>all-or-nothing</em> (see <see cref="ResolveDiagonal"/>): it is applied only when the full
-/// displacement is clear on <em>both</em> axes, otherwise the character stays put — a diagonal
-/// into a wall where only one axis is free stops the character entirely instead of sliding along
-/// the free axis.
+/// footprint (the fixed 0.5×0.5-tile lower-body box of every character, see
+/// <see cref="CollisionBoxHalfWidth"/> and <see cref="CollisionBoxHeightAboveFeet"/>) is clear;
+/// otherwise the axis is clamped to the <em>closest legal position</em> on that axis, so the
+/// leading edge of the footprint stops exactly at the near edge of the first blocking solid tile
+/// (or at the map edge, which <see cref="TileMap.IsSolid"/> treats as solid). A <em>diagonal</em>
+/// (both-axis) move is <em>all-or-nothing</em> (see <see cref="ResolveDiagonal"/>): it is applied
+/// only when the full displacement is clear on <em>both</em> axes, otherwise the character stays
+/// put — a diagonal into a wall where only one axis is free stops the character entirely instead
+/// of sliding along the free axis.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The footprint is the fixed 1×1 tile (48×48 px) box representing the lower body of the
-/// player sprite, anchored at the feet: with the half-width <c>hw</c> (0.5 tiles) and the height
-/// above the feet <c>heightAboveFeet</c> (1.0 tiles, i.e. <c>hw = 0.5</c> and
-/// <c>heightAboveFeet = 1.0</c> for the standard 48 px tile) the rectangle is
+/// The footprint is the fixed 0.5×0.5-tile (24×24 px at 48 px tiles) box representing the lower
+/// body of a character sprite, anchored at the feet: with the half-width <c>hw</c> (0.25 tiles)
+/// and the height above the feet <c>heightAboveFeet</c> (0.5 tiles, i.e. <c>hw = 0.25</c> and
+/// <c>heightAboveFeet = 0.5</c> for the standard 48 px tile) the rectangle is
 /// <c>x ∈ [pos.X - hw, pos.X + hw]</c>, <c>y ∈ [pos.Y - heightAboveFeet, pos.Y]</c>.
-/// The middle of the feet sits at the bottom-centre of the box (<c>(24, 48)</c> in pixels when
+/// The middle of the feet sits at the bottom-centre of the box (<c>(12, 24)</c> in pixels when
 /// the box origin is its upper-left). The box is independent of the rendered sprite size: a
 /// taller/wider spritesheet never widens the collision box, so a 1-tile-wide corridor always
 /// fits regardless of the spritesheet's cell size. Out-of-bounds tiles are solid (the map edge
 /// blocks movement), exactly like <see cref="TileMap.IsAreaSolid"/>.
+/// </para>
+/// <para>
+/// The player and every NPC share this footprint: the engine resolves the player's key-driven
+/// and auto-walk movement and every character's <c>StartMoving</c> autonomous movement with
+/// <see cref="ResolveDisplacement"/> against the map's solid tiles, so all characters collide
+/// with the world exactly alike.
 /// </para>
 /// <para>
 /// For a <em>cardinal</em> move each axis is clamped independently and the result of the X axis
@@ -36,17 +42,17 @@ namespace RPGEngine;
 /// revert-the-whole-step rule, the clamp always moves the leading edge exactly onto the boundary,
 /// so the feet stop exactly at the solid tile's edge (matching click-to-move) with no
 /// one-frame-step gap and no floating-point overshoot accumulation.
-/// <see cref="GameEngine.ClampPlayerToMap"/> remains the post-move safety net.
+/// <see cref="GameEngine.ClampPlayerToMap"/> remains the player-only post-move safety net.
 /// </para>
 /// <para>
 /// A <em>diagonal</em> move is <em>all-or-nothing</em> (<see cref="ResolveDiagonal"/>): the
-/// player moves diagonally only when the full displacement is clear on both axes. When either
-/// axis is blocked — e.g. a wall or the map edge on the X axis while Y is free — the player
+/// character moves diagonally only when the full displacement is clear on both axes. When either
+/// axis is blocked — e.g. a wall or the map edge on the X axis while Y is free — the character
 /// stops entirely (no wall-sliding along the free axis), so the engine can report a collision
-/// stop. This prevents diagonal corner-cutting and makes the player's movement state honest:
-/// pressing a diagonal pair against a wall keeps the player idle rather than reporting endless
-/// movement along the free axis. Cardinal moves keep the slide-to-boundary clamp, so a straight
-/// move into a wall still stops exactly at the boundary.
+/// stop. This prevents diagonal corner-cutting and makes the movement state honest: pressing a
+/// diagonal pair against a wall keeps the character idle rather than reporting endless movement
+/// along the free axis. Cardinal moves keep the slide-to-boundary clamp, so a straight move into
+/// a wall still stops exactly at the boundary.
 /// </para>
 /// <para>
 /// The per-axis gained-range scan assumes the starting footprint is legal (never overlapping a
@@ -61,6 +67,31 @@ namespace RPGEngine;
 /// </remarks>
 internal static class MovementCollisionResolver
 {
+    // The character collision footprint: a fixed 0.5×0.5-tile (24×24 px at 48 px tiles) lower-body
+    // box anchored at the feet. Position (the sprite's middle-bottom) is the bottom-centre of the
+    // box: x ∈ [pos.X - 0.25, pos.X + 0.25], y ∈ [pos.Y - 0.5, pos.Y] in tiles.
+    internal const double CollisionBoxHalfWidth = 0.25;
+    internal const double CollisionBoxHeightAboveFeet = 0.5;
+
+    /// <summary>
+    /// Resolves a full displacement: a <em>diagonal</em> move (both <paramref name="dx"/> and
+    /// <paramref name="dy"/> non-zero) is <em>all-or-nothing</em> (<see cref="ResolveDiagonal"/>),
+    /// while a <em>cardinal</em> move keeps the per-axis slide-to-boundary clamping
+    /// (<see cref="Resolve"/>). Mirrors the branching the engine's key-driven player movement
+    /// uses, so the player and every character's autonomous movement share one resolution path.
+    /// </summary>
+    /// <param name="from">The starting feet position, in tiles.</param>
+    /// <param name="dx">The requested horizontal displacement, in tiles.</param>
+    /// <param name="dy">The requested vertical displacement, in tiles.</param>
+    /// <param name="map">The map whose solid tiles (and edge) block movement.</param>
+    /// <param name="halfWidth">The half-width of the collision footprint (<c>hw</c>), in tiles.</param>
+    /// <param name="heightAboveFeet">The height the collision footprint extends above the feet, in tiles.</param>
+    /// <returns>The resolved feet position.</returns>
+    internal static Position ResolveDisplacement(Position from, double dx, double dy, TileMap map, double halfWidth, double heightAboveFeet)
+        => dx != 0 && dy != 0
+            ? ResolveDiagonal(from, dx, dy, map, halfWidth, heightAboveFeet)
+            : Resolve(from, dx, dy, map, halfWidth, heightAboveFeet);
+
     /// <summary>
     /// Returns the position with the X displacement applied (clamped to the boundary if it would
     /// overlap a solid tile or leave the map), then the Y displacement applied the same way,
@@ -73,10 +104,9 @@ internal static class MovementCollisionResolver
     /// <param name="dy">The requested vertical displacement, in tiles.</param>
     /// <param name="map">The map whose solid tiles (and edge) block movement.</param>
     /// <param name="halfWidth">The half-width of the collision footprint (<c>hw</c>), in tiles:
-    /// 0.5 for the player's fixed 1×1 tile lower-body box.</param>
+    /// 0.25 for the fixed 0.5×0.5-tile lower-body box.</param>
     /// <param name="heightAboveFeet">The height the collision footprint extends above the feet,
-    /// in tiles: 1.0 for the player's fixed 1×1 tile lower-body box (its bottom edge is the
-    /// feet).</param>
+    /// in tiles: 0.5 for the fixed 0.5×0.5-tile lower-body box (its bottom edge is the feet).</param>
     /// <returns>The resolved feet position: either the full requested displacement when it is
     /// legal, the closest legal position on each blocked axis, or (when the starting footprint
     /// was already illegal and the move would keep it illegal) the starting position.</returns>
@@ -138,8 +168,8 @@ internal static class MovementCollisionResolver
         // the full displacement is clear on BOTH axes - the per-axis gained-range scans below
         // detect any newly-entered solid column or row along the whole displacement, so a large
         // diagonal step cannot tunnel through a thin wall either. When either axis is blocked, the
-        // move is refused entirely rather than sliding along the free axis, so the player stops at
-        // the first position where one axis is blocked (one diagonal step short of the boundary).
+        // move is refused entirely rather than sliding along the free axis, so the character stops
+        // at the first position where one axis is blocked (one diagonal step short of the boundary).
         var horizontalClear = ClampHorizontal(from, dx, map, halfWidth, heightAboveFeet) == from.X + dx;
         var verticalClear = ClampVertical(from, dy, map, halfWidth, heightAboveFeet, xAfterX: from.X) == from.Y + dy;
 
@@ -159,8 +189,8 @@ internal static class MovementCollisionResolver
     /// overlaps a solid tile (or leaves the map). Reuses <see cref="TileMap.IsAreaSolid"/> with
     /// the same rectangle the engine's <see cref="GameEngine.PlayerFootprintOverlapsSolid"/>
     /// checks, so the resolver and the engine's footprint predicate cannot diverge (the engine's
-    /// predicate delegates here with the player's fixed 1×1 tile box). Internal so the engine
-    /// and the tests share one footprint definition.
+    /// predicate delegates here with the shared fixed 0.5×0.5-tile box). Internal so the engine,
+    /// the characters and the tests share one footprint definition.
     /// </summary>
     /// <param name="position">The feet position, in tiles.</param>
     /// <param name="map">The map whose solid tiles (and edge) block movement.</param>

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -73,20 +73,24 @@ namespace RPGEngine;
 /// invalid (solid / no path), in which case it cancels the walk.
 /// </para>
 /// <para>
-/// When a map is set, the player's displacement is resolved with <em>axis-separated movement
-/// and per-axis slide-to-boundary clamping</em> against the map's solid tiles: each axis is
-/// applied in turn and, when the player's collision footprint would overlap a solid tile or
-/// leave the map (the map edge is solid), it slides to the <em>closest legal position on that
-/// axis</em>, so the leading edge of the footprint stops <em>exactly</em> at the near edge of
-/// the first blocking solid tile (or at the map edge). The footprint is a <em>fixed 1×1 tile
-/// (48×48 px) box representing the lower body of the player sprite</em>, anchored at the feet
-/// (<see cref="Player.Position"/> is the middle-bottom of the sprite; the middle of the feet
-/// sits at the bottom-centre of the box, <c>(24, 48)</c> when the box's origin is its upper-left).
-/// The box is independent of the rendered sprite size, so a 1-tile-wide corridor always fits
-/// regardless of the spritesheet's cell size, and the feet always stop exactly at the solid
-/// tile's edge whether the tile is below, above or beside the player. Clamping keeps that
-/// 1×1 box inside the map. This blocks the player at solid tiles and prevents diagonal
-/// corner-cutting; a <em>cardinal</em> move slides a blocked axis to the exact boundary (the feet
+/// When a map is set, every character's displacement is resolved with <em>axis-separated
+/// movement and per-axis slide-to-boundary clamping</em> against the map's solid tiles: each
+/// axis is applied in turn and, when a character's collision footprint would overlap a solid
+/// tile or leave the map (the map edge is solid), it slides to the <em>closest legal position on
+/// that axis</em>, so the leading edge of the footprint stops <em>exactly</em> at the near edge
+/// of the first blocking solid tile (or at the map edge). The footprint is a <em>fixed
+/// 0.5×0.5-tile (24×24 px at 48 px tiles) box representing the lower body of the
+/// character sprite</em>, anchored at the feet (<see cref="Player.Position"/> is the
+/// middle-bottom of the sprite; the middle of the feet sits at the bottom-centre of the box,
+/// <c>(12, 24)</c> when the box's origin is its upper-left). The box is independent of the
+/// rendered sprite size, so a 1-tile-wide corridor always fits regardless of the spritesheet's
+/// cell size, and the feet always stop exactly at the solid tile's edge whether the tile is
+/// below, above or beside the character. The player's key-driven and auto-walk movement and
+/// every character's autonomous movement (the <c>StartMoving</c>/<c>Update</c> path, e.g. NPCs
+/// in <see cref="Characters"/>) are all resolved with the same shared resolver, so NPCs stop at
+/// solid tiles and at the map edge instead of walking through the world. Clamping keeps that
+/// 0.5×0.5 box inside the map for the player (the player-only post-move safety net). This
+/// blocks characters at solid tiles and prevents diagonal corner-cutting; a <em>cardinal</em> move slides a blocked axis to the exact boundary (the feet
 /// stop exactly at the solid tile's edge, matching click-to-move ("colliding with its feet"),
 /// with no one-frame-step gap and no floating-point overshoot accumulation), while a
 /// <em>diagonal</em> move is <em>all-or-nothing</em>: it is applied only when the full
@@ -151,14 +155,14 @@ public sealed class GameEngine : IDisposable
     // dots). Dots are small markers on top of the minimap map, not full sprites.
     private const float MinimapDotRadius = 3f;
 
-    // The player's collision footprint: a fixed 1x1 tile (48x48 px for a 48px-tile map) box
-    // representing the lower body of the player sprite. Player.Position (the middle-bottom of
-    // the sprite) is the middle of the feet at the bottom-centre of the box: the box spans
-    // x in [pos.X - 0.5, pos.X + 0.5] and y in [pos.Y - 1.0, pos.Y] in tiles. The box is
-    // independent of the rendered sprite size, so a 1-tile-wide corridor always fits regardless
-    // of the spritesheet's cell size, and the feet always stop exactly at the solid tile's edge.
-    internal const double CollisionBoxHalfWidth = 0.25;
-    internal const double CollisionBoxHeightAboveFeet = 0.5;
+    // The character collision footprint is defined once on MovementCollisionResolver (the
+    // footprint authority): the fixed 0.5x0.5-tile (24x24 px at 48 px tiles) lower-body box
+    // anchored at the feet. Player.Position (the middle-bottom of the sprite) is the middle of
+    // the feet at the bottom-centre of the box: the box spans x in [pos.X - 0.25, pos.X + 0.25]
+    // and y in [pos.Y - 0.5, pos.Y] in tiles. The box is independent of the rendered sprite
+    // size, so a 1-tile-wide corridor always fits regardless of the spritesheet's cell size, and
+    // the feet always stop exactly at the solid tile's edge. Player and characters share this
+    // footprint, so autonomous NPC movement collides with the world exactly like the player.
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameEngine"/> class with default state: a
@@ -340,8 +344,10 @@ public sealed class GameEngine : IDisposable
     /// <summary>
     /// Advances the simulation by <paramref name="dt"/> seconds: resolves the movement direction
     /// from the currently pressed keys, moves the player (resolving collisions against the map's
-    /// solid tiles with axis-separated movement when a map is set), clamps it inside the map, and
-    /// advances the walk-cycle animation of the player and every NPC.
+    /// solid tiles with axis-separated movement when a map is set), clamps it inside the map,
+    /// advances every character's autonomous movement (the <c>StartMoving</c>/<c>Update</c> path)
+    /// against the map's solid tiles and the map edge, and advances the walk-cycle animation of
+    /// the player and every NPC.
     /// </summary>
     /// <param name="dt">The elapsed time in seconds since the previous frame.</param>
     public void Update(double dt)
@@ -371,10 +377,14 @@ public sealed class GameEngine : IDisposable
             ClampPlayerToMap();
         }
 
-        Player.Character.Update(dt);
+        // Every character's autonomous movement (the StartMoving/Update path) is resolved
+        // against the map's solid tiles exactly like the player's key-driven movement. The
+        // player's character never uses StartMoving, so this only affects NPC autonomous
+        // movement; the player's key-driven and auto-walk movement is unchanged above.
+        Player.Character.Update(dt, Map);
         foreach (var character in _characters)
         {
-            character.Update(dt);
+            character.Update(dt, Map);
         }
     }
 
@@ -987,8 +997,8 @@ public sealed class GameEngine : IDisposable
                 move.X,
                 move.Y,
                 Map,
-                halfWidth: CollisionBoxHalfWidth,
-                heightAboveFeet: CollisionBoxHeightAboveFeet);
+                halfWidth: MovementCollisionResolver.CollisionBoxHalfWidth,
+                heightAboveFeet: MovementCollisionResolver.CollisionBoxHeightAboveFeet);
         }
 
         if (Player.Position != destination)
@@ -1055,7 +1065,7 @@ public sealed class GameEngine : IDisposable
     /// a map is set, resolves collisions against the map's solid tiles. A <em>cardinal</em>
     /// (single-axis) move uses <em>per-axis slide-to-boundary clamping</em> (see
     /// <see cref="MovementCollisionResolver.Resolve"/>): if the player's collision footprint
-    /// (the fixed 1×1 tile lower-body box anchored at the feet, see
+    /// (the fixed 0.5×0.5-tile lower-body box anchored at the feet, see
     /// <see cref="PlayerFootprintOverlapsSolid"/>) would overlap a solid tile or leave the map
     /// (the map edge is solid, see <see cref="Tiled.TileMap.IsSolid"/>), the axis slides to the
     /// <em>closest legal position</em> so the leading edge stops exactly at the near edge of the
@@ -1085,9 +1095,10 @@ public sealed class GameEngine : IDisposable
     /// actually displaced the player is reported as movement through
     /// <see cref="Player.ReportMovement(Direction)"/> as before (a diagonal move whose full
     /// displacement was clear counts as movement because both axes changed the position).
-    /// NPCs are not moved by the engine (they have no AI yet), so collision resolution only
-    /// applies to the player here; the public <see cref="Tiled.TileMap.IsSolid"/> API is
-    /// available for future NPC logic.
+    /// This method drives the player; every character's autonomous movement (the
+    /// <c>StartMoving</c>/<c>Update</c> path, e.g. NPCs in <see cref="Characters"/>) is resolved
+    /// with the same shared resolver by <see cref="Update(double)"/>, so all characters collide
+    /// with the world exactly like the player.
     /// </remarks>
     private void MovePlayerWithCollisionResolution(Direction direction, double dt)
     {
@@ -1102,35 +1113,23 @@ public sealed class GameEngine : IDisposable
         {
             Player.Position += delta;
         }
-        else if (delta.X != 0 && delta.Y != 0)
-        {
-            // A diagonal move is all-or-nothing: it is applied only when the full displacement is
-            // clear on both axes, so the player never slides along the free axis into a wall (a
-            // diagonal into a wall where only one axis is free stops the player entirely). A
-            // blocked diagonal leaves the position unchanged, so the fully-blocked collision stop
-            // is reported below (Player.Position == before -> ReportBlockedMove).
-            Player.Position = MovementCollisionResolver.ResolveDiagonal(
-                Player.Position,
-                delta.X,
-                delta.Y,
-                Map,
-                halfWidth: CollisionBoxHalfWidth,
-                heightAboveFeet: CollisionBoxHeightAboveFeet);
-        }
         else
         {
-            // A cardinal (single-axis) move keeps the per-axis slide-to-boundary clamping: each
-            // axis moves by the full requested displacement when the destination footprint is
-            // clear, otherwise it slides to the closest legal position on that axis (the leading
-            // edge of the fixed 1x1 tile lower-body box stops exactly at the near edge of the
-            // first blocking solid tile or at the map edge).
-            Player.Position = MovementCollisionResolver.Resolve(
+            // Resolve the displacement with the shared resolver: a diagonal move is all-or-nothing
+            // (applied only when the full displacement is clear on both axes, so the player never
+            // slides along the free axis into a wall), while a cardinal move keeps the per-axis
+            // slide-to-boundary clamping (each axis slides to the closest legal position on that
+            // axis, so the leading edge of the fixed 0.5x0.5-tile lower-body box stops exactly at
+            // the near edge of the first blocking solid tile or at the map edge). A blocked
+            // diagonal leaves the position unchanged, so the fully-blocked collision stop is
+            // reported below (Player.Position == before -> ReportBlockedMove).
+            Player.Position = MovementCollisionResolver.ResolveDisplacement(
                 Player.Position,
                 delta.X,
                 delta.Y,
                 Map,
-                halfWidth: CollisionBoxHalfWidth,
-                heightAboveFeet: CollisionBoxHeightAboveFeet);
+                MovementCollisionResolver.CollisionBoxHalfWidth,
+                MovementCollisionResolver.CollisionBoxHeightAboveFeet);
         }
 
         if (Player.Position == before)
@@ -1152,12 +1151,13 @@ public sealed class GameEngine : IDisposable
     /// <summary>
     /// Returns whether the player's collision footprint with its feet (middle-bottom) at
     /// <paramref name="position"/> overlaps a solid tile or leaves the map. The footprint is the
-    /// <em>fixed 1×1 tile lower-body box</em> (see <see cref="CollisionBoxHalfWidth"/> and
-    /// <see cref="CollisionBoxHeightAboveFeet"/>): it is 1 tile wide and 1 tile tall regardless
-    /// of the rendered sprite size, and it is anchored so the feet (the sprite's middle-bottom)
-    /// sit at <paramref name="position"/> with the middle of the feet at the bottom-centre of
-    /// the box. The map edge (which <see cref="Tiled.TileMap.IsSolid"/> treats as solid) remains
-    /// solid. The overlap is tested with <see cref="Tiled.TileMap.IsAreaSolid"/>, whose
+    /// <em>fixed 0.5×0.5-tile lower-body box</em> (see
+    /// <see cref="MovementCollisionResolver.CollisionBoxHalfWidth"/> and
+    /// <see cref="MovementCollisionResolver.CollisionBoxHeightAboveFeet"/>): it is half a tile
+    /// wide and half a tile tall regardless of the rendered sprite size, and it is anchored so
+    /// the feet (the sprite's middle-bottom) sit at <paramref name="position"/> with the middle
+    /// of the feet at the bottom-centre of the box. The map edge (which
+    /// <see cref="Tiled.TileMap.IsSolid"/> treats as solid) remains solid. The overlap is tested with <see cref="Tiled.TileMap.IsAreaSolid"/>, whose
     /// tile-boundary semantics (a footprint that ends exactly on a tile boundary does not overlap
     /// the next tile) define the exact boundary the per-axis slide-to-boundary clamp in
     /// <see cref="MovePlayerWithCollisionResolution(Direction, double)"/> stops at. This
@@ -1168,30 +1168,33 @@ public sealed class GameEngine : IDisposable
         => MovementCollisionResolver.FootprintOverlaps(
             position,
             Map!,
-            CollisionBoxHalfWidth,
-            CollisionBoxHeightAboveFeet);
+            MovementCollisionResolver.CollisionBoxHalfWidth,
+            MovementCollisionResolver.CollisionBoxHeightAboveFeet);
 
     /// <summary>
-    /// Clamps the player's feet position so its collision footprint (the fixed 1×1 tile
+    /// Clamps the player's feet position so its collision footprint (the fixed 0.5×0.5-tile
     /// lower-body box, see the class remarks) stays inside the map bounds. The feet are clamped
-    /// to <c>x ∈ [0.5, max(0.5, Map.Width - 0.5)]</c> and
-    /// <c>y ∈ [1.0, max(1.0, Map.Height)]</c>, all in tiles — the 1×1 box's left/right edges
-    /// stay at or inside the horizontal map edges and its top edge stays at or below the top map
-    /// edge, while the bottom edge (the feet) never goes below the bottom edge. For the default
-    /// 48×48 sprite with 48 px tiles this is <c>x ∈ [0.5, Map.Width - 0.5]</c>,
-    /// <c>y ∈ [1.0, Map.Height]</c>. Called after every move while a map is set.
+    /// to <c>x ∈ [0.25, max(0.25, Map.Width - 0.25)]</c> and
+    /// <c>y ∈ [0.5, max(0.5, Map.Height)]</c>, all in tiles — the 0.5×0.5 box's left/right
+    /// edges stay at or inside the horizontal map edges and its top edge stays at or below the
+    /// top map edge, while the bottom edge (the feet) never goes below the bottom edge. For the
+    /// default 48×48 sprite with 48 px tiles this is <c>x ∈ [0.25, Map.Width - 0.25]</c>,
+    /// <c>y ∈ [0.5, Map.Height]</c>. Called after every move while a map is set. This is the
+    /// player-only post-move safety net; NPCs are kept in bounds by the solid map edge (see
+    /// <see cref="Tiled.TileMap.IsSolid"/>) through their resolved autonomous movement.
     /// </summary>
     private void ClampPlayerToMap()
     {
-        // The fixed 1x1 tile lower-body box (see the class remarks and the collision constants)
-        // is clamped inside the map: its left/right edges stay within x in [0, Width] and its
-        // top edge (the box extends CollisionBoxHeightAboveFeet above the feet) stays at or
-        // below the top map edge, so the feet never go below the bottom edge (the feet are the
-        // box's bottom edge). For the default 48x48 sprite with 48 px tiles this is
-        // x in [0.5, Map.Width - 0.5], y in [1.0, Map.Height].
-        var minX = CollisionBoxHalfWidth;
-        var maxX = Math.Max(minX, Map!.Width - CollisionBoxHalfWidth);
-        var minY = CollisionBoxHeightAboveFeet;
+        // The fixed 0.5x0.5-tile lower-body box (see the class remarks and the shared collision
+        // constants on MovementCollisionResolver) is clamped inside the map: its left/right
+        // edges stay within x in [0, Width] and its top edge (the box extends
+        // CollisionBoxHeightAboveFeet above the feet) stays at or below the top map edge, so the
+        // feet never go below the bottom edge (the feet are the box's bottom edge). For the
+        // default 48x48 sprite with 48 px tiles this is x in [0.25, Map.Width - 0.25],
+        // y in [0.5, Map.Height].
+        var minX = MovementCollisionResolver.CollisionBoxHalfWidth;
+        var maxX = Math.Max(minX, Map!.Width - MovementCollisionResolver.CollisionBoxHalfWidth);
+        var minY = MovementCollisionResolver.CollisionBoxHeightAboveFeet;
         var maxY = Math.Max(minY, Map.Height);
 
         var position = Player.Position;

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -1,4 +1,6 @@
 using RPGEngine.Sprites;
+using RPGEngine.Tiled;
+using RPGEngine.Tests.Tiled;
 using SkiaSharp;
 using Xunit;
 
@@ -20,6 +22,7 @@ namespace RPGEngine.Tests;
 public class CharacterTests
 {
     private const int StandingFrame = 1; // the frame a fresh/stopped character renders at
+    private const double FrameDt = 1.0 / 60;
 
     // ---------------------------------------------------------------------
     // Acceptance 1: Move with speedFactor == 0 changes only Direction.
@@ -106,7 +109,7 @@ public class CharacterTests
     /// Verifies the walk-cycle animation is time-based and speed-scaled: at
     /// BaseSpeed == AnimationCycleSpeed == 2 (tiles/s, the new defaults) the cycle completes
     /// one full 4-frame cycle (<c>0 → 1 → 2 → 1</c>) per second. A single one-second
-    /// <see cref="Character.Update(double)"/> after moving advances exactly 4 frames and lands
+    /// <see cref="Character.Update(double, RPGEngine.Tiled.TileMap)"/> after moving advances exactly 4 frames and lands
     /// back on the standing frame.
     /// </summary>
     [Fact]
@@ -330,6 +333,151 @@ public class CharacterTests
         Assert.False(character.IsMoving);
         character.StopMoving();
         Assert.False(character.IsMoving);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance (story 64): autonomous movement (StartMoving/Update) is
+    // collision-resolved against the map's solid tiles and the map edge when a
+    // map is supplied, sharing the player's footprint and the same per-axis
+    // slide-to-boundary (cardinal) / all-or-nothing (diagonal) semantics. With
+    // no map the displacement stays raw (the historical behavior).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies StartMoving(Right) + Update(dt, map) against a solid column at x=2 from X=0.5 stops the feet at X = 2.0 - 0.25 = 1.75, and a further update keeps it there.</summary>
+    [Fact]
+    public void StartMoving_WithMap_StopsAtSolidColumnBoundary()
+    {
+        // 4x4 map: a "walls" collision layer with a solid column at x=2 for every row.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+        });
+        var map = TileMap.Load(fixture.MapPath);
+        var character = new Character { BaseSpeed = 2, Position = new Position(0.5, 1.0) };
+
+        character.StartMoving(Direction.Right);
+        character.Update(dt: 0.5, map); // exactly 1 tile right, still clear of the wall
+
+        Assert.Equal(new Position(1.5, 1.0), character.Position);
+
+        // The next step would push the box into the solid tile: the right edge stops exactly at
+        // the tile's left edge (x = 2.0), so the feet reach X = 2.0 - 0.25 = 1.75.
+        character.Update(dt: 0.5, map);
+        Assert.Equal(new Position(1.75, 1.0), character.Position);
+        Assert.True(character.Position.X + 0.25 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
+
+        // A further update keeps it there.
+        character.Update(dt: 0.5, map);
+        Assert.Equal(new Position(1.75, 1.0), character.Position);
+    }
+
+    /// <summary>Verifies StartMoving + Update(dt, map) on a map with no collision layer moves exactly BaseSpeed * dt tiles (map present, no solid tiles — regression).</summary>
+    [Fact]
+    public void StartMoving_WithMap_NoCollisionLayer_MovesExactly()
+    {
+        // A 4x4 map with a ground layer only (no collision layer).
+        using var fixture = CreateFilledMapFixture(4, 4);
+        var map = TileMap.Load(fixture.MapPath);
+        var character = new Character { BaseSpeed = 2, Position = new Position(1.0, 1.0) };
+
+        character.StartMoving(Direction.Right);
+        character.Update(dt: 1, map); // exactly BaseSpeed * dt = 2 tiles right
+
+        Assert.Equal(new Position(3.0, 1.0), character.Position);
+        Assert.True(character.IsMoving);
+    }
+
+    /// <summary>Verifies a diagonal autonomous move into a wall where only X is blocked stops the character entirely (no slide along the free Y axis): diagonal movement is all-or-nothing.</summary>
+    [Fact]
+    public void StartMoving_WithMap_DiagonalIntoWall_StopsEntirely()
+    {
+        // 5x5 map: a "walls" collision layer with a solid column at x=3 for every row.
+        var gids = new uint[25];
+        for (var y = 0; y < 5; y++)
+        {
+            gids[(y * 5) + 3] = 1;
+        }
+
+        using var fixture = CreateCollisionMapFixture(5, 5, gids);
+        var map = TileMap.Load(fixture.MapPath);
+        var character = new Character { BaseSpeed = 2, Position = new Position(2.75, 4.0) };
+
+        // Start flush against the left edge of the wall column (the fixed 0.5x0.5 box's right
+        // edge is exactly at x=3). Moving DownRight, X is blocked while Y is free.
+        character.StartMoving(Direction.DownRight);
+        character.Update(dt: 0.5, map);
+
+        // Diagonal is all-or-nothing: the character stops entirely, no slide along Y.
+        Assert.Equal(new Position(2.75, 4.0), character.Position);
+
+        // A further update keeps it there.
+        character.Update(dt: 0.5, map);
+        Assert.Equal(new Position(2.75, 4.0), character.Position);
+    }
+
+    /// <summary>Verifies StartMoving(Left) near the left map edge stops the character at the edge (never leaves the map): the left edge of the 0.5x0.5 box stops at x = 0, so the feet stop at X = 0.25.</summary>
+    [Fact]
+    public void StartMoving_WithMap_StopsAtLeftMapEdge()
+    {
+        // A 2x2 map with a ground layer only (no collision layer): only the map edge is solid.
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var map = TileMap.Load(fixture.MapPath);
+        var character = new Character { BaseSpeed = 2, Position = new Position(0.5, 1.5) };
+
+        character.StartMoving(Direction.Left);
+
+        // A single large step: the box's left edge (feet X - 0.25) stops at the left map edge.
+        character.Update(dt: 10, map);
+
+        Assert.Equal(0.25, character.Position.X, precision: 9);
+        Assert.True(character.Position.X - 0.25 >= 0.0 - 1e-9, "The footprint must never leave the map.");
+    }
+
+    /// <summary>Verifies a fully blocked autonomous character: Position is unchanged and the walk cycle snaps to the standing frame on the next Update.</summary>
+    [Fact]
+    public void StartMoving_WithMap_FullyBlocked_SnapsToStandingFrame()
+    {
+        // 4x4 map: a "walls" collision layer with a solid column at x=2 for every row.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+        });
+        var map = TileMap.Load(fixture.MapPath);
+        var character = new Character { BaseSpeed = 2, Position = new Position(0.5, 1.0) };
+        character.StartMoving(Direction.Right);
+
+        // Walk into the wall: after enough updates the character is blocked at the boundary.
+        for (var frame = 0; frame < 300; frame++)
+        {
+            character.Update(FrameDt, map);
+        }
+
+        Assert.Equal(1.75, character.Position.X, precision: 9);
+
+        // Now fully blocked: a further update leaves the position unchanged and the walk cycle
+        // (which detects movement via Position != _lastUpdatePosition) snaps to the standing frame.
+        var before = character.Position;
+        character.Update(FrameDt, map);
+        Assert.Equal(before, character.Position);
+        Assert.Equal(StandingFrame, character.AnimationFrame);
+    }
+
+    /// <summary>Verifies Update(dt) with no map keeps the raw movement behavior: the autonomous displacement is applied directly (no collision resolution).</summary>
+    [Fact]
+    public void Update_WithoutMap_MovesRawDisplacement()
+    {
+        var character = new Character { BaseSpeed = 2, Position = new Position(0, 0) };
+
+        character.StartMoving(Direction.Right);
+        character.Update(dt: 1); // no map: exactly 2 tiles right, raw
+
+        Assert.Equal(new Position(2, 0), character.Position);
+        Assert.True(character.IsMoving);
     }
 
     // ---------------------------------------------------------------------
@@ -702,4 +850,36 @@ public class CharacterTests
         Assert.Equal(expected, bitmap.GetPixel(0, 0));
         Assert.Equal(expected, bitmap.GetPixel(width - 1, height - 1));
     }
+
+    // ---------------------------------------------------------------------
+    // Helpers for the collision-resolved autonomous movement tests: build
+    // map fixtures (a filled walkable ground layer and an optional "walls"
+    // collision layer) exactly like the engine collision tests, so the
+    // character-under-test resolves against the same Tiled collision model.
+    // ---------------------------------------------------------------------
+
+    /// <summary>Creates a map fixture filled with red tiles in a single "ground" layer.</summary>
+    private static TiledTestFixture CreateFilledMapFixture(int width, int height)
+        => new(width, height, new[] { FilledLayer(width, height) });
+
+    /// <summary>
+    /// Creates a map fixture with a filled "ground" layer (walkable) and a "walls" collision
+    /// layer declaring the Tiled <c>is_collision</c> bool property set to <c>true</c>.
+    /// </summary>
+    private static TiledTestFixture CreateCollisionMapFixture(int width, int height, uint[] collisionGids)
+        => new(
+            width,
+            height,
+            new[]
+            {
+                FilledLayer(width, height),
+                new TileLayerSpec(
+                    "walls",
+                    collisionGids,
+                    Properties: new[] { new FixtureProperty("is_collision", "bool", "true") }),
+            });
+
+    /// <summary>Builds a fully filled single-layer spec for a map of the given size.</summary>
+    private static TileLayerSpec FilledLayer(int width, int height)
+        => new("ground", Enumerable.Repeat(1u, width * height).ToArray());
 }

--- a/tests/RPGEngine.Tests/GameEngineClickToMoveTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineClickToMoveTests.cs
@@ -137,7 +137,7 @@ public partial class GameEngineTests
 
     /// <summary>
     /// Verifies a click on a reachable target behind a wall computes a detour around the wall and
-    /// the player walks to the target. The wall is two tiles tall (rows 0-1) so the fixed 1×1
+    /// the player walks to the target. The wall is two tiles tall (rows 0-1) so the fixed 0.5×0.5
     /// tile lower-body box can pass through the gap at row 3 with its whole height clear of the
     /// wall's bottom edge.
     /// </summary>
@@ -145,8 +145,8 @@ public partial class GameEngineTests
     public void Click_OnReachableTargetBehindWall_WalksAroundTheWall()
     {
         // 7x5 map: a "walls" collision layer with a solid column at x=3 for rows 0..1, leaving a
-        // gap at rows 2-4 so the target at (5,3) is reachable only through the gap (the 1x1 box
-        // needs the whole 1-tile height clear, so it passes at row 3).
+        // gap at rows 2-4 so the target at (5,3) is reachable only through the gap (the 0.5x0.5
+        // box needs its footprint clear, so it passes at row 3).
         var gids = new uint[35];
         gids[(0 * 7) + 3] = 1;
         gids[(1 * 7) + 3] = 1;
@@ -292,9 +292,9 @@ public partial class GameEngineTests
         Assert.Equal(new Position(0, 0), engine.Player.Position);
 
         engine.Update(FrameDt);
-        // The clamp keeps the player's fixed 1x1 lower-body box in the map: the default feet
-        // start at (0, 0) and are clamped to (0.5, 1.0) (the box's left edge at x = 0 and its
+        // The clamp keeps the player's fixed 0.5x0.5 lower-body box in the map: the default feet
+        // start at (0, 0) and are clamped to (0.25, 0.5) (the box's left edge at x = 0 and its
         // top edge at y = 0).
-        Assert.Equal(new Position(0.5, 1.0), engine.Player.Position);
+        Assert.Equal(new Position(0.25, 0.5), engine.Player.Position);
     }
 }

--- a/tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineCollisionOnMoveTests.cs
@@ -51,7 +51,7 @@ public class GameEngineCollisionOnMoveTests
         }
 
         // The player stopped at the solid column: its footprint never enters it.
-        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
+        Assert.True(engine.Player.Position.X + 0.25 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
 
         // Exact event sequence: one (true, Right) on start, then exactly one (false, Right) on
         // the collision stop, and nothing more while D stays held.
@@ -114,7 +114,7 @@ public class GameEngineCollisionOnMoveTests
     public void Update_TurnWhileBlocked_FiresOnMoveFalseForNewDirectionOnce()
     {
         // 4x4 map with a solid column at x=2 (blocks Right) and a solid row at y=0 (blocks Up).
-        // The player starts with feet at y=2.0 so the fixed 1x1 box (y in [1.0, 2.0]) just
+        // The player starts with feet at y=1.5 so the fixed 0.5x0.5 box (y in [1.0, 1.5]) just
         // touches the solid row's bottom edge (y=1.0) without overlapping it, leaving the start
         // legal and Up immediately blocked.
         var gids = new uint[16];
@@ -130,7 +130,7 @@ public class GameEngineCollisionOnMoveTests
         using var fixture = CreateCollisionMapFixture(4, 4, gids);
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
-        engine.Player.Position = new Position(0.5, 2.0);
+        engine.Player.Position = new Position(0.5, 1.5);
 
         var events = new List<PlayerMoveEventArgs>();
         engine.Player.OnMove += (_, e) => events.Add(e);
@@ -143,7 +143,7 @@ public class GameEngineCollisionOnMoveTests
         }
 
         // Blocked at the wall (footprint never enters the solid column), facing Right.
-        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
+        Assert.True(engine.Player.Position.X + 0.25 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
         Assert.Equal(new PlayerMoveEventArgs(false, Direction.Right), events[^1]);
         events.Clear();
 
@@ -180,10 +180,11 @@ public class GameEngineCollisionOnMoveTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Start flush against the left edge of the wall column: moving UpRight, the X
+        // Start flush against the left edge of the wall column: the fixed 0.5x0.5 box's right
+        // edge (feet X + 0.25) is exactly at the wall column x=3, so moving UpRight, the X
         // displacement is blocked while Y is free. Diagonal movement is all-or-nothing, so the
         // player stops entirely instead of sliding straight up along the wall.
-        engine.Player.Position = new Position(2.5, 4.0);
+        engine.Player.Position = new Position(2.75, 4.0);
 
         var events = new List<PlayerMoveEventArgs>();
         engine.Player.OnMove += (_, e) => events.Add(e);
@@ -197,7 +198,7 @@ public class GameEngineCollisionOnMoveTests
         }
 
         // The player never moved: fully blocked on the first frame (X blocked, Y free - no slide).
-        Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(2.75, engine.Player.Position.X, precision: 6);
         Assert.Equal(4.0, engine.Player.Position.Y, precision: 6);
 
         // The blocked diagonal was reported exactly once: the player was idle facing Down, so
@@ -247,7 +248,7 @@ public class GameEngineCollisionOnMoveTests
         var stopped = engine.Player.Position;
         Assert.True(stopped.X > 1.5, "The player moved right before stopping.");
         Assert.True(stopped.Y < 4.0, "The player moved up before stopping.");
-        Assert.True(stopped.X + 0.5 <= 3.0 + 1e-9, "The footprint must never overlap the solid column.");
+        Assert.True(stopped.X + 0.25 <= 3.0 + 1e-9, "The footprint must never overlap the solid column.");
 
         // Exact sequence: (true, UpRight) on start, then exactly one (false, UpRight) when one
         // axis became blocked, and nothing more while W+D stay held.
@@ -332,12 +333,12 @@ public class GameEngineCollisionOnMoveTests
         // The player is fully blocked in the top-left corner region. All-or-nothing diagonal
         // movement stops the player at the first position where either axis is blocked (here the
         // Y axis, one diagonal step short of the top map edge, since a diagonal cannot take a
-        // partial step onto the boundary): the fixed 1x1 lower-body box never leaves the map (feet
-        // x in [0.5, 1.5], y in [1.0, 2.0]), and a further frame leaves both the position and the
-        // events unchanged.
+        // partial step onto the boundary): the fixed 0.5x0.5 lower-body box never leaves the map
+        // (feet x in [0.25, 1.75], y in [0.5, 2.0]), and a further frame leaves both the position
+        // and the events unchanged.
         var blockedPosition = engine.Player.Position;
-        Assert.True(blockedPosition.X >= 0.5 - 1e-9 && blockedPosition.X < 1.1, "The player must be stopped in the top-left corner region.");
-        Assert.True(blockedPosition.Y >= 1.0 - 1e-9 && blockedPosition.Y < 1.1, "The player must be stopped near the top map edge.");
+        Assert.True(blockedPosition.X >= 0.25 - 1e-9 && blockedPosition.X < 1.1, "The player must be stopped in the top-left corner region.");
+        Assert.True(blockedPosition.Y >= 0.5 - 1e-9 && blockedPosition.Y < 0.6, "The player must be stopped near the top map edge.");
 
         // Exact sequence: (true, UpLeft) when the walk started, then exactly one (false, UpLeft)
         // when both axes became blocked, and nothing more while W+A stay held.

--- a/tests/RPGEngine.Tests/GameEngineCollisionTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineCollisionTests.cs
@@ -15,13 +15,14 @@ namespace RPGEngine.Tests;
 public partial class GameEngineTests
 {
     // ---------------------------------------------------------------------
-    // Acceptance (story 23, updated by story 56): the player is clamped inside
-    // the map using the fixed 1×1 tile lower-body collision box. The box (48×48
-    // px, the lower body of the sprite) is independent of the rendered sprite
-    // size, so clamping is identical for the default 48×48 sprite and a larger
-    // 78×108 sprite: feet x ∈ [0.5, Map.Width - 0.5], y ∈ [1.0, Map.Height].
+    // Acceptance (story 23, updated by story 56 and story 64): the player is
+    // clamped inside the map using the fixed 0.5×0.5-tile lower-body collision
+    // box. The box (24×24 px at 48 px tiles, the lower body of the sprite) is
+    // independent of the rendered sprite size, so clamping is identical for the
+    // default 48×48 sprite and a larger 78×108 sprite: feet x ∈ [0.25,
+    // Map.Width - 0.25], y ∈ [0.5, Map.Height].
     // ---------------------------------------------------------------------
-    /// <summary>Verifies ClampPlayerToMap clamps the fixed 1×1 tile lower-body box regardless of the rendered sprite size (a 78×108 sheet clamps exactly like the default sprite).</summary>
+    /// <summary>Verifies ClampPlayerToMap clamps the fixed 0.5×0.5-tile lower-body box regardless of the rendered sprite size (a 78×108 sheet clamps exactly like the default sprite).</summary>
     [Fact]
     public void ClampPlayerToMap_UsesFixedOneTileBox_RegardlessOfSpriteSize()
     {
@@ -29,7 +30,7 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
 
         // A larger spritesheet (78×108 cells) must not widen or raise the collision box: the
-        // clamp still uses the fixed 1×1 tile lower-body box (the head sticks out visually but
+        // clamp still uses the fixed 0.5×0.5-tile lower-body box (the head sticks out visually but
         // never participates in collision/clamping).
         using (var stream = CharacterTestHelper.CreateSheetStream(seed: 1, width: 936, height: 864))
         {
@@ -37,24 +38,24 @@ public partial class GameEngineTests
         }
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
-        // Beyond the bottom-right corner: the 1×1 box clamps so its right edge (feet X + 0.5)
-        // stays at the map's right edge and its bottom edge (the feet) at the bottom edge:
-        // x = 10 - 0.5 = 9.5, y = 10.
+        // Beyond the bottom-right corner: the 0.5×0.5 box clamps so its right edge (feet X +
+        // 0.25) stays at the map's right edge and its bottom edge (the feet) at the bottom edge:
+        // x = 10 - 0.25 = 9.75, y = 10.
         engine.Player.Position = new Position(1000, 1000);
         engine.Update(FrameDt);
-        Assert.Equal(10 - 0.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(10 - 0.25, engine.Player.Position.X, precision: 6);
         Assert.Equal(10, engine.Player.Position.Y, precision: 6);
 
-        // Negative position clamps the feet to the top-left: the box's left edge (feet X - 0.5)
-        // at the left map edge (x = 0.5) and its top edge (feet Y - 1.0) at the top map edge
-        // (y = 1.0).
+        // Negative position clamps the feet to the top-left: the box's left edge (feet X - 0.25)
+        // at the left map edge (x = 0.25) and its top edge (feet Y - 0.5) at the top map edge
+        // (y = 0.5).
         engine.Player.Position = new Position(-100, -100);
         engine.Update(FrameDt);
-        Assert.Equal(0.5, engine.Player.Position.X, precision: 6);
-        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(0.25, engine.Player.Position.X, precision: 6);
+        Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
     }
 
-    /// <summary>Verifies the fixed 1×1 box clamp for a 78×108 sprite through ComputeCameraOrigin and rendered output.</summary>
+    /// <summary>Verifies the fixed 0.5×0.5 box clamp for a 78×108 sprite through ComputeCameraOrigin and rendered output.</summary>
     [Fact]
     public void ClampPlayerToMap_LargeSheet_VerifiedViaCameraAndRender()
     {
@@ -69,20 +70,20 @@ public partial class GameEngineTests
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 
         engine.Player.Position = new Position(1000, 1000);
-        engine.Update(FrameDt); // clamps the fixed 1×1 box to (9.5, 10)
+        engine.Update(FrameDt); // clamps the fixed 0.5×0.5 box to (9.75, 10)
 
         // The camera origin clamps to the map: maxX = maxY = 10 - 240/48 = 5 tiles.
         Assert.Equal(new Position(5, 5), engine.ComputeCameraOrigin(canvasSize, canvasSize));
 
         // The 78×108 sprite is anchored at its middle-bottom (feet): with the player's feet at
-        // (9.5, 10) tiles the screen feet are ((9.5-5)*48, (10-5)*48) = (216, 240) and the
-        // sprite top-left is (216 - 39, 240 - 108) = (177, 132); its centre is (216, 186).
+        // (9.75, 10) tiles the screen feet are ((9.75-5)*48, (10-5)*48) = (228, 240) and the
+        // sprite top-left is (228 - 39, 240 - 108) = (189, 132); its centre is (228, 186).
         using var bitmap = Render(engine, canvasSize, canvasSize);
         var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
-        Assert.Equal(expected, bitmap.GetPixel(177 + 39, 132 + 54));
+        Assert.Equal(expected, bitmap.GetPixel(189 + 39, 132 + 54));
     }
 
-    /// <summary>Verifies ClampPlayerToMap keeps the default 48×48 sprite's fixed 1×1 tile lower-body box in the map (feet x ∈ [0.5, 9.5], y ∈ [1.0, 10]).</summary>
+    /// <summary>Verifies ClampPlayerToMap keeps the default 48×48 sprite's fixed 0.5×0.5-tile lower-body box in the map (feet x ∈ [0.25, 9.75], y ∈ [0.5, 10]).</summary>
     [Fact]
     public void ClampPlayerToMap_DefaultSprite_ClampsFeetFootprint()
     {
@@ -90,19 +91,19 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Beyond the bottom-right corner: the 1×1 box's half-width is 0.5 tiles, so the feet
-        // clamp to x = 10 - 0.5 = 9.5 and y = 10 (the box's bottom edge, the feet, at the bottom).
+        // Beyond the bottom-right corner: the 0.5×0.5 box's half-width is 0.25 tiles, so the feet
+        // clamp to x = 10 - 0.25 = 9.75 and y = 10 (the box's bottom edge, the feet, at the bottom).
         engine.Player.Position = new Position(1000, 1000);
         engine.Update(FrameDt);
-        Assert.Equal(9.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(9.75, engine.Player.Position.X, precision: 6);
         Assert.Equal(10, engine.Player.Position.Y, precision: 6);
 
-        // Negative position clamps the feet to the top-left: x = 0.5 (left edge at 0), and
-        // y = 1.0 (the box's top edge at the top map edge y = 0).
+        // Negative position clamps the feet to the top-left: x = 0.25 (left edge at 0), and
+        // y = 0.5 (the box's top edge at the top map edge y = 0).
         engine.Player.Position = new Position(-100, -100);
         engine.Update(FrameDt);
-        Assert.Equal(0.5, engine.Player.Position.X, precision: 6);
-        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(0.25, engine.Player.Position.X, precision: 6);
+        Assert.Equal(0.5, engine.Player.Position.Y, precision: 6);
     }
 
     // ---------------------------------------------------------------------
@@ -128,21 +129,22 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // The default 48x48 sprite collides with a fixed 1x1 tile lower-body box (1 tile wide,
-        // 1 tile tall, feet at the bottom-centre). Start at (0.5, 1.0) and hold D.
+        // The default 48x48 sprite collides with a fixed 0.5x0.5-tile lower-body box (half a
+        // tile wide, half a tile tall, feet at the bottom-centre). Start at (0.5, 1.0) and hold D.
         engine.Player.Position = new Position(0.5, 1.0);
         engine.Input(Key.D, true);
 
-        // Move right by exactly 1 tile (dt = 0.5 at 2 tiles/s): the feet reach X = 1.5, where
-        // the box's right edge [1.0, 2.0] just touches the solid tile at x = 2.0.
+        // Move right by exactly 1 tile (dt = 0.5 at 2 tiles/s): the feet reach X = 1.5, still
+        // clear of the solid tile (the box's right edge is at 1.75).
         engine.Update(dt: 0.5);
         Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
 
-        // The next step would push the box into the solid tile and is clamped back.
+        // The next step would push the box into the solid tile and is clamped back: the right
+        // edge stops exactly at the tile's left edge (x = 2.0), so the feet reach X = 1.75.
         engine.Update(dt: 0.5);
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 6);
         Assert.Equal(1.0, engine.Player.Position.Y, precision: 6); // straight line, Y unchanged
-        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
+        Assert.True(engine.Player.Position.X + 0.25 <= 2.0 + 1e-9, "The footprint must never overlap the solid tile.");
         Assert.Equal(Direction.Right, engine.Player.Direction);
     }
 
@@ -165,7 +167,7 @@ public partial class GameEngineTests
         engine.Input(Key.S, true);
 
         // Move down by exactly 0.5 tiles (dt = 0.25 at 2 tiles/s): the feet reach Y = 2.0, where
-        // the fixed 1x1 box's bottom edge (the feet) just touches the solid row at y = 2.0.
+        // the fixed 0.5x0.5 box's bottom edge (the feet) just touches the solid row at y = 2.0.
         engine.Update(dt: 0.25);
         Assert.Equal(2.0, engine.Player.Position.Y, precision: 6);
 
@@ -192,11 +194,11 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Start flush against the left edge of the wall column (x=3): the fixed 1x1 box spans
-        // [2,3) horizontally at feet x=2.5. Moving UpRight, the X displacement is blocked by the
-        // wall while Y is free; diagonal movement is all-or-nothing, so the player stays put
-        // instead of sliding straight up along the wall.
-        engine.Player.Position = new Position(2.5, 4.0);
+        // Start flush against the left edge of the wall column (x=3): the fixed 0.5x0.5 box
+        // spans [2.75, 3.0) horizontally at feet x=2.75. Moving UpRight, the X displacement is
+        // blocked by the wall while Y is free; diagonal movement is all-or-nothing, so the player
+        // stays put instead of sliding straight up along the wall.
+        engine.Player.Position = new Position(2.75, 4.0);
         engine.Input(Key.W, true);
         engine.Input(Key.D, true);
 
@@ -205,9 +207,9 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // The player never moved: X stays at the wall's left edge (2.5) and Y stays at 4.0 (no
+        // The player never moved: X stays at the wall's left edge (2.75) and Y stays at 4.0 (no
         // sliding along the free axis).
-        Assert.Equal(2.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(2.75, engine.Player.Position.X, precision: 6);
         Assert.Equal(4.0, engine.Player.Position.Y, precision: 6);
     }
 
@@ -220,7 +222,7 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Feet in row 1 so the fixed 1x1 tile box (y in [0.5, 1.5]) is fully inside the map.
+        // Feet in row 1 so the fixed 0.5x0.5 tile box (y in [1.0, 1.5]) is fully inside the map.
         engine.Player.Position = new Position(0.5, 1.5);
         engine.Input(Key.D, true);
 
@@ -235,40 +237,40 @@ public partial class GameEngineTests
     }
 
     /// <summary>
-    /// Verifies a solid tile anywhere within the fixed 1×1 tile lower-body box blocks the
-    /// player: the box covers the whole body of the default 48×48 sprite, so a tile at "head"
-    /// level (row 0 while the feet are in row 1) is inside the box and stops the walk at the
-    /// tile's near edge, exactly like a tile at feet level.
+    /// Verifies a solid tile anywhere within the fixed 0.5×0.5-tile lower-body box blocks the
+    /// player: the box covers the lower body of the default 48×48 sprite, so a tile at the
+    /// box's top row is inside the box and stops the walk at the tile's near edge, exactly like
+    /// a tile at feet level.
     /// </summary>
     [Fact]
     public void Update_SolidTileInBodyBox_BlocksWalkingPast()
     {
-        // 4x4 map with a single solid tile at (2, 0) — inside the 1×1 box when the player's
-        // feet are in row 1 (the box spans y ∈ [0.5, 1.5], which includes row 0).
+        // 4x4 map with a single solid tile at (2, 0) — inside the 0.5×0.5 box when the player's
+        // feet are at y = 1.0 (the box spans y ∈ [0.5, 1.0], which includes row 0).
         var gids = new uint[16];
         gids[(0 * 4) + 2] = 1;
         using var fixture = CreateCollisionMapFixture(4, 4, gids);
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Feet in row 1: the 1×1 box spans y ∈ [0.5, 1.5], so the solid tile at (2, 0) is
+        // Feet at y = 1.0: the 0.5×0.5 box spans y ∈ [0.5, 1.0], so the solid tile at (2, 0) is
         // inside the box and must block the walk at the box's right edge (x = 2.0).
-        engine.Player.Position = new Position(0.5, 1.5);
+        engine.Player.Position = new Position(0.5, 1.0);
         engine.Input(Key.D, true);
 
         // One second at 2 tiles/s (dt = 1.0): the right edge stops exactly at the tile's left
-        // edge, so the feet clamp to X = 1.5 (never 2.5, the tile is inside the box).
+        // edge, so the feet clamp to X = 1.75 (never 2.5, the tile is inside the box).
         engine.Update(dt: 1.0);
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
-        Assert.Equal(1.5, engine.Player.Position.Y, precision: 6);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.0, engine.Player.Position.Y, precision: 6);
     }
 
     /// <summary>Verifies a solid tile in the lower-body region blocks the player at the feet boundary (feet X = 1.5).</summary>
     [Fact]
     public void Update_SolidTileInLowerBody_BlocksAtFeetBoundary()
     {
-        // 4x4 map with a single solid tile at (2, 1) — inside the 1×1 box when the player's
-        // feet are in row 1 (the box spans y ∈ [0.5, 1.5], which includes row 1).
+        // 4x4 map with a single solid tile at (2, 1) — inside the 0.5×0.5 box when the player's
+        // feet are at y = 1.5 (the box spans y ∈ [1.0, 1.5], which includes row 1).
         var gids = new uint[16];
         gids[(1 * 4) + 2] = 1;
         using var fixture = CreateCollisionMapFixture(4, 4, gids);
@@ -278,26 +280,27 @@ public partial class GameEngineTests
         engine.Player.Position = new Position(0.5, 1.5);
         engine.Input(Key.D, true);
 
-        // Move right by exactly 1 tile: the feet reach X = 1.5, where the 1×1 box's right edge
-        // [1.0, 2.0] just touches the solid tile at x = 2.0.
+        // Move right by exactly 1 tile: the feet reach X = 1.5, still clear of the solid tile
+        // (the box's right edge is at 1.75).
         engine.Update(dt: 0.5);
         Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
 
-        // The next step would push the box into the solid tile and is clamped back.
+        // The next step would push the box into the solid tile and is clamped back: the right
+        // edge stops exactly at the tile's left edge (x = 2.0), so the feet reach X = 1.75.
         engine.Update(dt: 0.5);
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 6);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 6);
         Assert.Equal(1.5, engine.Player.Position.Y, precision: 6);
-        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9);
+        Assert.True(engine.Player.Position.X + 0.25 <= 2.0 + 1e-9);
     }
 
     /// <summary>
     /// Verifies the map edge is solid: with no collision layer the player cannot walk out of the
-    /// map, and the displacement slides to the <em>exact</em> map edge of the fixed 1×1 tile
-    /// lower-body box. Walking right clamps the feet to exactly x = 1.5 (the box's right edge at
-    /// x = 2), walking down clamps them to exactly y = 2.0 (the box's bottom edge, the feet, at
-    /// the bottom map edge), and walking up clamps them to exactly y = 1.0 (the box's top edge
-    /// at y = 0). The default 48x48 sprite with 48 px tiles has a 1x1 box: hw = 0.5 and the box
-    /// extends 1 tile above the feet.
+    /// map, and the displacement slides to the <em>exact</em> map edge of the fixed 0.5×0.5-tile
+    /// lower-body box. Walking right clamps the feet to exactly x = 1.75 (the box's right edge
+    /// at x = 2), walking down clamps them to exactly y = 2.0 (the box's bottom edge, the feet,
+    /// at the bottom map edge), and walking up clamps them to exactly y = 0.5 (the box's top edge
+    /// at y = 0). The default 48x48 sprite with 48 px tiles has a 0.5x0.5 box: hw = 0.25 and the
+    /// box extends 0.5 tiles above the feet.
     /// </summary>
     [Fact]
     public void Update_MapEdgeIsSolid_PlayerCannotLeaveMap()
@@ -307,9 +310,9 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Start in row 1 so the fixed 1x1 box is fully inside the map, then walk right: the box
-        // stops when its right edge (feet X + 0.5) reaches the map edge at x=2, so the player's
-        // feet stop at exactly x = 1.5.
+        // Start in row 1 so the fixed 0.5x0.5 box is fully inside the map, then walk right: the
+        // box stops when its right edge (feet X + 0.25) reaches the map edge at x=2, so the
+        // player's feet stop at exactly x = 1.75.
         engine.Player.Position = new Position(0.5, 1.5);
         engine.Input(Key.D, true);
         for (var frame = 0; frame < 300; frame++)
@@ -317,9 +320,9 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 9);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 9);
         Assert.Equal(1.5, engine.Player.Position.Y, precision: 9);
-        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9);
+        Assert.True(engine.Player.Position.X + 0.25 <= 2.0 + 1e-9);
 
         // Then walk down: the same rule clamps the feet to exactly y = 2.0 (the box's bottom
         // edge, which is the feet, at the map edge y=2).
@@ -330,12 +333,12 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 9);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 9);
         Assert.Equal(2.0, engine.Player.Position.Y, precision: 9);
         Assert.True(engine.Player.Position.Y <= 2.0 + 1e-9);
 
-        // Finally walk up: the box's top edge (feet Y - 1.0) clamps at the top map edge y = 0,
-        // so the feet stop at exactly y = 1.0.
+        // Finally walk up: the box's top edge (feet Y - 0.5) clamps at the top map edge y = 0,
+        // so the feet stop at exactly y = 0.5.
         engine.Input(Key.S, false);
         engine.Input(Key.W, true);
         for (var frame = 0; frame < 300; frame++)
@@ -343,9 +346,9 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 9);
-        Assert.Equal(1.0, engine.Player.Position.Y, precision: 9);
-        Assert.True(engine.Player.Position.Y - 1.0 >= 0.0 - 1e-9);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 9);
+        Assert.Equal(0.5, engine.Player.Position.Y, precision: 9);
+        Assert.True(engine.Player.Position.Y - 0.5 >= 0.0 - 1e-9);
     }
 
     // ---------------------------------------------------------------------
@@ -354,10 +357,10 @@ public partial class GameEngineTests
     // of the first solid tile (or the map edge) instead of reverting the whole
     // step, so the feet stop exactly at the solid tile's edge - matching
     // click-to-move - with no one-frame-step gap and no floating-point
-    // overshoot accumulation. The collision footprint is the fixed 1×1 tile
-    // lower-body box (see the engine class remarks), so the box (and therefore
-    // the whole body for the default 48×48 sprite) stops exactly at the edge in
-    // every direction: down at the row's top edge, up at the row's bottom edge,
+    // overshoot accumulation. The collision footprint is the fixed 0.5×0.5-tile
+    // lower-body box (see the engine class remarks), so the box stops exactly at
+    // the edge in every direction: down at the row's top edge, up at the row's
+    // bottom edge,
     // right/left at the column's left/right edge.
     // ---------------------------------------------------------------------
     /// <summary>
@@ -394,8 +397,8 @@ public partial class GameEngineTests
     }
 
     /// <summary>
-    /// Verifies holding D (right) stops the feet at exactly x = 1.5 when a solid column starts
-    /// at x = 2 (the right edge of the fixed 1×1 tile box touches the column's left edge).
+    /// Verifies holding D (right) stops the feet at exactly x = 1.75 when a solid column starts
+    /// at x = 2 (the right edge of the fixed 0.5×0.5-tile box touches the column's left edge).
     /// </summary>
     [Fact]
     public void Update_KeyMovementRight_ClampsFeetToExactSolidColumnBoundary()
@@ -419,15 +422,15 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        Assert.Equal(1.5, engine.Player.Position.X, precision: 9);
+        Assert.Equal(1.75, engine.Player.Position.X, precision: 9);
         Assert.Equal(2.0, engine.Player.Position.Y, precision: 9);
-        Assert.True(engine.Player.Position.X + 0.5 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
+        Assert.True(engine.Player.Position.X + 0.25 <= 2.0 + 1e-9, "The footprint must never overlap the solid column.");
     }
 
     /// <summary>
     /// Verifies holding A (left) approaching the solid column [2,3) from the right stops the
-    /// feet at exactly x = 3.5: the left edge of the fixed 1×1 tile box touches the column's
-    /// right edge.
+    /// feet at exactly x = 3.25: the left edge of the fixed 0.5×0.5-tile box touches the
+    /// column's right edge.
     /// </summary>
     [Fact]
     public void Update_KeyMovementLeft_ClampsFeetToExactSolidColumnBoundary()
@@ -451,15 +454,15 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        Assert.Equal(3.5, engine.Player.Position.X, precision: 9);
+        Assert.Equal(3.25, engine.Player.Position.X, precision: 9);
         Assert.Equal(2.0, engine.Player.Position.Y, precision: 9);
-        Assert.True(engine.Player.Position.X - 0.5 >= 3.0 - 1e-9, "The footprint must never overlap the solid column.");
+        Assert.True(engine.Player.Position.X - 0.25 >= 3.0 - 1e-9, "The footprint must never overlap the solid column.");
     }
 
     /// <summary>
     /// Verifies holding W (up) approaching the solid row [2,3) from below stops the feet at
-    /// exactly y = 4.0: the top edge of the fixed 1×1 tile box touches the row's bottom edge
-    /// (y = 3.0), so the whole body stops below the ceiling with no head overlap.
+    /// exactly y = 3.5: the top edge of the fixed 0.5×0.5-tile box touches the row's bottom
+    /// edge (y = 3.0), so the lower-body box stops below the ceiling with no overlap.
     /// </summary>
     [Fact]
     public void Update_KeyMovementUp_ClampsFeetToExactSolidRowBoundary()
@@ -483,9 +486,9 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        Assert.Equal(4.0, engine.Player.Position.Y, precision: 9);
+        Assert.Equal(3.5, engine.Player.Position.Y, precision: 9);
         Assert.Equal(2.0, engine.Player.Position.X, precision: 9);
-        Assert.True(engine.Player.Position.Y - 1.0 >= 3.0 - 1e-9, "The footprint must never overlap the solid row.");
+        Assert.True(engine.Player.Position.Y - 0.5 >= 3.0 - 1e-9, "The footprint must never overlap the solid row.");
     }
 
     /// <summary>
@@ -508,21 +511,21 @@ public partial class GameEngineTests
         ConfigurePlayerSprite(engine, seed: 1);
 
         // A single step of 4 tiles (dt = 2.0 at 2 tiles/s) toward the wall at x = 3: the feet
-        // clamp to exactly x = 2.5 (the right edge of the fixed 1×1 tile box at the wall's left
-        // edge).
+        // clamp to exactly x = 2.75 (the right edge of the fixed 0.5×0.5-tile box at the wall's
+        // left edge).
         engine.Player.Position = new Position(0.5, 1.0);
         engine.Input(Key.D, true);
         engine.Update(dt: 2.0);
 
-        Assert.Equal(2.5, engine.Player.Position.X, precision: 9);
+        Assert.Equal(2.75, engine.Player.Position.X, precision: 9);
         Assert.Equal(1.0, engine.Player.Position.Y, precision: 9);
-        Assert.True(engine.Player.Position.X + 0.5 <= 3.0 + 1e-9, "The footprint must never overlap the solid column.");
+        Assert.True(engine.Player.Position.X + 0.25 <= 3.0 + 1e-9, "The footprint must never overlap the solid column.");
     }
 
     /// <summary>
-    /// Verifies key movement walks all the way down a 1-tile-wide corridor: the fixed 1×1 tile
-    /// lower-body box is exactly 1 tile wide, so a player centred in the corridor (feet x = 1.5,
-    /// box x in [1.0, 2.0]) never touches the side walls and reaches the far end. This is the
+    /// Verifies key movement walks all the way down a 1-tile-wide corridor: the fixed 0.5×0.5-tile
+    /// lower-body box is only half a tile wide, so a player centred in the corridor (feet x = 1.5,
+    /// box x in [1.25, 1.75]) never touches the side walls and reaches the far end. This is the
     /// scenario the fixed box fixes: a footprint wider than 1 tile (derived from a larger
     /// spritesheet) was stopped before the entrance.
     /// </summary>
@@ -541,8 +544,8 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Centred in the corridor entrance (feet x = 1.5, row 0 open): the 1x1 box spans exactly
-        // column 1, so holding S walks straight down to the bottom map edge (y = 4.0).
+        // Centred in the corridor entrance (feet x = 1.5, row 0 open): the 0.5x0.5 box spans
+        // within column 1, so holding S walks straight down to the bottom map edge (y = 4.0).
         engine.Player.Position = new Position(1.5, 0.5);
         engine.Input(Key.S, true);
         for (var frame = 0; frame < 300; frame++)
@@ -556,9 +559,10 @@ public partial class GameEngineTests
 
     /// <summary>
     /// Verifies a player with a <em>larger</em> rendered sprite (78×108 cells) can still walk
-    /// through a 1-tile-wide corridor: the collision box is the fixed 1×1 tile lower-body box,
-    /// independent of the spritesheet's cell size. Before this fix the footprint was derived from
-    /// the sprite width (1.625 tiles for 78 px), so the player was stopped before the entrance.
+    /// through a 1-tile-wide corridor: the collision box is the fixed 0.5×0.5-tile lower-body
+    /// box, independent of the spritesheet's cell size. Before this fix the footprint was derived
+    /// from the sprite width (1.625 tiles for 78 px), so the player was stopped before the
+    /// entrance.
     /// </summary>
     [Fact]
     public void Update_KeyMovementDownThroughOneTileCorridor_LargeSprite_IsNotBlocked()
@@ -586,8 +590,8 @@ public partial class GameEngineTests
             engine.Update(FrameDt);
         }
 
-        // The 78x108 sprite renders larger but collides with the fixed 1x1 box, so the corridor
-        // still fits: the feet reach the bottom map edge at exactly y = 4.0.
+        // The 78x108 sprite renders larger but collides with the fixed 0.5x0.5 box, so the
+        // corridor still fits: the feet reach the bottom map edge at exactly y = 4.0.
         Assert.Equal(1.5, engine.Player.Position.X, precision: 9);
         Assert.Equal(4.0, engine.Player.Position.Y, precision: 9);
     }
@@ -612,11 +616,13 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // The player stands at the wall's left boundary, below the wall's bottom corner:
-        // (2.5, 3.0). This is a legal position reachable by keys (walk right into the wall, then
-        // down). From here the direct displacement toward waypoint (3,3) centre (3.5, 3.5) would
-        // cross the solid corner at (3,2), so the auto-walk must cancel rather than cross it.
-        engine.Player.Position = new Position(2.5, 3.0);
+        // The player stands flush against the wall's left boundary, below the wall's bottom
+        // corner: (2.75, 3.0) - the fixed 0.5x0.5 lower-body box's right edge (feet X + 0.25) is
+        // exactly at the wall column x=3. This is a legal position reachable by keys (walk right
+        // into the wall, then down). From here the direct displacement toward waypoint (3,3)
+        // centre (3.5, 3.5) would cross the solid corner at (3,2), so the auto-walk must cancel
+        // rather than cross it.
+        engine.Player.Position = new Position(2.75, 3.0);
 
         const int canvas = 336; // 7 tiles x 48 px
         ClickOnTile(engine, 5, 3, canvas, canvas);
@@ -628,7 +634,7 @@ public partial class GameEngineTests
         {
             engine.Update(FrameDt);
             var p = engine.Player.Position;
-            if (engine.Map!.IsAreaSolid(p.X - 0.5, p.Y - 1.0, 1.0, 1.0))
+            if (engine.Map!.IsAreaSolid(p.X - 0.25, p.Y - 0.5, 0.5, 0.5))
             {
                 illegalFrames++;
             }
@@ -665,10 +671,11 @@ public partial class GameEngineTests
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
 
-        // Place the player at an illegal position: feet at y=3.49, so the fixed 1x1 box
-        // [2.49, 3.49] already overlaps the solid row at y=2 (its top edge is inside the wall).
+        // Place the player at an illegal position: feet at y=3.49, so the fixed 0.5x0.5 box
+        // [1.75, 2.25] x [2.99, 3.49] already overlaps the solid row at y=2 (its top edge is
+        // inside the wall).
         engine.Player.Position = new Position(2.0, 3.49);
-        Assert.True(engine.Map!.IsAreaSolid(2.0 - 0.5, 3.49 - 1.0, 1.0, 1.0), "sanity: the start is illegal");
+        Assert.True(engine.Map!.IsAreaSolid(2.0 - 0.25, 3.49 - 0.5, 0.5, 0.5), "sanity: the start is illegal");
 
         // Hold W (up, deeper into the wall): the move must be refused, never tunnelling through.
         engine.Input(Key.W, true);
@@ -685,9 +692,9 @@ public partial class GameEngineTests
     /// <summary>
     /// Verifies key movement from an illegal position can escape <em>away</em> from the wall
     /// (moving down clears the overlapping footprint), so an embedded player is never stuck. The
-    /// escape displacement must clear the whole overlap in one step: the fixed 1×1 box at
-    /// y = 3.49 overlaps the solid row [2,3) by 0.49 tiles, so a single large step down (rather
-    /// than many small ones, which stay illegal and are refused) is required.
+    /// escape displacement must clear the whole overlap: the fixed 0.5×0.5 box at y = 3.49
+    /// overlaps the solid row [2,3) by 0.01 tiles (its top edge at 2.99 is inside the wall), and
+    /// a single 0.6 s step down clears the overlap so the resolver returns a legal position.
     /// </summary>
     [Fact]
     public void Update_KeyMovementFromIllegalPosition_CanEscapeAwayFromWall()
@@ -706,13 +713,13 @@ public partial class GameEngineTests
         engine.Player.Position = new Position(2.0, 3.49);
         engine.Input(Key.S, true); // move down, away from the solid row above
 
-        // A single 0.6 s step (1.2 tiles) fully clears the 0.49-tile overlap in one displacement;
+        // A single 0.6 s step (1.2 tiles) fully clears the 0.01-tile overlap in one displacement;
         // the resolver then returns a legal position.
         engine.Update(dt: 0.6);
 
         Assert.True(engine.Player.Position.Y > 3.49, $"The player did not escape: Y={engine.Player.Position.Y}");
         Assert.False(
-            engine.Map!.IsAreaSolid(engine.Player.Position.X - 0.5, engine.Player.Position.Y - 1.0, 1.0, 1.0),
+            engine.Map!.IsAreaSolid(engine.Player.Position.X - 0.25, engine.Player.Position.Y - 0.5, 0.5, 0.5),
             "The footprint must be legal after escaping.");
     }
 }

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -239,6 +239,65 @@ public partial class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Acceptance (story 64): with a map set, the engine resolves every NPC's
+    // autonomous movement (the StartMoving/Update path) against the map's
+    // solid tiles and the map edge exactly like the player's key-driven
+    // movement, so NPCs stop at walls and at the map edge instead of walking
+    // through the world.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies an NPC started with StartMoving(Right) on a map with a solid column never overlaps the column and stops at the boundary (X + 0.25 &lt;= 2.0).</summary>
+    [Fact]
+    public void Update_NpcStartMoving_WithMap_StopsAtSolidColumn()
+    {
+        // 4x4 map: a "walls" collision layer with a solid column at x=2 for every row.
+        using var fixture = CreateCollisionMapFixture(4, 4, new uint[]
+        {
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+            0, 0, 1, 0,
+        });
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        var npc = new Character { BaseSpeed = 2, Position = new Position(0.5, 1.0) };
+        npc.StartMoving(Direction.Right);
+        engine.Characters.Add(npc);
+
+        for (var frame = 0; frame < 300; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The NPC stopped at the solid column: its footprint never enters it, and the feet stop
+        // exactly at the column's left edge (X = 2.0 - 0.25 = 1.75).
+        Assert.True(npc.Position.X + 0.25 <= 2.0 + 1e-9, "The NPC footprint must never overlap the solid column.");
+        Assert.Equal(1.75, npc.Position.X, precision: 9);
+        Assert.Equal(1.0, npc.Position.Y, precision: 9);
+        Assert.True(npc.IsMoving, "A blocked autonomous character stays started (the walk cycle snaps to standing).");
+    }
+
+    /// <summary>Verifies an NPC started toward the map edge stops at the edge (never leaves the map).</summary>
+    [Fact]
+    public void Update_NpcStartMoving_WithMap_StopsAtMapEdge()
+    {
+        // A 2x2 map with a ground layer only (no collision layer): only the map edge is solid.
+        using var fixture = CreateFilledMapFixture(2, 2);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        var npc = new Character { BaseSpeed = 2, Position = new Position(0.5, 1.5) };
+        npc.StartMoving(Direction.Left);
+        engine.Characters.Add(npc);
+
+        for (var frame = 0; frame < 300; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        // The 0.5x0.5 box's left edge (feet X - 0.25) stops at the left map edge: feet X = 0.25.
+        Assert.Equal(0.25, npc.Position.X, precision: 9);
+        Assert.True(npc.Position.X - 0.25 >= 0.0 - 1e-9, "The NPC footprint must never leave the map.");
+        Assert.True(npc.IsMoving, "A blocked autonomous character stays started (the walk cycle snaps to standing).");
+    }
+
+    // ---------------------------------------------------------------------
     // Acceptance 6: LoadSpriteSheet registers by unique name (duplicate →
     // InvalidOperationException), and Render uses the loaded sheets (a character
     // configured with a loaded sheet name and a valid character index 1..8


### PR DESCRIPTION
Closes #64

## Summary

Refactors autonomous movement so that **every** character's `StartMoving`/`Update` path is collision-resolved against the map's solid tiles **exactly like the player's key-driven movement**, sharing the same `MovementCollisionResolver` footprint and the same per-axis slide-to-boundary (cardinal) / all-or-nothing (diagonal) semantics.

### Source changes
- **`MovementCollisionResolver`** — became the footprint authority: moved the two collision constants here (`CollisionBoxHalfWidth = 0.25`, `CollisionBoxHeightAboveFeet = 0.5`, the reduced 0.5×0.5-tile lower-body box) and added `ResolveDisplacement` which picks all-or-nothing diagonal vs per-axis slide-to-boundary cardinal resolution. Updated stale 1×1-tile remarks to the reduced box.
- **`Character`** — `internal void Update(double dt, TileMap? map = null)`; when `IsMoving` the autonomous displacement is resolved via `MovementCollisionResolver.ResolveDisplacement` when a map is supplied, otherwise applied raw. Animation logic unchanged (a fully blocked character snaps to the standing frame). `Move(...)` stays a raw one-shot displacement, documented as such.
- **`GameEngine`** — removed the duplicated constants and references the resolver's everywhere (`MovePlayerWithCollisionResolution`, `PlayerFootprintOverlapsSolid`, `ClampPlayerToMap`); simplified the player's map branch to `ResolveDisplacement`; passes the map to every character update in `Update`. `ClampPlayerToMap` remains the player-only post-move safety net. Updated stale comments/class remarks.

### Test changes
- Updated the **18 stale collision/clamp tests** to the reduced box dimensions (right `X + 0.25`, left `X - 0.25`, top `Y - 0.5`, feet at `Y`; `ClampPlayerToMap` feet `x ∈ [0.25, Width - 0.25]`, `y ∈ [0.5, Height]`) in `GameEngineCollisionTests.cs`, `GameEngineCollisionOnMoveTests.cs`, `GameEngineClickToMoveTests.cs` (incl. `Click_BeforeAnyRender_IsIgnoredWithoutThrowing`).
- **New `CharacterTests`** (unit, no engine): solid-column stop at `X = 1.75`, no-collision-layer regression (moves `BaseSpeed * dt`), diagonal all-or-nothing stop, left map-edge stop, fully-blocked → standing frame, and no-map raw movement.
- **New `GameEngineTests`** (end-to-end): an NPC `StartMoving(Right)` stops at a solid column (`X + 0.25 <= 2.0`), and an NPC toward the map edge stops at the edge; the existing `Update_NpcStartedWithStartMoving_MovesNpc` (no map) still passes.

### Documentation
- `docs/api/Character.md`, `docs/Architecture.md`, `docs/api/GameEngine.md`, `docs/README.md` updated: autonomous movement is collision-resolved when the engine supplies a map (removed the "hosts responsible for keeping them in bounds" statements), footprint description updated to the 0.5×0.5-tile box.

### Verification
- `dotnet build RPGEngine.sln -c Release` — **0 warnings / 0 errors** (CS1591 enforced).
- `dotnet test tests/RPGEngine.Tests -c Release` — **405 passed / 0 failed**.
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~CharacterTests|FullyQualifiedName~GameEngineTests"` — **112 passed / 0 failed**.