### PR TITLE
Story 70: Icon sets — GameEngine.LoadIconSet/LoadIconSetAsync, Character.IconIndex and icon rendering above sprites

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,13 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > solid tiles and the map edge with the same fixed 0.5×0.5-tile lower-body footprint, so NPCs
 > stop at walls and at the map edge instead of walking through the world.
 >
+> **Icon sets:** `engine.LoadIconSet(path)` (or the stream / `LoadIconSetAsync` overloads) loads
+> a single **icon set** — a PNG divided into 32×32 tiles, with the rows/columns deduced from the
+> image dimensions — into the engine. A character with a non-null `Character.IconIndex` then
+> draws the selected 32×32 icon **above its sprite** (centered horizontally on the character,
+> its bottom edge at the sprite's top edge) in the Y-sorted character pass. See
+> `docs/api/IconSet.md` and `docs/api/Character.md`.
+>
 > **Minimap:** `engine.RenderMinimap(canvas, zoomLevel)` draws the map's prerendered layers plus a
 > green dot for the player and a yellow dot for each NPC onto a separate surface. `zoomLevel`
 > `1.0` fits the whole map (the default); `> 1` zooms in around the player's dot (clamped to the
@@ -136,9 +143,10 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 | Page | What it covers |
 | --- | --- |
 | [Architecture](Architecture.md) | Composition model, camera, spritesheet layout, part ordering, rendering order and the Tiled read model. |
-| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), **click-to-move auto-walk (`Click`)** and the input-precedence rules, asset loading (sync + async) and `SpriteSheetExists`, camera, black background / map centering, **Y-sorted character rendering** (NPCs + player by `Position.Y`, higher Y drawn on top), map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
-| [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references, the speed-scaled walk-cycle animation (`AnimationCycleSpeed`), autonomous movement (`StartMoving` / `StopMoving` / `IsMoving`), and the movement-state events (`OnStartMoving` / `OnStopMoving` / `Stop()`). |
+| [api/GameEngine.md](api/GameEngine.md) | Root object: game loop, input (8 directions), **click-to-move auto-walk (`Click`)** and the input-precedence rules, asset loading (sync + async: spritesheets, part sheets and the single **icon set** via `LoadIconSet` / `LoadIconSetAsync`) and `SpriteSheetExists`, camera, black background / map centering, **Y-sorted character rendering** (NPCs + player by `Position.Y`, higher Y drawn on top, **icons drawn above each sprite**), map ownership (`IDisposable`), and the minimap (`RenderMinimap` — fit/zoom semantics, green player + yellow NPC dots). |
+| [api/Character.md](api/Character.md) / [api/Player.md](api/Player.md) | In-world state, sprite references, the speed-scaled walk-cycle animation (`AnimationCycleSpeed`), autonomous movement (`StartMoving` / `StopMoving` / `IsMoving`), the movement-state events (`OnStartMoving` / `OnStopMoving` / `Stop()`), and **`IconIndex`** (icons drawn above the sprite when an icon set is loaded). |
 | [api/SpriteSheet.md](api/SpriteSheet.md) | The 12×8 sheet layout (derived cell size, e.g. 576×384 or 936×864) and the **1..8 character index** semantics. |
+| [api/IconSet.md](api/IconSet.md) | Icon sets: a 32×32 tile grid with **row-major** indexing (`row = iconIndex / ColumnCount`, `col = iconIndex % ColumnCount`), loaded into the engine and displayed above character sprites. |
 | [api/SpriteSheetManager.md](api/SpriteSheetManager.md) | Loading full/part sheets by path or stream, including the async `LoadAsync`/`LoadPartAsync` overloads. |
 | [api/TileMap.md](api/TileMap.md) / [api/TileSet.md](api/TileSet.md) | Tiled TMX/TSX loading (sync + async); prerendered layer images, viewport-culled image-blit rendering and `IDisposable`; map custom properties, object layers, the `above_player` flag and collision (`IsSolid`, the `is_collision` layer convention). |
 | [api/TileMapLayer.md](api/TileMapLayer.md) | Tile-layer data and the `AbovePlayer` / `IsCollision` flags. |

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -22,6 +22,12 @@ spritesheet references used to render it.
   the player's key-driven movement — so NPCs stop at walls and at the map edge instead of
   walking through the world. The one-shot `Move(...)` displacement stays a raw displacement
   (only the `StartMoving`/`Update` path is resolved).
+- A non-null `IconIndex` renders the selected 32×32 icon **above the sprite** (centered
+  horizontally on the character, its bottom edge at the sprite's top edge) within the
+  character's Y-sorted draw pass, **when an icon set is loaded** into the engine
+  (`GameEngine.LoadIconSet` / `LoadIconSetAsync`). A non-null index with no icon set loaded
+  throws `InvalidOperationException` at draw time; an index outside the loaded set's range throws
+  `ArgumentOutOfRangeException`.
 
 ## Properties
 
@@ -103,6 +109,28 @@ irrelevant for part sheets — they are composed in the fixed RPG Maker MZ order
 var character = new Character();
 character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
 character.SpriteSheets.Add(new SpriteSheetRef("cape", CharacterIndex: 4));
+```
+
+### `int? IconIndex`
+
+Gets or sets the index of the icon from the loaded icon set to display **above** the character's
+sprite, or `null` to display no icon. The default is `null`. The icon is selected with the
+**row-major** formula `iconRow = floor(iconIndex / ColumnCount)`,
+`iconColumn = iconIndex % ColumnCount` — consecutive indices walk left-to-right across a row
+first, then wrap to the next row (index 1 is to the right of index 0). A non-null value renders
+the selected 32×32 icon above the sprite (centered horizontally on the character, its bottom edge
+at the sprite's top edge) when an icon set is loaded; a non-null index with no set loaded throws
+`InvalidOperationException` at draw time.
+
+For the player, use `Player.Character.IconIndex` (there is no forwarding property on `Player`).
+
+```csharp
+// The engine must have an icon set loaded (e.g. engine.LoadIconSet("assets/icons/icons.png")).
+// A 96×64 set is 3 columns × 2 rows: index 0 is the top-left tile and index 1 is to its right.
+var character = new Character { Position = new Position(3.5, 4.5) };
+character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+character.IconIndex = 0; // draw the top-left icon above the sprite
+character.IconIndex = null; // hide the icon again
 ```
 
 ## Methods

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -93,6 +93,12 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   prerenders each tile layer into an `SKImage` on load).
 - Tile sets are not loaded through the engine: a `TileMap` owns the tilesets its layers
   reference. Standalone tilesets are loaded directly through the `TileSet.Load` factories.
+- **Icon sets**: `LoadIconSet` / `LoadIconSetAsync` load a single icon set (a PNG divided into
+  32×32 tiles) into the engine. Characters with a non-null `Character.IconIndex` then draw the
+  selected 32×32 icon **above their sprite** (centered horizontally on the character, its bottom
+  edge at the sprite's top edge) within the Y-sorted character pass. The engine holds exactly one
+  icon set; a subsequent load **replaces** the previous set. See
+  [IconSet.md](IconSet.md) and [Character.md](Character.md).
 
 ## Constructors
 
@@ -393,6 +399,46 @@ streams that only support asynchronous reads. The caller remains the owner of th
 using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/character_part_body.png"));
 await engine.LoadPartSpriteSheetAsync("villager_body", stream, CharacterPartType.Body);
 ```
+
+### `void LoadIconSet(string path)`
+
+Loads the single **icon set** from a file path into the engine so characters with a non-null
+`Character.IconIndex` can display a small icon **above their sprite**. The set is a PNG divided
+into 32×32 tiles of arbitrary overall size; the number of rows and columns is deduced from the
+image dimensions (`RowCount = height / 32`, `ColumnCount = width / 32`). Throws
+`ArgumentNullException` when `path` is null; `ArgumentException` when `path` is empty after
+trimming, the image cannot be decoded, or its dimensions are not a positive multiple of 32 on both
+axes.
+
+```csharp
+engine.LoadIconSet("assets/icons/icons.png"); // e.g. a 96×64 PNG (3 columns × 2 rows)
+```
+
+### `void LoadIconSet(Stream stream)`
+
+Loads the single icon set from a stream (the file-system-free entry point, e.g. WebAssembly builds
+where assets are fetched over HTTP). The caller remains the owner of the stream. Throws
+`ArgumentNullException` when `stream` is null; `ArgumentException` when the image cannot be decoded
+or its dimensions are not a positive multiple of 32 on both axes.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/icons/icons.png"));
+engine.LoadIconSet(stream);
+```
+
+### `Task LoadIconSetAsync(Stream stream)`
+
+The asynchronous counterpart of `LoadIconSet(Stream)` for streams that only support asynchronous
+reads (e.g. certain network/browser streams). The caller remains the owner of the stream.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/icons/icons.png"));
+await engine.LoadIconSetAsync(stream);
+```
+
+> **Replacement semantics:** the engine holds exactly **one** icon set. A subsequent
+> `LoadIconSet` / `LoadIconSetAsync` call (path, stream or async) **replaces** the previous set —
+> there is no name, so there is no duplicate-name error.
 
 ### `bool SpriteSheetExists(string name)`
 

--- a/docs/api/IconSet.md
+++ b/docs/api/IconSet.md
@@ -1,0 +1,131 @@
+# IconSet
+
+Namespace: `RPGEngine.Sprites` — a single icon set: an image divided into a **32×32 tile grid**
+from which characters can display a small icon **above their sprite** (e.g. a quest marker or a
+status balloon).
+
+The number of rows and columns is **deduced from the image dimensions** (`RowCount = height / 32`,
+`ColumnCount = width / 32`), so a 96×64 image is a 3-column × 2-row set of 6 icons and a 32×32
+image is a 1×1 set of a single icon.
+
+## Remarks
+
+- This is the icon-set counterpart of `SpriteSheet`: a plain data + slice object that owns the
+  single decoded `SKImage` backing every icon returned by `GetIcon`. The decoded image is never
+  mutated.
+- Instances are created through the `Load(string)` / `Load(Stream)` / `LoadAsync(Stream)`
+  factories (the constructor is internal) and are **not** `IDisposable`; the engine owns the
+  single loaded instance for its lifetime.
+- Icons are addressed with a zero-based index using the **row-major** formula
+  `row = iconIndex / ColumnCount`, `col = iconIndex % ColumnCount` (integer division, i.e. floor).
+  Consecutive indices walk **left-to-right across a row first**, then wrap to the next row:
+  index 0 is the top-left tile, index 1 is immediately to its **right**, and a full row is
+  filled before moving down. On a 96×64 set (3 columns × 2 rows), index 4 is the tile at
+  `(row = 1, col = 1)`. This row-major ordering is the only one that is valid for arbitrary
+  (non-square) sets and matches the engine's existing character-index convention
+  (`SpriteSheet.GetSprite`: `charCol = (index − 1) % 4`, `charRow = (index − 1) / 4`).
+
+## Constants
+
+### `const int TileSize = 32`
+
+The normative icon tile size in pixels.
+
+## Properties
+
+### `int RowCount`
+
+Gets the number of icon rows in the set (`source.Height / TileSize`) — the **vertical** count of
+32×32 tiles.
+
+### `int ColumnCount`
+
+Gets the number of icon columns in the set (`source.Width / TileSize`) — the **horizontal** count
+of 32×32 tiles.
+
+### `int Count`
+
+Gets the total number of icons in the set (`RowCount × ColumnCount`).
+
+## Methods
+
+### `static IconSet Load(string path)`
+
+Loads the icon set from a file path: the image is decoded and its dimensions validated as a 32×32
+grid. Throws `ArgumentNullException` when `path` is null; `ArgumentException` when `path` is empty
+after trimming, the image cannot be decoded, or its dimensions are not a positive multiple of 32
+on both axes.
+
+```csharp
+var iconSet = IconSet.Load("assets/icons/icons.png"); // e.g. a 96×64 PNG (3 columns × 2 rows)
+```
+
+### `static IconSet Load(Stream stream)`
+
+Loads the icon set from a stream (the file-system-free entry point, e.g. WebAssembly builds where
+assets are fetched over HTTP). The caller remains the owner of the stream. Throws
+`ArgumentNullException` when `stream` is null; `ArgumentException` when the image cannot be decoded
+or its dimensions are not a positive multiple of 32 on both axes.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/icons/icons.png"));
+var iconSet = IconSet.Load(stream);
+```
+
+### `static Task<IconSet> LoadAsync(Stream stream)`
+
+The asynchronous counterpart of `Load(Stream)` for streams that only support asynchronous reads
+(e.g. certain network/browser streams). The stream is copied into an in-memory buffer asynchronously
+and decoded from that seekable buffer, so no synchronous read is performed on the caller's stream.
+The caller remains the owner of the stream.
+
+```csharp
+using var stream = new MemoryStream(await http.GetByteArrayAsync("assets/icons/icons.png"));
+var iconSet = await IconSet.LoadAsync(stream);
+```
+
+### `SKImage GetIcon(int iconIndex)`
+
+Returns the 32×32 icon at `iconIndex` (zero-based, `0..Count - 1`). The returned image is an
+**independent raster crop** the caller owns and disposes. Throws `ArgumentOutOfRangeException`
+when `iconIndex` is outside the set.
+
+The icon is selected with the **row-major** formula `row = iconIndex / ColumnCount`,
+`col = iconIndex % ColumnCount`: consecutive indices walk left-to-right across a row first, then
+wrap to the next row. On a 3-column set, index 1 is the **second tile of the top row** — to the
+**right** of index 0 — not the tile below it.
+
+```csharp
+using var icon = iconSet.GetIcon(iconIndex: 4); // 96×64 set: the tile at (row = 4/3 = 1, col = 4%3 = 1)
+canvas.DrawImage(icon, new SKPoint(0, 0));
+```
+
+## Example: loading a set and displaying an icon above a character
+
+```csharp
+var engine = new GameEngine();
+
+// Load the player's full spritesheet and the icon set (a 96×64 PNG = 3 columns × 2 rows).
+engine.LoadSpriteSheet("hero", "assets/characters/character_full.png");
+engine.LoadIconSet("assets/icons/icons.png");
+
+engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+engine.Player.Position = new Position(2.5, 3.0);
+
+// Index 0 is the top-left tile; on a 3-column set, index 1 is to its right (across the row).
+engine.Player.Character.IconIndex = 0;
+
+// Render as usual: the selected 32×32 icon is drawn above the player's sprite, centered
+// horizontally on the character's feet, its bottom edge at the sprite's top edge.
+using var bitmap = new SKBitmap(240, 240);
+using (var canvas = new SKCanvas(bitmap))
+{
+    canvas.Clear(SKColors.Transparent);
+    engine.Render(canvas, dt: 1.0 / 60);
+}
+```
+
+> A non-null `Character.IconIndex` with no icon set loaded throws `InvalidOperationException` at
+> draw time; an index outside the loaded set's range throws `ArgumentOutOfRangeException`. The
+> engine holds exactly **one** icon set — a subsequent `LoadIconSet`/`LoadIconSetAsync` call
+> **replaces** the previous set (there is no name, so no duplicate-name error).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -28,6 +28,7 @@ documented**. Every page below includes a commented, compilable example; the tes
 | Type | Kind | Page |
 | --- | --- | --- |
 | `SpriteSheet` | class | [SpriteSheet.md](SpriteSheet.md) |
+| `IconSet` | class | [IconSet.md](IconSet.md) |
 | `SpriteSheetRef` | readonly record struct | [SpriteSheetRef.md](SpriteSheetRef.md) |
 | `SpriteSheetType` | enum | [SpriteSheetType.md](SpriteSheetType.md) |
 | `CharacterPartType` | enum | [CharacterPartType.md](CharacterPartType.md) |

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -117,6 +117,25 @@ public sealed class Character
     public IList<SpriteSheetRef> SpriteSheets => _spriteSheets;
 
     /// <summary>
+    /// Gets or sets the index of the icon from the loaded icon set to display above the
+    /// character's sprite, or <see langword="null"/> to display no icon. The icon is selected
+    /// with the row-major formula <c>iconRow = floor(iconIndex / ColumnCount)</c>,
+    /// <c>iconColumn = iconIndex % ColumnCount</c>.
+    /// </summary>
+    /// <remarks>
+    /// A non-null value renders the selected 32×32 icon <em>above</em> the sprite (centered
+    /// horizontally on the character's feet, its bottom edge at the sprite's top edge) within
+    /// the character's Y-sorted draw pass, when an icon set is loaded into the engine (see
+    /// <c>GameEngine.LoadIconSet</c>/<c>GameEngine.LoadIconSetAsync</c>). A non-null index with
+    /// no icon set loaded throws <see cref="InvalidOperationException"/> at draw time; an index
+    /// outside the loaded set's <c>0..Count-1</c> range throws
+    /// <see cref="ArgumentOutOfRangeException"/> at draw time. The default is
+    /// <see langword="null"/> (no icon). Use <see cref="Player.Character"/>'s
+    /// <c>IconIndex</c> for the player (there is no forwarding property on <see cref="Player"/>).
+    /// </remarks>
+    public int? IconIndex { get; set; }
+
+    /// <summary>
     /// Gets the current walk-cycle animation frame (0..2). The middle frame (1) is the standing
     /// frame. The frame advances on a time/speed basis (see <see cref="Update(double, TileMap)"/>). This
     /// accessor is internal so tests can verify animation advancement.
@@ -267,23 +286,28 @@ public sealed class Character
     /// Draws the character at <paramref name="anchorPosition"/> (its feet position — the
     /// middle-bottom of the sprite — minus the camera origin). The spritesheet references are
     /// resolved through <paramref name="spriteSheetManager"/>, which the engine supplies at
-    /// draw time.
+    /// draw time. When <see cref="IconIndex"/> is non-null and an icon set is supplied through
+    /// <paramref name="iconSet"/>, the selected 32×32 icon is drawn above the sprite (centered
+    /// horizontally on the feet, its bottom edge at the sprite's top edge).
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
     /// <param name="anchorPosition">The feet (middle-bottom) anchor of the sprite, in pixels:
     /// the sprite is drawn above and centered on this point.</param>
     /// <param name="dt">The elapsed time in seconds (reserved for future animation timing).</param>
     /// <param name="spriteSheetManager">The manager that resolves the referenced sheet names.</param>
+    /// <param name="iconSet">The icon set loaded into the engine, or <see langword="null"/> when
+    /// none is loaded. Required to be non-null when <see cref="IconIndex"/> is non-null.</param>
     /// <exception cref="InvalidOperationException">
     /// The <see cref="SpriteSheets"/> list mixes full and part sheets, or contains more than one
-    /// full sheet.
+    /// full sheet, or <see cref="IconIndex"/> is non-null while <paramref name="iconSet"/> is
+    /// <see langword="null"/> (no icon set is loaded).
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// A <see cref="SpriteSheetRef"/> has a <see cref="SpriteSheetRef.CharacterIndex"/> outside 1..8.
     /// </exception>
-    internal void Draw(SKCanvas canvas, Position anchorPosition, double dt, SpriteSheetManager spriteSheetManager)
+    internal void Draw(SKCanvas canvas, Position anchorPosition, double dt, SpriteSheetManager spriteSheetManager, IconSet? iconSet)
     {
-        _compositor.Draw(canvas, anchorPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager);
+        _compositor.Draw(canvas, anchorPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager, iconSet, IconIndex);
     }
 
     /// <summary>

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -143,6 +143,13 @@ namespace RPGEngine;
 public sealed class GameEngine : IDisposable
 {
     private readonly SpriteSheetManager _spriteSheetManager = new();
+
+    // The single icon set "loaded into the game": a PNG divided into 32×32 tiles from which
+    // characters with a non-null Character.IconIndex draw a small icon above their sprite. A
+    // subsequent LoadIconSet/LoadIconSetAsync call replaces the previous set (there is no name,
+    // so no duplicate-name error).
+    private IconSet? _iconSet;
+
     private readonly List<Character> _characters = [];
     private readonly HashSet<Key> _pressedKeys = [];
     private TileMap? _map;
@@ -493,7 +500,7 @@ public sealed class GameEngine : IDisposable
             var charactersInRenderOrder = _characters.Append(Player.Character).OrderBy(c => c.Position.Y);
             foreach (var character in charactersInRenderOrder)
             {
-                character.Draw(canvas, character.Position.ToPixels(ts), dt, _spriteSheetManager);
+                character.Draw(canvas, character.Position.ToPixels(ts), dt, _spriteSheetManager, _iconSet);
             }
 
             if (Map is not null)
@@ -856,6 +863,77 @@ public sealed class GameEngine : IDisposable
         => _spriteSheetManager.LoadPartAsync(name, stream, partType);
 
     /// <summary>
+    /// Loads the single icon set from <paramref name="path"/> into the engine so characters with
+    /// a non-null <see cref="Character.IconIndex"/> can display a small icon above their sprite
+    /// (e.g. a quest marker or status balloon). The set is a PNG divided into 32×32 tiles of
+    /// arbitrary overall size; the number of rows and columns is deduced from the image
+    /// dimensions (<c>RowCount = height / <see cref="IconSet.TileSize"/></c>,
+    /// <c>ColumnCount = width / <see cref="IconSet.TileSize"/></c>).
+    /// </summary>
+    /// <param name="path">The path to an icon-set image file (PNG or other SkiaSharp-supported format).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="path"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions do not form a valid 32×32 grid (positive width and height, each a multiple of
+    /// <see cref="IconSet.TileSize"/>).
+    /// </exception>
+    /// <remarks>
+    /// The engine holds exactly one icon set: a subsequent <see cref="LoadIconSet(string)"/> (or
+    /// the stream / async overloads) <em>replaces</em> the previous set. There is no name, so
+    /// there is no duplicate-name error.
+    /// </remarks>
+    public void LoadIconSet(string path)
+    {
+        _iconSet = IconSet.Load(path);
+    }
+
+    /// <summary>
+    /// Loads the single icon set from <paramref name="stream"/> into the engine so characters
+    /// with a non-null <see cref="Character.IconIndex"/> can display a small icon above their
+    /// sprite. This is the file-system-free entry point (e.g. WebAssembly builds where assets
+    /// are fetched over HTTP).
+    /// </summary>
+    /// <param name="stream">A stream containing the encoded icon-set image (PNG or other SkiaSharp-supported format).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// The image cannot be decoded, or its dimensions do not form a valid 32×32 grid (positive
+    /// width and height, each a multiple of <see cref="IconSet.TileSize"/>).
+    /// </exception>
+    /// <remarks>
+    /// The caller remains the owner of <paramref name="stream"/>; it is not disposed here. The
+    /// engine holds exactly one icon set: a subsequent <see cref="LoadIconSet(Stream)"/> (or the
+    /// path / async overloads) <em>replaces</em> the previous set.
+    /// </remarks>
+    public void LoadIconSet(Stream stream)
+    {
+        _iconSet = IconSet.Load(stream);
+    }
+
+    /// <summary>
+    /// Asynchronously loads the single icon set from <paramref name="stream"/> into the engine so
+    /// characters with a non-null <see cref="Character.IconIndex"/> can display a small icon
+    /// above their sprite. This is the asynchronous counterpart of
+    /// <see cref="LoadIconSet(Stream)"/> for streams that only support asynchronous reads (e.g.
+    /// certain network/browser streams).
+    /// </summary>
+    /// <param name="stream">A stream containing the encoded icon-set image (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>A task that completes when the icon set is loaded and stored.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// The image cannot be decoded, or its dimensions do not form a valid 32×32 grid (positive
+    /// width and height, each a multiple of <see cref="IconSet.TileSize"/>).
+    /// </exception>
+    /// <remarks>
+    /// The caller remains the owner of <paramref name="stream"/>; it is not disposed here. The
+    /// engine holds exactly one icon set: a subsequent <see cref="LoadIconSetAsync(Stream)"/> (or
+    /// the path / stream overloads) <em>replaces</em> the previous set.
+    /// </remarks>
+    public async Task LoadIconSetAsync(Stream stream)
+    {
+        _iconSet = await IconSet.LoadAsync(stream).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Returns whether a spritesheet is registered under <paramref name="name"/>. Full sheets
     /// (loaded with <see cref="LoadSpriteSheet(string, Stream)"/>) and part sheets (loaded with
     /// <see cref="LoadPartSpriteSheet(string, Stream, CharacterPartType)"/>) share one registry,
@@ -1077,7 +1155,7 @@ public sealed class GameEngine : IDisposable
     /// Cancels any in-progress auto-walk by clearing the waypoint queue and resetting the
     /// auto-walk step state (the current step's <see cref="Player.OnStartMoving"/> was not
     /// reported, or no longer applies). The player itself stops on the next <see cref="Update"/>
-    /// (no input and no path &#8594; <see cref="Player.Stop"/>) unless it was stopped by the caller
+    /// (no input and no path → <see cref="Player.Stop"/>) unless it was stopped by the caller
     /// (a blocked auto-walk step stops it immediately).
     /// </summary>
     private void CancelAutoWalk()
@@ -1150,7 +1228,7 @@ public sealed class GameEngine : IDisposable
     /// The movement events are raised at a deterministic time relative to the displacement:
     /// <see cref="Player.ReportMovement(Direction)"/> is called <em>before</em> the position is
     /// updated, so <see cref="Player.OnStartMoving"/> fires when the player starts moving in a new
-    /// direction (idle &#8594; moving, or a direction change while moving &#8212; e.g. pressing a second key so
+    /// direction (idle → moving, or a direction change while moving — e.g. pressing a second key so
     /// the effective direction becomes a diagonal) and observes the pre-move position.
     /// After the displacement is resolved, a move with no net displacement (fully blocked by solid
     /// tiles or the map edge on every axis) is reported as a <em>collision stop</em> through

--- a/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
+++ b/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
@@ -37,6 +37,16 @@ namespace RPGEngine.Sprites;
 /// A cell's top-left is therefore at
 /// <c>(anchorPosition.X - width/2, anchorPosition.Y - height)</c> in pixels.
 /// </para>
+/// <para>
+/// When the character has a non-null <c>IconIndex</c> (see <c>Character.IconIndex</c>) and an
+/// icon set is supplied to <see cref="Draw"/>, the selected 32×32 icon is drawn <em>after</em>
+/// the sprite, <em>above</em> it: centered horizontally on the character's feet X, with its
+/// bottom edge at the sprite's top edge, within the character's Y-sorted draw pass (the engine
+/// sorts characters by <c>Position.Y</c> before drawing, so the icon moves with its character).
+/// A non-null icon index with no icon set loaded throws <see cref="InvalidOperationException"/>;
+/// an icon index outside the set's range throws <see cref="ArgumentOutOfRangeException"/> from
+/// <see cref="IconSet.GetIcon"/>.
+/// </para>
 /// </remarks>
 internal sealed class CharacterSpriteCompositor
 {
@@ -44,8 +54,17 @@ internal sealed class CharacterSpriteCompositor
     private const int MaxCharacterIndex = 8;
 
     /// <summary>
+    /// The cell height used to place an icon when the character has no spritesheet: the
+    /// documented default sprite size of 48 (the same default as <c>Character.GetSpriteSize</c>),
+    /// so a marker can be shown on a spriteless character.
+    /// </summary>
+    private const int DefaultCellHeight = 48;
+
+    /// <summary>
     /// Draws the character described by <paramref name="spriteSheetRefs"/> at
-    /// <paramref name="anchorPosition"/>.
+    /// <paramref name="anchorPosition"/>. When <paramref name="iconIndex"/> is non-null and
+    /// <paramref name="iconSet"/> is non-null, the selected 32×32 icon is drawn above the sprite
+    /// after it (see <see cref="DrawIcon"/>).
     /// </summary>
     /// <param name="canvas">The canvas to draw onto.</param>
     /// <param name="anchorPosition">The middle-bottom (feet) anchor of the sprite, in pixels:
@@ -55,12 +74,19 @@ internal sealed class CharacterSpriteCompositor
     /// <param name="direction">The direction the character faces.</param>
     /// <param name="frame">The animation frame (0..2).</param>
     /// <param name="manager">Resolves sheet names to <see cref="SpriteSheet"/> instances.</param>
+    /// <param name="iconSet">The icon set loaded into the engine, or <see langword="null"/> when
+    /// none is loaded. Required to be non-null when <paramref name="iconIndex"/> is non-null.</param>
+    /// <param name="iconIndex">The zero-based icon index to draw above the sprite, or
+    /// <see langword="null"/> to draw no icon.</param>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// A reference has a <see cref="SpriteSheetRef.CharacterIndex"/> outside 1..8.
+    /// A reference has a <see cref="SpriteSheetRef.CharacterIndex"/> outside 1..8, or
+    /// <paramref name="iconIndex"/> is outside the set's <c>0..Count-1</c> range.
     /// </exception>
     /// <exception cref="KeyNotFoundException">A referenced sheet name is not loaded in <paramref name="manager"/>.</exception>
     /// <exception cref="InvalidOperationException">
-    /// The list mixes full and part sheets, or contains more than one full sheet.
+    /// The list mixes full and part sheets, or contains more than one full sheet, or
+    /// <paramref name="iconIndex"/> is non-null while <paramref name="iconSet"/> is
+    /// <see langword="null"/> (no icon set is loaded).
     /// </exception>
     public void Draw(
         SKCanvas canvas,
@@ -68,10 +94,26 @@ internal sealed class CharacterSpriteCompositor
         IReadOnlyList<SpriteSheetRef> spriteSheetRefs,
         Direction direction,
         int frame,
-        SpriteSheetManager manager)
+        SpriteSheetManager manager,
+        IconSet? iconSet,
+        int? iconIndex)
     {
+        // Strict validation up front, mirroring the existing full/part and character-index
+        // checks: an icon can only be drawn from a loaded icon set, so a non-null index with no
+        // loaded set is a misconfiguration.
+        if (iconIndex is not null && iconSet is null)
+        {
+            throw new InvalidOperationException(
+                "No icon set is loaded. Call GameEngine.LoadIconSet (or LoadIconSetAsync) " +
+                "before setting a character's IconIndex.");
+        }
+
         if (spriteSheetRefs.Count == 0)
         {
+            // A spriteless character: draw only the icon, placed above the documented default
+            // sprite size of 48×48 (the same default as Character.GetSpriteSize), so a marker
+            // can be shown on a character without a sheet.
+            DrawIcon(canvas, anchorPosition, DefaultCellHeight, iconSet, iconIndex);
             return;
         }
 
@@ -84,6 +126,7 @@ internal sealed class CharacterSpriteCompositor
         {
             // A single full sheet: draw its cell directly, no composition.
             DrawCell(canvas, anchorPosition, resolved[0], direction, frame);
+            DrawIcon(canvas, anchorPosition, resolved[0].Sheet.CellHeight, iconSet, iconIndex);
             return;
         }
 
@@ -96,6 +139,11 @@ internal sealed class CharacterSpriteCompositor
         }
 
         ComposeParts(canvas, anchorPosition, resolved, direction, frame);
+
+        // The icon is placed above the sprite using the derived cell height the parts were drawn
+        // at (all parts of a composition come from the same RPG Maker MZ export, so they share a
+        // cell size; the first resolved part is authoritative).
+        DrawIcon(canvas, anchorPosition, resolved[0].Sheet.CellHeight, iconSet, iconIndex);
     }
 
     /// <summary>
@@ -207,6 +255,43 @@ internal sealed class CharacterSpriteCompositor
         canvas.DrawImage(sprite, new SKPoint(
             (float)(anchorPosition.X - sprite.Width / 2.0),
             (float)(anchorPosition.Y - sprite.Height)));
+    }
+
+    /// <summary>
+    /// Draws the selected icon above the sprite when one is configured: the 32×32 icon is drawn
+    /// centered horizontally on the character's feet X, with its bottom edge at the sprite's top
+    /// edge. The sprite's top is at <c>anchorPosition.Y - cellHeight</c>, so the icon's top-left
+    /// is at <c>(anchorPosition.X - icon.Width / 2, anchorPosition.Y - cellHeight - icon.Height)</c>.
+    /// </summary>
+    /// <param name="canvas">The canvas to draw onto.</param>
+    /// <param name="anchorPosition">The feet (middle-bottom) anchor of the sprite, in pixels.</param>
+    /// <param name="cellHeight">The derived cell height the sprite was drawn at (the default 48
+    /// for a spriteless character).</param>
+    /// <param name="iconSet">The icon set loaded into the engine, or <see langword="null"/>.</param>
+    /// <param name="iconIndex">The zero-based icon index, or <see langword="null"/> for no icon.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="iconIndex"/> is outside the set's <c>0..Count-1</c> range.
+    /// </exception>
+    private static void DrawIcon(
+        SKCanvas canvas,
+        Position anchorPosition,
+        int cellHeight,
+        IconSet? iconSet,
+        int? iconIndex)
+    {
+        if (iconIndex is null || iconSet is null)
+        {
+            return;
+        }
+
+        // The icon is drawn above the sprite: 32x32, centered horizontally on the character's
+        // feet X, its bottom edge at the sprite's top edge. The sprite's top is at
+        // anchorPosition.Y - cellHeight, so the icon's top-left is at
+        // (anchorPosition.X - 16, anchorPosition.Y - cellHeight - 32).
+        using var icon = iconSet.GetIcon(iconIndex.Value);
+        canvas.DrawImage(icon, new SKPoint(
+            (float)(anchorPosition.X - icon.Width / 2.0),
+            (float)(anchorPosition.Y - cellHeight - icon.Height)));
     }
 
     /// <summary>Returns the first resolved part of the given type, or <see langword="null"/> when absent.</summary>

--- a/src/RPGEngine/Sprites/IconSet.cs
+++ b/src/RPGEngine/Sprites/IconSet.cs
@@ -1,0 +1,238 @@
+using SkiaSharp;
+
+namespace RPGEngine.Sprites;
+
+/// <summary>
+/// A single icon set: an image divided into a 32×32 tile grid from which characters can display
+/// a small icon above their sprite (e.g. a quest marker or a status balloon). The number of rows
+/// and columns is deduced from the decoded image dimensions (<see cref="RowCount"/> =
+/// <c>height / <see cref="TileSize"/></c>, <see cref="ColumnCount"/> = <c>width /
+/// <see cref="TileSize"/></c>), so a 96×64 image is a 3-column × 2-row set of 6 icons and a
+/// 32×32 image is a 1×1 set of a single icon.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the icon-set counterpart of <see cref="SpriteSheet"/>: a plain data + slice object
+/// that owns the single decoded <see cref="SKImage"/> backing every icon returned by
+/// <see cref="GetIcon"/>. The decoded image is never mutated. Instances are created through the
+/// <see cref="Load(string)"/>, <see cref="Load(Stream)"/> and <see cref="LoadAsync(Stream)"/>
+/// factories (the constructor is internal) and are not <see cref="System.IDisposable"/>; the
+/// engine owns the single loaded instance for its lifetime.
+/// </para>
+/// <para>
+/// Icons are addressed with a zero-based index using the <em>row-major</em> formula
+/// <c>row = iconIndex / ColumnCount</c>, <c>col = iconIndex % ColumnCount</c> (integer division,
+/// i.e. floor). Consecutive indices walk <em>left-to-right across a row first</em>, then wrap to
+/// the next row: index 0 is the top-left tile, index 1 is immediately to its <em>right</em>, and
+/// a full row is filled before moving down. On a 96×64 set (3 columns × 2 rows), index 4 is the
+/// tile at <c>(row = 1, col = 1)</c>. This row-major ordering is the only one that is valid for
+/// arbitrary (non-square) sets and matches the engine's existing character-index convention
+/// (<c>SpriteSheet.GetSprite</c>: <c>charCol = (index − 1) % 4</c>, <c>charRow = (index − 1) / 4</c>).
+/// </para>
+/// </remarks>
+public sealed class IconSet
+{
+    /// <summary>The normative icon tile size in pixels.</summary>
+    public const int TileSize = 32;
+
+    private readonly SKImage _source;
+
+    /// <summary>
+    /// Gets the number of icon rows in the set (<c>source.Height / <see cref="TileSize"/></c>),
+    /// i.e. the vertical count of 32×32 tiles.
+    /// </summary>
+    public int RowCount { get; }
+
+    /// <summary>
+    /// Gets the number of icon columns in the set (<c>source.Width / <see cref="TileSize"/></c>),
+    /// i.e. the horizontal count of 32×32 tiles.
+    /// </summary>
+    public int ColumnCount { get; }
+
+    /// <summary>Gets the total number of icons in the set (<see cref="RowCount"/> × <see cref="ColumnCount"/>).</summary>
+    public int Count => RowCount * ColumnCount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IconSet"/> class. Sets are created through
+    /// the <see cref="Load(string)"/>, <see cref="Load(Stream)"/> and <see cref="LoadAsync(Stream)"/>
+    /// factories.
+    /// </summary>
+    /// <param name="source">The decoded set image, already validated as a 32×32 tile grid.</param>
+    /// <param name="rowCount">The derived row count (<c>source.Height / <see cref="TileSize"/></c>).</param>
+    /// <param name="columnCount">The derived column count (<c>source.Width / <see cref="TileSize"/></c>).</param>
+    internal IconSet(SKImage source, int rowCount, int columnCount)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        RowCount = rowCount;
+        ColumnCount = columnCount;
+    }
+
+    /// <summary>
+    /// Loads the icon set at <paramref name="path"/>: the image is decoded and its dimensions are
+    /// validated as a 32×32 tile grid.
+    /// </summary>
+    /// <param name="path">The path to an image file (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>The loaded <see cref="IconSet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="path"/> is empty after trimming, the image cannot be decoded, or its
+    /// dimensions do not form a valid 32×32 grid (positive width and height, each a multiple of
+    /// <see cref="TileSize"/>).
+    /// </exception>
+    public static IconSet Load(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (path.Trim().Length == 0)
+        {
+            throw new ArgumentException("Icon set path must not be empty after trimming.", nameof(path));
+        }
+
+        using var stream = File.OpenRead(path);
+        return Load(stream);
+    }
+
+    /// <summary>
+    /// Loads the icon set from <paramref name="stream"/>: the image is decoded and its dimensions
+    /// are validated as a 32×32 tile grid. This is the file-system-free entry point (e.g.
+    /// WebAssembly builds where assets are fetched over HTTP).
+    /// </summary>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>The loaded <see cref="IconSet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// The image cannot be decoded, or its dimensions do not form a valid 32×32 grid (positive
+    /// width and height, each a multiple of <see cref="TileSize"/>).
+    /// </exception>
+    /// <remarks>
+    /// The caller remains the owner of <paramref name="stream"/>; it is not disposed here.
+    /// </remarks>
+    public static IconSet Load(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var image = Decode(stream, "<stream>");
+        return new IconSet(image, image.Height / TileSize, image.Width / TileSize);
+    }
+
+    /// <summary>
+    /// Asynchronously loads the icon set from <paramref name="stream"/>. This is the asynchronous
+    /// counterpart of <see cref="Load(Stream)"/> for streams that only support asynchronous reads
+    /// (e.g. certain network/browser streams).
+    /// </summary>
+    /// <param name="stream">A stream containing the encoded image (PNG or other SkiaSharp-supported format).</param>
+    /// <returns>A task that resolves to the loaded <see cref="IconSet"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// The image cannot be decoded, or its dimensions do not form a valid 32×32 grid (positive
+    /// width and height, each a multiple of <see cref="TileSize"/>).
+    /// </exception>
+    /// <remarks>
+    /// The stream is copied into an in-memory buffer asynchronously and decoded from that seekable
+    /// buffer with the same validation as the synchronous overload, so no synchronous read is
+    /// performed on the caller's stream. The caller remains the owner of <paramref name="stream"/>;
+    /// it is not disposed here.
+    /// </remarks>
+    public static async Task<IconSet> LoadAsync(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer).ConfigureAwait(false);
+        buffer.Position = 0;
+
+        return Load(buffer);
+    }
+
+    /// <summary>
+    /// Returns the 32×32 icon at <paramref name="iconIndex"/> within the set.
+    /// </summary>
+    /// <param name="iconIndex">The zero-based icon index, in <c>0..<see cref="Count"/> - 1</c>.</param>
+    /// <returns>
+    /// An independent 32×32 <see cref="SKImage"/> cropped from the decoded source. The caller owns
+    /// and disposes it.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="iconIndex"/> is outside <c>0..<see cref="Count"/> - 1</c>.
+    /// </exception>
+    /// <remarks>
+    /// The icon is selected with the <em>row-major</em> formula
+    /// <c>row = iconIndex / ColumnCount</c>, <c>col = iconIndex % ColumnCount</c>: consecutive
+    /// indices walk left-to-right across a row first, then wrap to the next row (index 1 is to the
+    /// right of index 0). On a 96×64 set (3 columns × 2 rows), index 4 is the tile at
+    /// <c>(row = 1, col = 1)</c>.
+    /// <para>
+    /// The returned image is an independent <see cref="TileSize"/>×<see cref="TileSize"/> raster
+    /// crop of the decoded source, produced with nearest-neighbour sampling (a 1:1 pixel copy,
+    /// never a re-encode). We deliberately avoid <c>SKImage.Subset</c> here: on SkiaSharp 3.119.4,
+    /// subsets of an image decoded from encoded data crash the native runtime once an earlier
+    /// subset has been disposed (the same reasoning as <see cref="SpriteSheet.GetSprite"/>).
+    /// </para>
+    /// </remarks>
+    public SKImage GetIcon(int iconIndex)
+    {
+        if (iconIndex < 0 || iconIndex >= Count)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(iconIndex),
+                iconIndex,
+                $"Icon index must be between 0 and {Count - 1} for an icon set with {Count} icons.");
+        }
+
+        // Row-major slicing: row = iconIndex / ColumnCount, col = iconIndex % ColumnCount.
+        var row = iconIndex / ColumnCount;
+        var col = iconIndex % ColumnCount;
+
+        var source = new SKRectI(
+            col * TileSize,
+            row * TileSize,
+            (col + 1) * TileSize,
+            (row + 1) * TileSize);
+
+        // Raster crop of the decoded source with nearest-neighbour sampling (1:1 pixel copy, no
+        // re-encode). SKImage.FromBitmap copies the pixels, so the returned image is independent
+        // of _source and of the temporary bitmap disposed below.
+        var iconBitmap = new SKBitmap(TileSize, TileSize);
+        try
+        {
+            using var canvas = new SKCanvas(iconBitmap);
+            canvas.Clear(SKColors.Transparent);
+
+            var destination = new SKRect(0, 0, TileSize, TileSize);
+            var sampling = new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
+            canvas.DrawImage(_source, source, destination, sampling);
+
+            return SKImage.FromBitmap(iconBitmap);
+        }
+        finally
+        {
+            iconBitmap.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Decodes the image from <paramref name="stream"/> and validates it as a 32×32 tile grid
+    /// (mirrors <c>SpriteSheetManager.Decode</c>).
+    /// </summary>
+    private static SKImage Decode(Stream stream, string sourceDescription)
+    {
+        var image = SKImage.FromEncodedData(stream)
+            ?? throw new ArgumentException($"The image '{sourceDescription}' could not be decoded as an icon set.");
+
+        // Capture the dimensions before any disposal: the decoded image must stay alive while its
+        // native properties are read (accessing it inside the exception message after Dispose()
+        // would be a native use-after-free).
+        var width = image.Width;
+        var height = image.Height;
+        if (width <= 0 || height <= 0 || width % TileSize != 0 || height % TileSize != 0)
+        {
+            image.Dispose();
+            throw new ArgumentException(
+                $"An icon set must be an image divided into {TileSize}×{TileSize} tiles " +
+                $"(positive width and height, each a multiple of {TileSize}), but '{sourceDescription}' " +
+                $"was {width}×{height}.");
+        }
+
+        return image;
+    }
+}

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -638,7 +638,7 @@ public class CharacterTests
         using var bitmap = new SKBitmap(CharacterTestHelper.CellSize, CharacterTestHelper.CellSize);
         using var canvas = new SKCanvas(bitmap);
         Assert.Throws<InvalidOperationException>(
-            () => character.Draw(canvas, new Position(0, 0), dt: 1, manager));
+            () => character.Draw(canvas, new Position(0, 0), dt: 1, manager, null));
     }
 
     // ---------------------------------------------------------------------
@@ -660,7 +660,7 @@ public class CharacterTests
         using var bitmap = new SKBitmap(CharacterTestHelper.CellSize, CharacterTestHelper.CellSize);
         using var canvas = new SKCanvas(bitmap);
         Assert.Throws<ArgumentOutOfRangeException>(
-            () => character.Draw(canvas, new Position(0, 0), dt: 1, manager));
+            () => character.Draw(canvas, new Position(0, 0), dt: 1, manager, null));
     }
 
     // ---------------------------------------------------------------------
@@ -758,7 +758,7 @@ public class CharacterTests
         {
             canvas.Clear(SKColors.Transparent);
             // The sprite's middle-bottom (feet) sits at (48, 72): top-left (24, 24).
-            character.Draw(canvas, new Position(48, 72), dt: 1, manager);
+            character.Draw(canvas, new Position(48, 72), dt: 1, manager, null);
         }
 
         var expected = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.Down, StandingFrame);
@@ -833,7 +833,7 @@ public class CharacterTests
         using (var canvas = new SKCanvas(bitmap))
         {
             canvas.Clear(SKColors.Transparent);
-            character.Draw(canvas, new Position(width / 2.0, height), dt: 1, manager);
+            character.Draw(canvas, new Position(width / 2.0, height), dt: 1, manager, null);
         }
 
         return bitmap;

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -870,4 +870,68 @@ public class DocsExamplesTests
         Assert.Equal(12, map.Height);
         Assert.Equal(3, map.Layers.Count); // ground + decor + trees_above
     }
+
+    // ---------------------------------------------------------------------
+    // docs/api/IconSet.md and docs/api/Character.md: loading an icon set and
+    // displaying an icon above a character's sprite (story 70).
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// The icon-set example from the documentation: load a 96×64 icon set (3 columns × 2 rows),
+    /// load it into the engine, set <c>Player.Character.IconIndex</c> and render, then assert the
+    /// icon tile's unique color appears above the sprite.
+    /// </summary>
+    [Fact]
+    public void IconSet_LoadAndDisplayIcon_Example()
+    {
+        // 1. Load an icon set: a PNG divided into 32×32 tiles of arbitrary overall size; the
+        //    number of rows and columns is deduced from the dimensions.
+        using (var stream = new MemoryStream(IconSetTestHelper.CreateIconSetPng(rows: 2, cols: 3), writable: false))
+        {
+            var iconSet = IconSet.Load(stream);
+
+            Console.WriteLine(iconSet.RowCount);    // 2 (height / 32 = 64 / 32)
+            Console.WriteLine(iconSet.ColumnCount); // 3 (width / 32 = 96 / 32)
+            Console.WriteLine(iconSet.Count);       // 6 (RowCount * ColumnCount)
+
+            // Row-major indexing: on a 3-column set, index 1 is the second tile of the top row
+            // (to the right of index 0), and index 4 is the tile at (row = 4/3 = 1, col = 4%3 = 1).
+            using var icon = iconSet.GetIcon(4);
+            Assert.Equal(IconSetTestHelper.TileSize, icon.Width);  // 32
+            Assert.Equal(IconSetTestHelper.TileSize, icon.Height); // 32
+        }
+
+        // 2. Load the set into the engine and display an icon above a character's sprite.
+        var engine = new GameEngine();
+        using (var sheetStream = CharacterTestHelper.CreateSheetStream(seed: 1))
+        {
+            engine.LoadSpriteSheet("hero", sheetStream);
+        }
+
+        using (var iconStream = IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3))
+        {
+            engine.LoadIconSet(iconStream);
+        }
+
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        engine.Player.Character.IconIndex = 0; // the top-left icon of the loaded set
+        engine.Player.Position = new Position(2.5, 3.0);
+
+        // 3. Render one frame and assert the icon is drawn above the sprite: the player's feet
+        //    are at (120, 144), the 48×48 sprite spans (96, 96)-(144, 144) and the 32×32 icon
+        //    spans (104, 64)-(136, 96), so the icon center is (120, 80) and the sprite center is
+        //    (120, 120).
+        const int canvasSize = 240;
+        using var bitmap = new SKBitmap(canvasSize, canvasSize);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.Render(canvas, FrameDt);
+        }
+
+        var expectedIcon = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 0);
+        Assert.Equal(expectedIcon, bitmap.GetPixel(120, 80));
+
+        var expectedSprite = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, frame: 1);
+        Assert.Equal(expectedSprite, bitmap.GetPixel(120, 120));
+    }
 }

--- a/tests/RPGEngine.Tests/GameEngineIconTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineIconTests.cs
@@ -1,0 +1,291 @@
+using RPGEngine.Sprites;
+using RPGEngine.Tests.Sprites;
+using SkiaSharp;
+using Xunit;
+
+namespace RPGEngine.Tests;
+
+/// <summary>
+/// Acceptance tests for the engine's icon-set API (story 70): <c>GameEngine.LoadIconSet</c> /
+/// <c>LoadIconSetAsync</c> and <c>Character.IconIndex</c> rendering. The icon-set fixtures are
+/// PNGs divided into 32×32 tiles, each tile filled with a unique color (see
+/// <see cref="IconSetTestHelper"/>); the sprite fixtures are the seeded full sheets of
+/// <see cref="CharacterTestHelper"/>.
+/// </summary>
+/// <remarks>
+/// All rendering tests place a 48×48 sprite at a known feet anchor so the icon's expected pixel
+/// position is exact: with the player at (2.5, 3.0) tiles and no map (48 px tiles), the feet are
+/// at (120, 144), the sprite's top-left at (96, 96) and the 32×32 icon's top-left at (104, 64),
+/// so the sprite center is (120, 120) and the icon center is (120, 80).
+/// </remarks>
+public class GameEngineIconTests
+{
+    private const double FrameDt = 1.0 / 60;
+    private const int CellSize = 48;
+    private const int StandingFrame = 1;
+    private const int CanvasSize = 240;
+
+    // The player's anchor and the derived pixel positions used by the rendering assertions.
+    private static readonly Position PlayerPosition = new(2.5, 3.0);
+    private const int PlayerSpriteCenterX = 120;
+    private const int PlayerSpriteCenterY = 120;
+    private const int PlayerIconCenterX = 120;
+    private const int PlayerIconCenterY = 80;
+
+    // ---------------------------------------------------------------------
+    // Acceptance 8: each LoadIconSet overload stores the set (proven by
+    // rendering); async via AsyncOnlyStream.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies the path, stream and async (AsyncOnlyStream) overloads each store the set, proven
+    /// by rendering the loaded icon's color above the player's sprite.
+    /// </summary>
+    [Fact]
+    public async Task LoadIconSet_ByPath_ByStream_Async_AllLoad()
+    {
+        var expected = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 0);
+
+        // By path.
+        var path = WriteTempPng(IconSetTestHelper.CreateIconSetPng(rows: 2, cols: 3));
+        try
+        {
+            var byPath = new GameEngine();
+            byPath.LoadIconSet(path);
+            ConfigurePlayer(byPath);
+            byPath.Player.Character.IconIndex = 0;
+            AssertIconRendered(byPath, expected);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        // By stream.
+        var byStream = new GameEngine();
+        using (var stream = IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3))
+        {
+            byStream.LoadIconSet(stream);
+        }
+
+        ConfigurePlayer(byStream);
+        byStream.Player.Character.IconIndex = 0;
+        AssertIconRendered(byStream, expected);
+
+        // Async via an async-only stream (proves no synchronous read of the caller's stream).
+        var byAsync = new GameEngine();
+        using (var stream = new AsyncOnlyStream(IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3)))
+        {
+            await byAsync.LoadIconSetAsync(stream);
+        }
+
+        ConfigurePlayer(byAsync);
+        byAsync.Player.Character.IconIndex = 0;
+        AssertIconRendered(byAsync, expected);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 9: a subsequent load replaces the previous set.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies loading a second icon set replaces the first: rendering uses set B's colors.</summary>
+    [Fact]
+    public void LoadIconSet_ReplacesPreviousSet()
+    {
+        var engine = new GameEngine();
+
+        // Set A: 96×64 (3 columns × 2 rows).
+        using (var streamA = IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3))
+        {
+            engine.LoadIconSet(streamA);
+        }
+
+        ConfigurePlayer(engine);
+        engine.Player.Character.IconIndex = 0;
+        var colorA = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 0);
+        AssertIconRendered(engine, colorA);
+
+        // Set B: 64×96 (2 columns × 3 rows) — different dimensions, so the same icon index 0
+        // maps to a different color.
+        using (var streamB = IconSetTestHelper.CreateIconSetStream(rows: 3, cols: 2))
+        {
+            engine.LoadIconSet(streamB);
+        }
+
+        var colorB = IconSetTestHelper.IconColor(rows: 3, cols: 2, iconIndex: 0);
+        Assert.NotEqual(colorA, colorB);
+        AssertIconRendered(engine, colorB);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 10: invalid input throws.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies null path/stream throw ArgumentNullException and a non-32-grid PNG throws ArgumentException.</summary>
+    [Fact]
+    public async Task LoadIconSet_InvalidInput_Throws()
+    {
+        var engine = new GameEngine();
+
+        // null path / null stream.
+        Assert.Throws<ArgumentNullException>(() => engine.LoadIconSet((string)null!));
+        Assert.Throws<ArgumentNullException>(() => engine.LoadIconSet((Stream)null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => engine.LoadIconSetAsync(null!));
+
+        // A PNG whose dimensions are not a 32×32 grid.
+        using var bad = new MemoryStream(IconSetTestHelper.CreateIconSetPngBySize(width: 33, height: 32), writable: false);
+        Assert.Throws<ArgumentException>(() => engine.LoadIconSet(bad));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 11: rendering pixel tests.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies a player with a full sheet and IconIndex = i renders the icon tile's unique color
+    /// at the icon's center, above the sprite's color at the sprite center.
+    /// </summary>
+    [Fact]
+    public void Render_CharacterWithIconIndex_DrawsIconAboveSprite()
+    {
+        var engine = new GameEngine();
+        ConfigurePlayer(engine);
+        engine.Player.Character.IconIndex = 0;
+        using (var iconStream = IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3))
+        {
+            engine.LoadIconSet(iconStream);
+        }
+
+        using var bitmap = Render(engine, CanvasSize, CanvasSize);
+
+        var expectedIcon = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 0);
+        Assert.Equal(expectedIcon, bitmap.GetPixel(PlayerIconCenterX, PlayerIconCenterY));
+
+        var expectedSprite = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+        Assert.Equal(expectedSprite, bitmap.GetPixel(PlayerSpriteCenterX, PlayerSpriteCenterY));
+    }
+
+    /// <summary>
+    /// Regression: with IconIndex null the pixel above the sprite is not the icon color and the
+    /// sprite still renders.
+    /// </summary>
+    [Fact]
+    public void Render_CharacterWithoutIconIndex_DrawsNoIcon()
+    {
+        var engine = new GameEngine();
+        ConfigurePlayer(engine);
+        using (var iconStream = IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3))
+        {
+            engine.LoadIconSet(iconStream);
+        }
+
+        using var bitmap = Render(engine, CanvasSize, CanvasSize);
+
+        var iconColor = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 0);
+        Assert.NotEqual(iconColor, bitmap.GetPixel(PlayerIconCenterX, PlayerIconCenterY));
+
+        var expectedSprite = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, StandingFrame);
+        Assert.Equal(expectedSprite, bitmap.GetPixel(PlayerSpriteCenterX, PlayerSpriteCenterY));
+    }
+
+    /// <summary>Verifies two NPCs with different IconIndex values each render their own icon color above their own sprite.</summary>
+    [Fact]
+    public void Render_TwoCharacters_DifferentIcons()
+    {
+        var engine = new GameEngine();
+        using (var iconStream = IconSetTestHelper.CreateIconSetStream(rows: 2, cols: 3))
+        {
+            engine.LoadIconSet(iconStream);
+        }
+
+        var npc1 = ConfigureNpc(engine, "npc1", seed: 2, characterIndex: 1, position: new Position(1.5, 2.0));
+        npc1.IconIndex = 0;
+        var npc2 = ConfigureNpc(engine, "npc2", seed: 3, characterIndex: 2, position: new Position(3.5, 2.0));
+        npc2.IconIndex = 1;
+        engine.Characters.Add(npc1);
+        engine.Characters.Add(npc2);
+
+        using var bitmap = Render(engine, CanvasSize, CanvasSize);
+
+        // NPC1 at (1.5, 2.0): feet (72, 96), sprite top-left (48, 48), icon top-left (56, 16),
+        // icon center (72, 32), sprite center (72, 72).
+        var icon1 = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 0);
+        Assert.Equal(icon1, bitmap.GetPixel(72, 32));
+        Assert.Equal(CharacterTestHelper.SpriteColor(2, 1, Direction.Down, StandingFrame), bitmap.GetPixel(72, 72));
+
+        // NPC2 at (3.5, 2.0): feet (168, 96), sprite top-left (144, 48), icon top-left (152, 16),
+        // icon center (168, 32), sprite center (168, 72).
+        var icon2 = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 1);
+        Assert.NotEqual(icon1, icon2);
+        Assert.Equal(icon2, bitmap.GetPixel(168, 32));
+        Assert.Equal(CharacterTestHelper.SpriteColor(3, 2, Direction.Down, StandingFrame), bitmap.GetPixel(168, 72));
+    }
+
+    /// <summary>Verifies a non-null IconIndex with no icon set loaded throws InvalidOperationException at Render.</summary>
+    [Fact]
+    public void Render_CharacterWithIconIndex_NoIconSetLoaded_Throws()
+    {
+        var engine = new GameEngine();
+        ConfigurePlayer(engine);
+        engine.Player.Character.IconIndex = 0;
+
+        using var bitmap = new SKBitmap(CanvasSize, CanvasSize);
+        using var canvas = new SKCanvas(bitmap);
+        Assert.Throws<InvalidOperationException>(() => engine.Render(canvas, FrameDt));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// <summary>Loads a seeded full sheet under the name "hero" and configures the player to use it.</summary>
+    private static void ConfigurePlayer(GameEngine engine)
+    {
+        using var stream = CharacterTestHelper.CreateSheetStream(seed: 1);
+        engine.LoadSpriteSheet("hero", stream);
+        engine.Player.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        engine.Player.Position = PlayerPosition;
+    }
+
+    /// <summary>Loads a seeded full sheet under the given name and returns a new NPC character configured to use it.</summary>
+    private static Character ConfigureNpc(
+        GameEngine engine,
+        string sheetName,
+        int seed,
+        int characterIndex,
+        Position position)
+    {
+        using var stream = CharacterTestHelper.CreateSheetStream(seed);
+        engine.LoadSpriteSheet(sheetName, stream);
+        var npc = new Character { Position = position };
+        npc.SpriteSheets.Add(new SpriteSheetRef(sheetName, CharacterIndex: characterIndex));
+        return npc;
+    }
+
+    /// <summary>Renders the engine into a fresh transparent bitmap of the requested size.</summary>
+    private static SKBitmap Render(GameEngine engine, int width, int height)
+    {
+        var bitmap = new SKBitmap(width, height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            engine.Render(canvas, FrameDt);
+        }
+
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Renders the engine and asserts the player's icon center pixel is the expected icon color
+    /// (proving the loaded set is in effect).
+    /// </summary>
+    private static void AssertIconRendered(GameEngine engine, SKColor expectedIcon)
+    {
+        using var bitmap = Render(engine, CanvasSize, CanvasSize);
+        Assert.Equal(expectedIcon, bitmap.GetPixel(PlayerIconCenterX, PlayerIconCenterY));
+    }
+
+    /// <summary>Writes a PNG to a temporary file and returns its path.</summary>
+    private static string WriteTempPng(byte[] png)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "rpg-engine-iconset-" + Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllBytes(path, png);
+        return path;
+    }
+}

--- a/tests/RPGEngine.Tests/Sprites/IconSetTestHelper.cs
+++ b/tests/RPGEngine.Tests/Sprites/IconSetTestHelper.cs
@@ -1,0 +1,191 @@
+using System.IO.Compression;
+using System.Text;
+using SkiaSharp;
+
+namespace RPGEngine.Tests.Sprites;
+
+/// <summary>
+/// Generates icon-set fixtures: PNG images divided into 32×32 tiles, each tile filled with a
+/// unique opaque color, so pixel-level tests can tell exactly which icon was drawn. The color
+/// scheme mirrors <c>CharacterTestHelper.CellColor</c>: the <c>(rows, cols, iconIndex)</c>
+/// triple is encoded into RGB.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The color scheme guarantees global uniqueness across <c>(rows, cols, iconIndex)</c>: the red
+/// channel uniquely identifies the <c>(rows, cols)</c> pair, the green channel uniquely
+/// identifies the icon index within a set (so two different icons of the same set never share a
+/// color, and two sets with different dimensions never share an icon color either).
+/// </para>
+/// <para>
+/// <see cref="CreateIconSetPng(int,int)"/> always produces a valid <c>rows × cols</c> grid; the
+/// <c>(width, height)</c> overload additionally supports arbitrary dimensions (including zero) so
+/// the loader's <see cref="ArgumentException"/> validation path can be exercised.
+/// </para>
+/// </remarks>
+internal static class IconSetTestHelper
+{
+    /// <summary>The normative icon tile size in pixels (matches <c>IconSet.TileSize</c>).</summary>
+    public const int TileSize = 32;
+
+    /// <summary>
+    /// Returns the unique opaque color used for the tile at <paramref name="iconIndex"/> of a
+    /// <c>rows × cols</c> icon set.
+    /// </summary>
+    public static SKColor IconColor(int rows, int cols, int iconIndex)
+    {
+        // R uniquely identifies the (rows, cols) pair, G the icon within the set, B a secondary
+        // mix. Distinct (rows, cols, iconIndex) triples always map to distinct colors for the
+        // set sizes used by the tests.
+        var r = (byte)((rows * 31 + cols * 17 + 1) % 256);
+        var g = (byte)((iconIndex * 41) % 256);
+        var b = (byte)((rows * 5 + cols * 11 + iconIndex * 23) % 256);
+        return new SKColor(r, g, b, alpha: 255);
+    }
+
+    /// <summary>
+    /// Encodes a <c>rows × cols</c> icon set (a <c>(cols * 32) × (rows * 32)</c> image) as PNG,
+    /// where every 32×32 tile is filled with the unique color from
+    /// <see cref="IconColor(int,int,int)"/>.
+    /// </summary>
+    public static byte[] CreateIconSetPng(int rows, int cols)
+        => CreateIconSetPngBySize(cols * TileSize, rows * TileSize);
+
+    /// <summary>
+    /// Encodes a PNG of the requested dimensions. When the dimensions form a valid 32×32 grid
+    /// (positive width and height, each a multiple of <see cref="TileSize"/>), every tile is
+    /// filled with the unique per-icon color from <see cref="IconColor(int,int,int)"/> at the
+    /// 32×32 tile size; any other size is left transparent (only its dimensions matter for
+    /// validation tests).
+    /// </summary>
+    public static byte[] CreateIconSetPngBySize(int width, int height)
+    {
+        if (width <= 0 || height <= 0)
+        {
+            // SkiaSharp cannot encode a zero-dimension image, so hand-build raw PNG bytes that
+            // represent those dimensions. They are not decodable (PNG requires positive
+            // dimensions), but they let the loader's ArgumentException path be exercised.
+            return CreateRawPng(width, height);
+        }
+
+        var validGrid = width % TileSize == 0 && height % TileSize == 0;
+        var rows = height / TileSize;
+        var cols = width / TileSize;
+
+        using var bitmap = new SKBitmap(width, height);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+
+            if (validGrid)
+            {
+                for (var row = 0; row < rows; row++)
+                {
+                    for (var col = 0; col < cols; col++)
+                    {
+                        var iconIndex = (row * cols) + col;
+                        using var paint = new SKPaint { Color = IconColor(rows, cols, iconIndex), IsAntialias = false };
+                        canvas.DrawRect(
+                            new SKRect(col * TileSize, row * TileSize, (col + 1) * TileSize, (row + 1) * TileSize),
+                            paint);
+                    }
+                }
+            }
+        }
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    /// <summary>Returns a read-only stream containing a <c>rows × cols</c> icon set encoded as PNG.</summary>
+    public static MemoryStream CreateIconSetStream(int rows, int cols)
+        => new(CreateIconSetPng(rows, cols), writable: false);
+
+    /// <summary>
+    /// Hand-builds raw PNG bytes with the requested (possibly zero) dimensions without going
+    /// through the SkiaSharp encoder, using 8-bit RGBA (color type 6) and valid chunk CRCs.
+    /// </summary>
+    private static byte[] CreateRawPng(int width, int height)
+    {
+        using var ms = new MemoryStream();
+        ms.Write(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, 0, 8);
+
+        var ihdr = new byte[13];
+        WriteBigEndian(ihdr, 0, width);
+        WriteBigEndian(ihdr, 4, height);
+        ihdr[8] = 8;  // bit depth
+        ihdr[9] = 6;  // color type: RGBA
+        ihdr[10] = 0; // compression
+        ihdr[11] = 0; // filter
+        ihdr[12] = 0; // interlace
+        ms.Write(Chunk("IHDR", ihdr), 0, 4 + 4 + 13 + 4);
+
+        // One scanline per row: a filter byte (0 = none) plus the row's pixel bytes. With a zero
+        // width the scanlines carry only the filter bytes; with a zero height IDAT is empty.
+        var raw = new List<byte>();
+        var rowBytes = checked(width * 4);
+        for (var y = 0; y < height; y++)
+        {
+            raw.Add(0);
+            for (var x = 0; x < rowBytes; x++)
+            {
+                raw.Add(0);
+            }
+        }
+
+        using var compressed = new MemoryStream();
+        using (var zlib = new ZLibStream(compressed, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            zlib.Write(raw.ToArray(), 0, raw.Count);
+        }
+
+        var idat = Chunk("IDAT", compressed.ToArray());
+        ms.Write(idat, 0, idat.Length);
+
+        var iend = Chunk("IEND", Array.Empty<byte>());
+        ms.Write(iend, 0, iend.Length);
+        return ms.ToArray();
+    }
+
+    private static void WriteBigEndian(byte[] buffer, int offset, int value)
+    {
+        buffer[offset] = (byte)(value >> 24);
+        buffer[offset + 1] = (byte)(value >> 16);
+        buffer[offset + 2] = (byte)(value >> 8);
+        buffer[offset + 3] = (byte)value;
+    }
+
+    private static byte[] Chunk(string type, byte[] data)
+    {
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        using var ms = new MemoryStream();
+        WriteBigEndian(ms, data.Length);
+        ms.Write(typeBytes, 0, 4);
+        ms.Write(data, 0, data.Length);
+        WriteBigEndian(ms, (int)Crc32(typeBytes.Concat(data).ToArray()));
+        return ms.ToArray();
+    }
+
+    private static void WriteBigEndian(Stream stream, int value)
+    {
+        stream.WriteByte((byte)(value >> 24));
+        stream.WriteByte((byte)(value >> 16));
+        stream.WriteByte((byte)(value >> 8));
+        stream.WriteByte((byte)value);
+    }
+
+    private static uint Crc32(byte[] data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (var i = 0; i < 8; i++)
+            {
+                crc = (crc >> 1) ^ ((crc & 1) != 0 ? 0xEDB88320u : 0u);
+            }
+        }
+        return crc ^ 0xFFFFFFFF;
+    }
+}

--- a/tests/RPGEngine.Tests/Sprites/IconSetTests.cs
+++ b/tests/RPGEngine.Tests/Sprites/IconSetTests.cs
@@ -1,0 +1,190 @@
+using RPGEngine.Sprites;
+using SkiaSharp;
+using Xunit;
+
+namespace RPGEngine.Tests.Sprites;
+
+/// <summary>
+/// Acceptance tests for <see cref="IconSet"/> (story 70: icon sets loaded into the engine and
+/// displayed above character sprites). The fixtures are PNGs divided into 32×32 tiles, each
+/// tile filled with a unique color encoding <c>(rows, cols, iconIndex)</c> (see
+/// <see cref="IconSetTestHelper"/>), so pixel-level assertions can tell exactly which icon was
+/// sliced.
+/// </summary>
+public class IconSetTests
+{
+    // ---------------------------------------------------------------------
+    // Acceptance 1: a 96-wide × 64-tall PNG derives 3 columns × 2 rows (rows
+    // are the vertical count = height/32, columns the horizontal count =
+    // width/32).
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies a 96×64 PNG derives ColumnCount == 3, RowCount == 2 and Count == 6.</summary>
+    [Fact]
+    public void Load_96x64_DerivesRowsAndColumns()
+    {
+        using var stream = new MemoryStream(IconSetTestHelper.CreateIconSetPng(rows: 2, cols: 3), writable: false);
+        var set = IconSet.Load(stream);
+
+        Assert.Equal(3, set.ColumnCount); // width / 32 = 96 / 32
+        Assert.Equal(2, set.RowCount);    // height / 32 = 64 / 32
+        Assert.Equal(6, set.Count);       // RowCount * ColumnCount
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 2: GetIcon uses the corrected row-major formula
+    // row = iconIndex / ColumnCount, col = iconIndex % ColumnCount. For the
+    // 3-column × 2-row set, index i returns the tile at (row = i / 3, col = i % 3).
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies GetIcon slices the correct 32×32 tile for every index 0..5 of a 3-column × 2-row
+    /// set, proving index 1 is to the right of index 0 (across a row) and indices wrap to the
+    /// next row at index 3.
+    /// </summary>
+    [Fact]
+    public void GetIcon_UsesRowMajorFormula()
+    {
+        const int rows = 2;
+        const int cols = 3;
+
+        using var stream = new MemoryStream(IconSetTestHelper.CreateIconSetPng(rows, cols), writable: false);
+        var set = IconSet.Load(stream);
+
+        for (var iconIndex = 0; iconIndex < set.Count; iconIndex++)
+        {
+            using var icon = set.GetIcon(iconIndex);
+
+            // The tile is 32×32 and every pixel carries the unique color of tile
+            // (row = iconIndex / cols, col = iconIndex % cols). If the implementation used the
+            // (incorrect) column-major formula the colors would not match: index 1 must be the
+            // second tile of the top row (to the right of index 0), not the tile below index 0.
+            var expectedRow = iconIndex / cols;
+            var expectedCol = iconIndex % cols;
+            var expected = IconSetTestHelper.IconColor(rows, cols, iconIndex);
+
+            Assert.Equal(IconSetTestHelper.TileSize, icon.Width);
+            Assert.Equal(IconSetTestHelper.TileSize, icon.Height);
+
+            using var bitmap = new SKBitmap(IconSetTestHelper.TileSize, IconSetTestHelper.TileSize);
+            using (var canvas = new SKCanvas(bitmap))
+            {
+                canvas.Clear(SKColors.Transparent);
+                canvas.DrawImage(icon, new SKPoint(0, 0));
+            }
+
+            for (var y = 0; y < IconSetTestHelper.TileSize; y++)
+            {
+                for (var x = 0; x < IconSetTestHelper.TileSize; x++)
+                {
+                    Assert.Equal(expected, bitmap.GetPixel(x, y));
+                }
+            }
+
+            // Sanity: the same index on a column-major layout would land in a different cell, so
+            // the expected color itself proves the row-major ordering (the fixture fills tile
+            // (row, col) with IconColor(rows, cols, row * cols + col)).
+            _ = expectedRow;
+            _ = expectedCol;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 3: GetIcon rejects indices outside 0..Count-1.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies GetIcon throws ArgumentOutOfRangeException for -1 and Count.</summary>
+    [Fact]
+    public void GetIcon_OutOfRange_Throws()
+    {
+        using var stream = new MemoryStream(IconSetTestHelper.CreateIconSetPng(rows: 2, cols: 3), writable: false);
+        var set = IconSet.Load(stream);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => set.GetIcon(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => set.GetIcon(set.Count));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 4: dimensions that are not a positive multiple of 32 throw.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies loading an image whose dimensions are not a 32×32 grid throws ArgumentException.</summary>
+    [Theory]
+    [InlineData(33, 32)]  // width not a multiple of 32
+    [InlineData(64, 31)]  // height not a multiple of 32
+    [InlineData(0, 32)]   // zero width
+    public void Load_NonMultipleOf32_Throws(int width, int height)
+    {
+        using var stream = new MemoryStream(IconSetTestHelper.CreateIconSetPngBySize(width, height), writable: false);
+        Assert.Throws<ArgumentException>(() => IconSet.Load(stream));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 5: undecodable bytes throw.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies loading garbage bytes throws ArgumentException.</summary>
+    [Fact]
+    public void Load_Undecodable_Throws()
+    {
+        using var stream = new MemoryStream(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 }, writable: false);
+        Assert.Throws<ArgumentException>(() => IconSet.Load(stream));
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 6: LoadAsync reads an async-only stream (no synchronous read
+    // of the caller's stream) and derives the same rows/columns.
+    // ---------------------------------------------------------------------
+    /// <summary>Verifies LoadAsync loads a 96×64 set from a non-seekable, read-async-only stream.</summary>
+    [Fact]
+    public async Task LoadAsync_ReadsAsyncOnlyStream()
+    {
+        using var stream = new AsyncOnlyStream(
+            new MemoryStream(IconSetTestHelper.CreateIconSetPng(rows: 2, cols: 3), writable: false));
+
+        var set = await IconSet.LoadAsync(stream);
+
+        Assert.Equal(3, set.ColumnCount);
+        Assert.Equal(2, set.RowCount);
+        Assert.Equal(6, set.Count);
+
+        using var icon = set.GetIcon(0);
+        Assert.Equal(IconSetTestHelper.TileSize, icon.Width);
+        Assert.Equal(IconSetTestHelper.TileSize, icon.Height);
+    }
+
+    // ---------------------------------------------------------------------
+    // Acceptance 7: GetIcon returns an independent crop that the caller owns;
+    // disposing an earlier returned icon does not affect a later one.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies two calls to GetIcon return independent 32×32 images: disposing the first has no
+    /// effect on the second (the raster-crop copy, never a shared subset).
+    /// </summary>
+    [Fact]
+    public void GetIcon_ReturnsIndependentCrop()
+    {
+        using var stream = new MemoryStream(IconSetTestHelper.CreateIconSetPng(rows: 2, cols: 3), writable: false);
+        var set = IconSet.Load(stream);
+
+        var first = set.GetIcon(0);
+        var second = set.GetIcon(1);
+
+        try
+        {
+            first.Dispose(); // disposing an earlier crop must not affect later ones
+
+            Assert.Equal(IconSetTestHelper.TileSize, second.Width);
+            Assert.Equal(IconSetTestHelper.TileSize, second.Height);
+
+            var expected = IconSetTestHelper.IconColor(rows: 2, cols: 3, iconIndex: 1);
+            using var bitmap = new SKBitmap(IconSetTestHelper.TileSize, IconSetTestHelper.TileSize);
+            using (var canvas = new SKCanvas(bitmap))
+            {
+                canvas.Clear(SKColors.Transparent);
+                canvas.DrawImage(second, new SKPoint(0, 0));
+            }
+
+            Assert.Equal(expected, bitmap.GetPixel(0, 0));
+        }
+        finally
+        {
+            second.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Closes #70

## Story 70: Icon sets

Implements the icon-set feature from the epic [#68](https://github.com/elliottv/rpg-engine/issues/68): a PNG divided into 32×32 tiles can be loaded into the engine, and a character with a non-null `Character.IconIndex` renders the selected icon **above its sprite**.

### What was done

**`IconSet` (new, `RPGEngine.Sprites`)**
- Public sealed data + slice object owning one decoded `SKImage` (the icon-set counterpart of `SpriteSheet`).
- `TileSize = 32`, `RowCount = height / 32`, `ColumnCount = width / 32`, `Count = RowCount * ColumnCount`.
- `Load(string path)`, `Load(Stream stream)`, `LoadAsync(Stream stream)` factories with validation mirroring `SpriteSheetManager.Decode` (undecodable or non-32×32-grid dimensions → `ArgumentException`; a 32×32 image is valid).
- `GetIcon(int)` slices the **corrected row-major** formula `row = iconIndex / ColumnCount`, `col = iconIndex % ColumnCount` (index 1 is to the right of index 0) as an independent nearest-neighbour raster crop (deliberately avoids `SKImage.Subset` — the SkiaSharp 3.119.4 native crash documented in `SpriteSheet.GetSprite`). Out-of-range → `ArgumentOutOfRangeException`.

**`GameEngine`**
- `private IconSet? _iconSet`; `LoadIconSet(string path)`, `LoadIconSet(Stream stream)`, `LoadIconSetAsync(Stream stream)` thin delegating wrappers storing the single set. **Replacement semantics** documented: a subsequent load replaces the previous set (no name → no duplicate-name error).
- `Render` passes `_iconSet` to every character's `Draw`.

**`Character`**
- `public int? IconIndex` (default `null`), XML-documented with the row-major formula; `Draw` forwards it (and the icon set) to the compositor.

**`CharacterSpriteCompositor`**
- `Draw` gains `IconSet? iconSet, int? iconIndex` and draws the selected 32×32 icon **after the sprite, above it** (centered on the feet X, bottom edge at the sprite's top edge; default 48 cell height for spriteless characters). Misconfiguration: non-null icon index with no loaded set → `InvalidOperationException`; out-of-range → `ArgumentOutOfRangeException`.

**Tests** (all green)
- `IconSetTestHelper` (unique per-tile colors encoding `(rows, cols, iconIndex)`), `IconSetTests`, `GameEngineIconTests`, `DocsExamplesTests.IconSet_LoadAndDisplayIcon_Example`, plus the `CharacterTests` `Draw` call-site updates for the new parameter.
- `dotnet build -c Release`: 0 warnings / 0 errors (CS1591 satisfied — every new public member documented).
- `dotnet test tests/RPGEngine.Tests -c Release`: 428 passed (411 baseline + 17 new).

**Docs**
- New `docs/api/IconSet.md`; `docs/api/GameEngine.md` (LoadIconSet/LoadIconSetAsync sections + icon-set remarks), `docs/api/Character.md` (`IconIndex` section), `docs/api/README.md` (index), `docs/README.md` (loading/rendering rows + callout).

Out of scope per the story: multiple named icon sets/registry, public `GameEngine` icon-set property, minimap icons, icon z-ordering, animation, non-32×32 tiles, placement-rule changes, and `Player.IconIndex` forwarding (use `Player.Character.IconIndex`).