### PR TITLE
Story 65: Y-sorted character rendering (draw order by Position.Y)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -412,8 +412,16 @@ when the player was moving; the engine calls it when there is no input and no au
 `GameEngine.Render(canvas, dt)` draws a single frame in a fixed order:
 
 ```
-below-player layers → NPCs → player → above-player layers
+below-player layers → characters (NPCs + player) sorted by Y → above-player layers
 ```
+
+All characters — every NPC in `GameEngine.Characters` **and the player** — are drawn in a
+single pass sorted by `Position.Y` ascending: a character with a **higher** `Position.Y` (lower
+on the screen, closer to the viewer) is drawn **last** and appears on top of the others, so a
+character lower on the screen occludes one higher up. The player is part of this ordering and
+may be drawn **behind** other characters when its Y is lower. `OrderBy` is stable, so equal-Y
+characters keep their relative order (NPCs in `Characters`-list order, then the player) and the
+draw order is deterministic. `RenderMinimap` is unchanged: its dots have no Y ordering.
 
 - When a `TileMap` is set, the canvas is **cleared to black first** — this is the black
   background behind and around the map.
@@ -425,12 +433,13 @@ below-player layers → NPCs → player → above-player layers
   images; the engine disposes the previous map when `GameEngine.Map` is replaced and when the
   engine itself is disposed.
 - **Drawing is a per-layer image blit.** `TileMap.Draw` blits the prerendered images of the
-  layers **below** the player (every layer whose `TileMapLayer.AbovePlayer` is `false`), each
-  NPC and the player are drawn on top, and finally `TileMap.DrawAbovePlayer` blits the layers
-  whose `above_player` custom property is `true` so those tiles appear **in front of** the
-  player (e.g. tree canopies the player walks under). Each blit draws the intersection of the
-  viewport with the layer image bounds, so viewport culling is preserved and no per-tile work
-  happens per frame.
+  layers **below** the player (every layer whose `TileMapLayer.AbovePlayer` is `false`), then
+  all characters (the NPCs in `GameEngine.Characters` and the player) are drawn on top, sorted
+  by `Position.Y` ascending (a higher Y is drawn last / on top, including the player), and
+  finally `TileMap.DrawAbovePlayer` blits the layers whose `above_player` custom property is
+  `true` so those tiles appear **in front of** every character (e.g. tree canopies the player
+  walks under). Each blit draws the intersection of the viewport with the layer image bounds, so
+  viewport culling is preserved and no per-tile work happens per frame.
 - **The camera works in tiles and renders in pixels.** `Render` computes the camera origin in
   tiles (follow + clamp, see above), derives a pixel viewport
   `(origin.X*ts, origin.Y*ts, origin.X*ts + canvasWidth, origin.Y*ts + canvasHeight)` and passes

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ using var bitmap = new SKBitmap(640, 480);
 using (var canvas = new SKCanvas(bitmap))
 {
     canvas.Clear(SKColors.Black);
-    engine.Render(canvas, dt: 1.0 / 60); // black background, centered map, above_player layers on top
+    engine.Render(canvas, dt: 1.0 / 60); // black background, centered map, Y-sorted characters, above_player layers on top
 }
 
 // 6. Read the map's custom properties and object layers.
@@ -133,7 +133,7 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 | Page | What it covers |
 | --- | --- |
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering, rendering order and the Tiled read model. |
-| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), **click-to-move auto-walk (`Click`)** and the input-precedence rules, asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
+| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), **click-to-move auto-walk (`Click`)** and the input-precedence rules, asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, **Y-sorted character rendering** (NPCs + player by `Position.Y`, higher Y drawn on top), map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
 | [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references, the speed-scaled walk-cycle animation (`AnimationCycleSpeed`), autonomous movement (`StartMoving` / `StopMoving` / `IsMoving`), and the movement-state event (`OnMove` / `PlayerMoveEventArgs` / `Stop()`). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -27,10 +27,13 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   canvas size — the foundation the "click to move" and "GUI around game objects" features will
   build on.
 - When a map is set, `Render` clears the whole canvas to black first, then draws the map's
-  below-player layers, then every NPC, then the player, and finally the map's `above_player`
-  layers (tile layers declaring the Tiled `above_player` custom property) so those tiles appear
-  on top of the player. Without a map the canvas is left untouched and only the characters are
-  drawn.
+  below-player layers, then **all characters (the NPCs in `Characters` and the player) sorted by
+  `Position.Y` ascending**, and finally the map's `above_player` layers (tile layers declaring
+  the Tiled `above_player` custom property) so those tiles appear on top of every character.
+  Within the character pass a character with a higher `Position.Y` (lower on the screen, closer
+  to the viewer) is drawn last and appears on top of the others, so the player may be drawn
+  behind an NPC whose Y is higher. Without a map the canvas is left untouched and only the
+  characters (Y-sorted) are drawn.
 - Movement input combines every held bound key into a single 8-direction vector: opposite keys
   cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
   at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
@@ -109,7 +112,9 @@ engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 ### `IList<Character> Characters`
 
 Gets the mutable list of NPC characters present in the game world. The player is never in this
-list (it is rendered separately, on top).
+list; it is rendered alongside the NPCs in `Render`'s **Y-sorted character pass** (all
+characters are drawn sorted by `Position.Y` ascending, higher Y last / on top), so the player
+may be drawn behind an NPC whose Y is higher.
 
 The engine's update loop calls `Character.Update(dt, Map)` on every NPC each frame, so an NPC
 started with `StartMoving` moves autonomously and its displacement is **collision-resolved**
@@ -215,11 +220,14 @@ engine.Update(dt: 1.0 / 60);
 
 Draws one frame onto the canvas. When a map is set the canvas is cleared to black first (the
 black background behind/around a map smaller than the canvas), then the map's below-player
-layers are drawn, then every NPC, then the player on top, and finally the map's `above_player`
-layers so those tiles appear above the player. The camera follows the player, centers a map
-smaller than the canvas, and is clamped so the viewport stays inside the map; the canvas size is
-read from the canvas clip bounds. The camera origin is computed in tiles and converted to a
-pixel viewport for the map and to pixel screen positions for the characters.
+layers are drawn, then **all characters (the NPCs in `Characters` and the player) sorted by
+`Position.Y` ascending** — a character with a higher Y (lower on the screen) is drawn last and
+appears on top of the others, so the player may be drawn behind an NPC whose Y is higher — and
+finally the map's `above_player` layers so those tiles appear above every character. The camera
+follows the player, centers a map smaller than the canvas, and is clamped so the viewport stays
+inside the map; the canvas size is read from the canvas clip bounds. The camera origin is
+computed in tiles and converted to a pixel viewport for the map and to pixel screen positions for
+the characters.
 
 ```csharp
 using var bitmap = new SKBitmap(640, 480);

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -42,10 +42,13 @@ namespace RPGEngine;
 /// </para>
 /// <para>
 /// When a map is set, <see cref="Render"/> clears the whole canvas to black first, then draws
-/// the map's below-player layers, then every NPC, then the player, and finally the map's
+/// the map's below-player layers, then all characters (the NPCs in <see cref="Characters"/> and
+/// the player) sorted by <see cref="Character.Position"/> Y ascending, and finally the map's
 /// <c>above_player</c> layers (tile layers declaring the Tiled <c>above_player</c> custom
-/// property) so those tiles appear on top of the player. Without a map the canvas is left
-/// untouched and only the characters are drawn.
+/// property) so those tiles appear on top of every character. Within the character pass a
+/// character with a higher Y (lower on the screen, closer to the viewer) is drawn last and
+/// appears on top of the others, so the player may be drawn behind an NPC whose Y is higher.
+/// Without a map the canvas is left untouched and only the characters (Y-sorted) are drawn.
 /// </para>
 /// <para>
 /// Movement input combines every held bound key into a single 8-direction vector: each key that
@@ -181,8 +184,10 @@ public sealed class GameEngine : IDisposable
 
     /// <summary>
     /// Gets the mutable list of NPC characters present in the game world. The player is never in
-    /// this list (it is rendered separately, on top). Items added to or removed from the list are
-    /// taken into account on the next <see cref="Render"/>.
+    /// this list; it is rendered alongside the NPCs in <see cref="Render"/>'s Y-sorted character
+    /// pass, so it may be drawn behind an NPC whose <see cref="Character.Position"/> Y is higher.
+    /// Items added to or removed from the list are taken into account on the next
+    /// <see cref="Render"/>.
     /// </summary>
     public IList<Character> Characters => _characters;
 
@@ -391,13 +396,17 @@ public sealed class GameEngine : IDisposable
     /// <summary>
     /// Draws one frame onto <paramref name="canvas"/>. When a map is set the canvas is cleared to
     /// black first (the black background behind/around a map smaller than the canvas), then the
-    /// map's below-player layers are drawn, then every NPC, then the player on top, and finally
-    /// the map's <c>above_player</c> layers so those tiles appear above the player. The camera
-    /// follows the player, centers a map smaller than the canvas, and is clamped so the viewport
-    /// stays inside the map; the canvas size is read from the canvas clip bounds so the view
-    /// adapts to the current surface size automatically. The camera origin is computed in tiles
-    /// and converted to a pixel viewport for the map (a pure pixel renderer) and to pixel screen
-    /// positions for the characters.
+    /// map's below-player layers are drawn, then all characters (the NPCs in
+    /// <see cref="Characters"/> and the player) sorted by <see cref="Character.Position"/> Y
+    /// ascending, and finally the map's <c>above_player</c> layers so those tiles appear above
+    /// every character. Within the character pass a character with a higher Y (lower on the
+    /// screen, closer to the viewer) is drawn last and appears on top of the others, so the
+    /// player may be drawn behind an NPC whose Y is higher. The camera follows the player,
+    /// centers a map smaller than the canvas, and is clamped so the viewport stays inside the
+    /// map; the canvas size is read from the canvas clip bounds so the view adapts to the current
+    /// surface size automatically. The camera origin is computed in tiles and converted to a
+    /// pixel viewport for the map (a pure pixel renderer) and to pixel screen positions for the
+    /// characters.
     /// </summary>
     /// <param name="canvas">The canvas to draw onto (CPU or GPU backed; see the class remarks).</param>
     /// <param name="dt">The elapsed time in seconds since the previous frame (reserved for future animation timing).</param>
@@ -439,8 +448,9 @@ public sealed class GameEngine : IDisposable
         // middle-bottom, so a character's sprite top-left is at
         // (pos.X*ts - w/2 - origin.X*ts, pos.Y*ts - h - origin.Y*ts) in world pixels and its
         // feet (anchor) at (pos.X*ts - origin.X*ts, pos.Y*ts - origin.Y*ts).
-        // Draw order is: below-player map layers -> each NPC -> the player -> above-player map
-        // layers, so tiles marked with the Tiled above_player property appear on top of the player.
+        // Draw order is: below-player map layers -> every character (NPCs and the player) sorted
+        // by Y ascending (higher Y drawn last, on top) -> above-player map layers, so tiles
+        // marked with the Tiled above_player property appear on top of every character.
         canvas.Save();
         try
         {
@@ -451,12 +461,15 @@ public sealed class GameEngine : IDisposable
                 Map.Draw(canvas, viewport);
             }
 
-            foreach (var character in _characters)
+            // Draw every character (NPCs + the player) sorted by Y ascending, so a character with
+            // a higher Y (lower on screen) is drawn last and appears on top. OrderBy is stable:
+            // equal-Y characters keep their relative order (NPCs in Characters-list order, then
+            // the player), so the draw order is deterministic.
+            var charactersInRenderOrder = _characters.Append(Player.Character).OrderBy(c => c.Position.Y);
+            foreach (var character in charactersInRenderOrder)
             {
                 character.Draw(canvas, character.Position.ToPixels(ts), dt, _spriteSheetManager);
             }
-
-            Player.Character.Draw(canvas, Player.Position.ToPixels(ts), dt, _spriteSheetManager);
 
             if (Map is not null)
             {

--- a/tests/RPGEngine.Tests/GameEngineTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineTests.cs
@@ -711,6 +711,132 @@ public partial class GameEngineTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 65: Y-sorted character rendering. All characters (the NPCs in
+    // Characters and the player) are drawn in a single pass sorted by
+    // Position.Y ascending: a character with a higher Y (lower on screen,
+    // closer to the viewer) is drawn last / on top, so the player may be
+    // drawn behind an NPC. OrderBy is stable, so equal-Y characters keep
+    // their Characters-list order (the earlier entry is drawn first, i.e.
+    // underneath). The map draw order is unchanged: below-player layers ->
+    // characters (Y-sorted) -> above-player layers.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies that of two overlapping NPCs at the same X with different Y, the one with the higher Y is drawn on top.</summary>
+    [Fact]
+    public void Render_NpcOverNpc_HigherYDrawnOnTop()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480x480 red tiles
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        engine.Characters.Add(ConfigureNpc(engine, "npcLower", seed: 2, characterIndex: 2, new Position(2.0, 2.0)));
+        engine.Characters.Add(ConfigureNpc(engine, "npcHigher", seed: 3, characterIndex: 3, new Position(2.0, 2.5)));
+
+        using var bitmap = Render(engine, 240, 240);
+
+        // Camera origin is (0,0) (the default player at (0,0) clamps the desired origin to 0).
+        // The lower-Y NPC's 48x48 sprite covers x[72,120) y[48,96) and the higher-Y NPC's covers
+        // x[72,120) y[72,120), so they overlap in x[72,120) y[72,96). The higher-Y NPC is drawn
+        // last (on top): the overlap pixel (96, 84) is its cell color.
+        var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 3, Direction.Down, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(96, 84));
+    }
+
+    /// <summary>Verifies an NPC with a higher Y than the player and an overlapping sprite is drawn on top of the player (the player is rendered behind the NPC).</summary>
+    [Fact]
+    public void Render_NpcOverPlayer_NpcDrawnOnTop()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480x480 red tiles
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(2.0, 2.0);
+
+        engine.Characters.Add(ConfigureNpc(engine, "npc", seed: 3, characterIndex: 3, new Position(2.0, 2.5)));
+
+        using var bitmap = Render(engine, 240, 240);
+
+        // Camera origin is (0,0) (the player at (2.0, 2.0) clamps the desired origin to 0). The
+        // player's sprite covers x[72,120) y[48,96) and the NPC's covers x[72,120) y[72,120),
+        // overlapping at (96, 84). The NPC has the higher Y, so it is drawn last / on top of the
+        // player: the overlap pixel is the NPC's cell color.
+        var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 3, Direction.Down, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(96, 84));
+    }
+
+    /// <summary>Verifies an NPC with a lower Y than the player and an overlapping sprite is drawn underneath the player (the player is on top).</summary>
+    [Fact]
+    public void Render_PlayerOverNpc_PlayerDrawnOnTop()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480x480 red tiles
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(2.0, 2.5);
+
+        engine.Characters.Add(ConfigureNpc(engine, "npc", seed: 3, characterIndex: 3, new Position(2.0, 2.0)));
+
+        using var bitmap = Render(engine, 240, 240);
+
+        // Camera origin is (0,0) (the player at (2.0, 2.5) clamps the desired origin to 0). The
+        // NPC's sprite covers x[72,120) y[48,96) and the player's covers x[72,120) y[72,120),
+        // overlapping at (96, 84). The player has the higher Y, so it is drawn last / on top of
+        // the NPC: the overlap pixel is the player's cell color.
+        var expected = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(96, 84));
+    }
+
+    /// <summary>Verifies two NPCs with the same Y keep their Characters-list order: the earlier entry is drawn first (underneath), the later entry on top.</summary>
+    [Fact]
+    public void Render_EqualY_KeepsCharactersListOrder()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10); // 480x480 red tiles
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+
+        var first = ConfigureNpc(engine, "npcFirst", seed: 2, characterIndex: 2, new Position(2.0, 2.5));
+        var second = ConfigureNpc(engine, "npcSecond", seed: 3, characterIndex: 3, new Position(2.0, 2.5));
+
+        // Added first -> drawn first (underneath); the later entry is on top. The two sprites
+        // coincide at x[72,120) y[72,120), so their centre pixel (96, 96) shows the top one.
+        engine.Characters.Add(first);
+        engine.Characters.Add(second);
+        using (var bitmap = Render(engine, 240, 240))
+        {
+            var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 3, Direction.Down, StandingFrame);
+            Assert.Equal(expected, bitmap.GetPixel(96, 96));
+        }
+
+        // Reversing the list order flips which sprite is on top: the stable OrderBy preserves
+        // the Characters-list order, so the earlier entry is always the one underneath.
+        engine.Characters.Remove(first);
+        engine.Characters.Remove(second);
+        engine.Characters.Add(second);
+        engine.Characters.Add(first);
+        using (var bitmap = Render(engine, 240, 240))
+        {
+            var expected = CharacterTestHelper.SpriteColor(seed: 2, characterIndex: 2, Direction.Down, StandingFrame);
+            Assert.Equal(expected, bitmap.GetPixel(96, 96));
+        }
+    }
+
+    /// <summary>Verifies that without a map the same Y-sorted order applies to characters only (regression that characters still render, Y-sorted).</summary>
+    [Fact]
+    public void Render_NoMap_CharactersRenderYSorted()
+    {
+        var engine = new GameEngine(); // no map: camera origin (0,0), only characters drawn
+
+        engine.Characters.Add(ConfigureNpc(engine, "npcLower", seed: 2, characterIndex: 2, new Position(2.0, 2.0)));
+        engine.Characters.Add(ConfigureNpc(engine, "npcHigher", seed: 3, characterIndex: 3, new Position(2.0, 2.5)));
+
+        using var bitmap = Render(engine, 240, 240);
+
+        // The higher-Y NPC is drawn on top at the overlap pixel (96, 84) ...
+        var expected = CharacterTestHelper.SpriteColor(seed: 3, characterIndex: 3, Direction.Down, StandingFrame);
+        Assert.Equal(expected, bitmap.GetPixel(96, 84));
+
+        // ... and a pixel covered only by the lower-Y NPC (not the higher one) still shows the
+        // lower NPC's color, proving both characters rendered without a map.
+        var lowerOnly = CharacterTestHelper.SpriteColor(seed: 2, characterIndex: 2, Direction.Down, StandingFrame);
+        Assert.Equal(lowerOnly, bitmap.GetPixel(96, 60));
+    }
+
+    // ---------------------------------------------------------------------
     // Story 37 acceptance 4: SurfaceToWorld / WorldToSurface are camera-aware
     // and inverses within floating-point tolerance. With no map the origin is
     // (0,0), so SurfaceToWorld(408, 408, 960, 960) == (8.5, 8.5) tiles.
@@ -952,6 +1078,16 @@ public partial class GameEngineTests
         using var stream = CharacterTestHelper.CreateSheetStream(seed);
         engine.LoadSpriteSheet("hero", stream);
         engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+    }
+
+    /// <summary>Loads a seeded full sheet under the given name and returns a new NPC character configured to use it.</summary>
+    private static Character ConfigureNpc(GameEngine engine, string sheetName, int seed, int characterIndex, Position position)
+    {
+        using var stream = CharacterTestHelper.CreateSheetStream(seed);
+        engine.LoadSpriteSheet(sheetName, stream);
+        var npc = new Character { Position = position };
+        npc.SpriteSheets.Add(new SpriteSheetRef(sheetName, CharacterIndex: characterIndex));
+        return npc;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Implements **Y-sorted character rendering** (issue #65, epic #63): `GameEngine.Render` now draws **every character** — all NPCs in `GameEngine.Characters` **and the player** — in a single pass sorted by `Position.Y` ascending. A character with a **higher** `Position.Y` (lower on the screen, closer to the viewer) is drawn **last** and appears on top, so the player may be drawn **behind** an NPC whose Y is higher.

### Changes

- **`src/RPGEngine/GameEngine.cs`** — `Render(SKCanvas, double)` replaces the two draw passes (the NPC loop, then the player) with a single Y-sorted pass:
  ```csharp
  var charactersInRenderOrder = _characters.Append(Player.Character).OrderBy(c => c.Position.Y);
  foreach (var character in charactersInRenderOrder)
  {
      character.Draw(canvas, character.Position.ToPixels(ts), dt, _spriteSheetManager);
  }
  ```
  `OrderBy` is stable, so equal-Y characters keep their relative order (NPCs in `Characters`-list order, then the player). The map draw order is unchanged (**below-player layers → characters Y-sorted → above-player layers**); `RenderMinimap` is unchanged. Updated the class remarks, `Characters` remarks and `Render` remarks to describe the Y-sorted draw order.

- **`tests/RPGEngine.Tests/GameEngineTests.cs`** — new pixel tests using the seeded `CharacterTestHelper` sheets (globally unique cell colors) + the existing `Render(engine, w, h)` helper:
  1. `Render_NpcOverNpc_HigherYDrawnOnTop` — higher-Y NPC drawn on top at the overlap pixel.
  2. `Render_NpcOverPlayer_NpcDrawnOnTop` — NPC with higher Y rendered over the player.
  3. `Render_PlayerOverNpc_PlayerDrawnOnTop` — player with higher Y rendered over the NPC.
  4. `Render_EqualY_KeepsCharactersListOrder` — equal-Y NPCs keep `Characters`-list order (earlier entry underneath), verified both ways.
  5. `Render_NoMap_CharactersRenderYSorted` — no-map regression: characters still render Y-sorted.
  Plus a `ConfigureNpc` helper.

- **Docs** — updated `docs/Architecture.md` (Rendering diagram → `below-player layers → characters (NPCs + player) sorted by Y → above-player layers`, plus Y-order prose), `docs/api/GameEngine.md` (`Render` / `Characters` remarks), and `docs/README.md` (rendering-related row + quick-start comment).

### Verification

- `dotnet build -c Release` → **0 warnings / 0 errors** (CS1591 clean; no new public API).
- `dotnet test tests/RPGEngine.Tests -c Release` → **410 passed, 0 failed**.
- `dotnet test tests/RPGEngine.Tests --filter "FullyQualifiedName~GameEngineTests|FullyQualifiedName~SampleSceneTests"` → **87 passed, 0 failed** (existing render pixel tests unchanged: `SampleSceneTests.Render_PlayerCentrePixel_MatchesFullSheetFixture`, `Render_VillagerCentrePixel_IsTopMostPart`, `Render_GuardCentrePixel_IsTopMostPart`, `GameEngineTests.Render_MapPlayerAndNpc_AllLayersPresent`, `Render_AbovePlayerLayer_TileDrawsOverPlayer`).