### PR TITLE
Story 74: Direction becomes a continuous 2D vector type (8-direction key/sprite mapping preserved)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -32,7 +32,10 @@ the in-world state lives on `Character`:
   character stands), in **tiles**. The sprite is rendered above and centered on this point; its
   size is the configured sheet's derived cell size, in pixels, used only for clamping and the
   collision footprint.
-- `Character.Direction` — the facing direction (8 directions: Down/Left/Right/Up plus the four diagonals).
+- `Character.Direction` — the facing direction: a continuous 2-D direction vector (`X`, `Y`
+  doubles; Y grows down). The old 8 directions survive as the eight canonical unit `Direction`
+  statics (Down/Left/Right/Up plus the four diagonals), which key input always yields and which
+  sprites still use.
 - `Character.BaseSpeed` — movement speed in **tiles per second** (the player default is 2,
   i.e. the tile-unit equivalent of 96 px/s at 48 px tiles).
 - `Character.SpriteSheets` — the list of `SpriteSheetRef`s (sheet name + 1..8 character index).
@@ -146,9 +149,10 @@ charRow = (i - 1) / 4
 
 Its cell `(frame, direction)` is at column `charCol * 3 + frame` and row
 `charRow * 4 + direction.RowIndex()`, where the direction rows are
-`0 = Down`, `1 = Left`, `2 = Right`, `3 = Up`. Diagonal directions have no dedicated row and
-fall back to their horizontal component's row (`DownLeft`/`UpLeft` → 1, `DownRight`/`UpRight`
-→ 2), so a diagonally-facing character renders with the side-view row.
+`0 = Down`, `1 = Left`, `2 = Right`, `3 = Up`. `RowIndex` snaps a (possibly continuous)
+direction to its nearest canonical direction first; canonical diagonal directions have no
+dedicated row and fall back to their horizontal component's row (`DownLeft`/`UpLeft` → 1,
+`DownRight`/`UpRight` → 2), so a diagonally-facing character renders with the side-view row.
 
 A `SpriteSheetRef(Name, CharacterIndex)` pairs a loaded sheet name with one of the **8
 characters** in that sheet. The index is enforced (1..8) where the reference is consumed — at
@@ -207,14 +211,16 @@ There are **two ways a character moves**, and both go through the same `Characte
 (internal, `map` nullable) called by the engine's update loop every frame:
 
 1. **Engine key input (the player).** `GameEngine.Update` combines every held bound key into a
-   single **8-direction vector**: each key that is bound to a movement direction (via
-   `GameConfig.GetDirection`) contributes its unit delta, the deltas are summed, normalized and
-   quantized to the nearest of the eight `Direction` values. Opposite keys cancel (`W`+`S` or
-   `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right) at the same
-   speed as cardinal movement (the diagonal deltas are normalized, magnitude 1). When no bound
-   key is held the player stops and the animation snaps back to the standing frame. The engine
-   reads `GameConfig` at input time and never caches a snapshot. The player's displacement is
-   resolved (and collision-checked) by the engine itself, then handed to `Player.ReportMovement`.
+   single direction vector (`Direction` is a continuous 2-D vector, like `Position`): each key
+   that is bound to a movement direction (via `GameConfig.GetDirection`) contributes its
+   canonical unit direction vector, the vectors are summed, normalized and snapped to the
+   nearest of the eight canonical `Direction` values (key input always yields one of the eight).
+   Opposite keys cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a canonical
+   diagonal (`W`+`D` → up-right) at the same speed as cardinal movement (all canonical
+   directions are unit vectors, magnitude 1). When no bound key is held the player stops and the
+   animation snaps back to the standing frame. The engine reads `GameConfig` at input time and
+   never caches a snapshot. The player's displacement is resolved (and collision-checked) by the
+   engine itself, then handed to `Player.ReportMovement`.
 2. **Autonomous movement (`Character.StartMoving` / `StopMoving`).** A host starts a character
    (typically an NPC in `GameEngine.Characters`) with `StartMoving(direction)`, which faces it
    and sets `IsMoving = true`. While `IsMoving`, every `Character.Update(dt, map)` moves the
@@ -401,7 +407,7 @@ auto-walk never moves the player through or into a solid tile.
   path) **cancels** it.
 
 **Movement-state events**: `Player` exposes `OnStartMoving` and `OnStopMoving`
-(`EventHandler<Direction>`, carrying only the facing `Direction` — the old
+(`EventHandler<Direction>`, carrying only the facing `Direction` vector — the old
 `PlayerMoveEventArgs` wrapper was removed). `OnStartMoving` fires **exactly** when the player
 begins moving in a new direction and **before** the position is updated: on the first frame a
 movement key takes effect (idle → moving) for move-by-key, on **direction changes while

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,7 +134,7 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > updated — and `Player.OnStopMoving` fires when every key is released, when the last auto-walk
 > step is reached, or when the player is blocked by a collision (the engine reports the blocked
 > move, so `OnStopMoving` fires even against a wall). Both events carry only the facing
-> `Direction`. Diagonal key movement is all-or-nothing (no wall-sliding): a diagonal into a wall
+> `Direction` (the direction vector). Diagonal key movement is all-or-nothing (no wall-sliding): a diagonal into a wall
 > where only one axis is free stops the player entirely and reports the collision stop the same
 > way. See `docs/api/GameEngine.md` and `docs/api/Player.md`.
 

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -2,8 +2,9 @@
 
 Namespace: `RPGEngine` — a character present in the game world (the player or an NPC).
 
-`Character` holds the position (in **tiles**), facing direction (8 directions, cardinal +
-diagonal), movement speed (in tiles per second), the walk-cycle animation state and the list of
+`Character` holds the position (in **tiles**), facing direction (a continuous 2-D direction
+vector, see `Direction.md`; the eight canonical directions remain for key input and sprite
+rows), movement speed (in tiles per second), the walk-cycle animation state and the list of
 spritesheet references used to render it.
 
 ## Remarks
@@ -47,10 +48,18 @@ var character = new Character { Position = new Position(3.5, 4.5) };
 
 ### `Direction Direction`
 
-Gets or sets the direction the character is facing.
+Gets or sets the direction the character is facing: a continuous 2-D direction vector
+(`X`, `Y` doubles, Y grows down), typically one of the eight canonical unit directions but
+allowed to be any continuous unit vector. Defaults to `Direction.Down` (the historical default
+facing), even though `default(Direction)` is the zero vector. Movement is
+`Direction * BaseSpeed * factor * dt`, so the vector should be unit-length; when rendering, the
+facing is snapped to the nearest canonical 8 direction for the sprite row
+(`DirectionExtensions.Nearest8`), so sprites stay 8-direction.
 
 ```csharp
 var character = new Character { Direction = Direction.Down };
+// A continuous facing is also possible:
+character.Direction = new Direction(0.6, 0.8);
 ```
 
 ### `double BaseSpeed`

--- a/docs/api/Direction.md
+++ b/docs/api/Direction.md
@@ -1,30 +1,115 @@
 # Direction
 
-Namespace: `RPGEngine` — the eight facing directions used throughout the engine.
+Namespace: `RPGEngine` — a direction in the game world, expressed as an **immutable 2-D vector
+value type** with `double` components (`X` grows right, `Y` grows down) — the same double model
+as `Position`. It is a `readonly record struct Direction(double X, double Y)`.
 
-The cardinal values match the RPG Maker MZ character sheet row order
-(`0 = down`, `1 = left`, `2 = right`, `3 = up`); the diagonal values follow them and have no
-dedicated sprite-sheet row — a diagonally-facing character renders with the side-view row of its
-horizontal component (see `DirectionExtensions.RowIndex`). This is the single source of truth
-used by sprite cropping and rendering.
+The historical 8-value enum is gone, but the **eight canonical unit directions** it represented
+survive as static members (`Direction.Down`, `Direction.Left`, …) and are listed in
+`Direction.All`. Key input and sprite rows still use exactly these eight: key input yields one of
+the eight canonical directions, and a facing — which may in general be a continuous unit vector —
+is adapted to the nearest canonical direction for the sprite sheet row via
+`DirectionExtensions.Nearest8` / `DirectionExtensions.RowIndex`.
 
-## Values
+`default(Direction)` is the zero vector `(0, 0)`. Consumers that need a facing default (e.g.
+`Character.Direction`) initialize it explicitly to `Direction.Down` to preserve the historical
+default facing.
 
-| Value | Value number | Sprite row | Meaning |
+## Canonical unit directions
+
+The eight canonical unit directions, in the historical enum order. Diagonals are **normalized**
+(each component is ±√½ ≈ ±0.7071), so diagonal movement covers the same distance as cardinal
+movement.
+
+| Static | Components | Sprite row | Meaning |
 | --- | --- | --- | --- |
-| `Down` | 0 | 0 | Facing down. |
-| `Left` | 1 | 1 | Facing left. |
-| `Right` | 2 | 2 | Facing right. |
-| `Up` | 3 | 3 | Facing up. |
-| `DownLeft` | 4 | 1 (side view) | Facing down-left. |
-| `DownRight` | 5 | 2 (side view) | Facing down-right. |
-| `UpLeft` | 6 | 1 (side view) | Facing up-left. |
-| `UpRight` | 7 | 2 (side view) | Facing up-right. |
+| `Down` | `(0, +1)` | 0 | Facing down. |
+| `Left` | `(-1, 0)` | 1 | Facing left. |
+| `Right` | `(1, 0)` | 2 | Facing right. |
+| `Up` | `(0, -1)` | 3 | Facing up. |
+| `DownLeft` | `(-√½, +√½)` | 1 (side view) | Facing down-left. |
+| `DownRight` | `(+√½, +√½)` | 2 (side view) | Facing down-right. |
+| `UpLeft` | `(-√½, -√½)` | 1 (side view) | Facing up-left. |
+| `UpRight` | `(+√½, -√½)` | 2 (side view) | Facing up-right. |
+
+`All` exposes these eight in the same order (`Down`, `Left`, `Right`, `Up`, `DownLeft`,
+`DownRight`, `UpLeft`, `UpRight`).
+
+## Members
+
+### `double X` / `double Y`
+
+The horizontal (x, grows right) and vertical (y, grows down) components. Both are `double`.
+
+### `static Direction Down`, `Left`, `Right`, `Up`, `DownLeft`, `DownRight`, `UpLeft`, `UpRight`
+
+The eight canonical **unit** directions (see the table above).
+
+### `static IReadOnlyList<Direction> All`
+
+The eight canonical unit directions, in the historical enum order.
+
+### `static Direction operator -(Direction d)`
+
+Returns the opposite direction: component-wise negation `(-X, -Y)`. For the eight canonical
+directions this matches the enum's historical opposite (`Down` ↔ `Up`, `Left` ↔ `Right`, and
+each diagonal flips both signs); it stays well-defined for any continuous direction.
+
+### `static Direction operator *(Direction d, double scalar)` / `static Direction operator *(double scalar, Direction d)`
+
+Returns the component-wise product of the direction and the scalar. Movement multiplies the
+(unit) direction vector by the travelled distance: `direction * (BaseSpeed * factor * dt)`.
+
+### `static implicit operator Vector2(Direction d)`
+
+Converts the direction to an equivalent `Vector2` with the same components. A direction *is* a
+2-D vector, so this makes a direction directly usable wherever a `Vector2` offset is expected
+(e.g. adding a scaled direction to a `Position`).
+
+### `double Length`
+
+The Euclidean length (magnitude) of the direction. The canonical unit directions all have
+length 1, so their displacement equals `BaseSpeed * factor * dt`. Movement assumes a unit-length
+direction: a non-unit vector scales the displacement by its length.
+
+### `bool IsZero`
+
+Whether the direction is the zero vector `(0, 0)` — the value of `default(Direction)`.
+
+### `Direction Normalized`
+
+The direction normalized to unit length, keeping its direction unchanged. Throws
+`InvalidOperationException` when the direction is the zero vector `(0, 0)`, which has no
+direction to normalize.
+
+### `string ToString()`
+
+Returns the canonical name (e.g. `"Up"`) when the direction equals one of the eight canonical
+directions in `All`, for readability and logging; otherwise returns the component pair
+`"(X, Y)"`.
 
 ## Example
 
 ```csharp
-var direction = Direction.UpRight;
-Console.WriteLine((int)direction); // 7
-Console.WriteLine(direction.RowIndex()); // 2 — falls back to the Right (side-view) row
+// The eight canonical directions are still available as unit vectors.
+var up = Direction.Up;            // (0, -1)
+Console.WriteLine(up);            // "Up"
+Console.WriteLine(up.RowIndex()); // 3 — RPG Maker MZ row 3
+
+// A continuous facing is expressed as a 2-D vector of doubles, just like Position.
+var continuous = new Direction(0.6, 0.8);
+Console.WriteLine(continuous.Length); // 1 (0.6² + 0.8² = 1)
+Console.WriteLine(continuous);        // "(0.6, 0.8)" — not a canonical name
+
+// Key input always yields one of the eight canonical directions...
+var config = new GameConfig();
+Console.WriteLine(config.GetMovementDirection([Key.W, Key.D])); // UpRight
+
+// ...and sprites adapt a continuous facing to the nearest canonical 8-direction row.
+Console.WriteLine(continuous.Nearest8()); // DownRight
+Console.WriteLine(continuous.RowIndex()); // 2 — the Right (side-view) row
+
+// Movement multiplies the direction vector by the speed.
+var character = new Character { BaseSpeed = 2 };
+character.Move(Direction.Right, speedFactor: 1, dt: 0.5); // +1 tile right (2 * 0.5)
 ```

--- a/docs/api/DirectionExtensions.md
+++ b/docs/api/DirectionExtensions.md
@@ -1,74 +1,54 @@
 # DirectionExtensions
 
-Namespace: `RPGEngine` — convenience members for the `Direction` enum: screen-space deltas,
-opposites, sprite-sheet row indices and axis classification.
+Namespace: `RPGEngine` — the **8-direction adaptation layer** for the `Direction` vector type.
+`Direction` is now a continuous 2-D vector (see `Direction.md`), but key input and sprites still
+use the eight canonical directions; these helpers express that mapping:
+
+- `Nearest8` — adapts a (possibly continuous) direction to the nearest of the eight canonical
+  unit directions (the epic's *"the direction vector is adapted to the old 8 directions"*).
+- `RowIndex` — maps a direction to its RPG Maker MZ character-sheet row, snapping first.
+- `Opposite` — returns the opposite direction (vector negation).
 
 ## Methods
 
-### `Vector2 Delta(this Direction d)`
+### `Direction Nearest8(this Direction d)`
 
-Returns the screen-space unit delta for the direction. Screen coordinates grow Y downward, so
-`Down` is `(0, +1)` and `Up` is `(0, -1)`. Diagonal deltas are **normalized** (magnitude 1, not
-√2), so diagonal movement is exactly as fast as cardinal movement. Throws
-`ArgumentOutOfRangeException` for an undefined direction.
-
-```csharp
-Console.WriteLine(Direction.Up.Delta());       // (0, -1)
-Console.WriteLine(Direction.Right.Delta());    // (1, 0)
-Console.WriteLine(Direction.UpRight.Delta());  // (0.7071, -0.7071) — normalized diagonal
-```
-
-### `Direction Opposite(this Direction d)`
-
-Returns the opposite direction (`Down` ↔ `Up`, `Left` ↔ `Right`, `DownLeft` ↔ `UpRight`,
-`DownRight` ↔ `UpLeft`). Throws `ArgumentOutOfRangeException` for an undefined direction.
+Returns the closest of the eight canonical unit directions in `Direction.All`, chosen by dot
+product against each canonical unit vector after normalizing `d` (so only the direction matters,
+not its length). The zero vector `(0, 0)` has no direction and snaps to `Direction.Down`.
 
 ```csharp
-Console.WriteLine(Direction.Up.Opposite());     // Down
-Console.WriteLine(Direction.UpRight.Opposite()); // DownLeft
+Console.WriteLine(Direction.Up.Nearest8());        // Up — a canonical direction is unchanged
+Console.WriteLine(new Direction(0.9, 0.2).Nearest8());  // Right — mostly horizontal, slightly down
+Console.WriteLine(new Direction(0.03, -0.99).Nearest8()); // Up — almost straight up
+Console.WriteLine(default(Direction).Nearest8());  // Down — the zero vector snaps to Down
 ```
 
 ### `int RowIndex(this Direction d)`
 
-Returns the RPG Maker MZ character sheet row for this direction (`0 = down`, `1 = left`,
-`2 = right`, `3 = up`). Cardinal directions return their enum value; diagonal directions
-deliberately fall back to their **horizontal** component's row (`DownLeft`/`UpLeft` → 1,
-`DownRight`/`UpRight` → 2) so a diagonally-facing character renders with the side-view row,
-which reads better than the front or back rows for an oblique facing.
+Returns the RPG Maker MZ character-sheet row the character renders with (`0 = down`,
+`1 = left`, `2 = right`, `3 = up`). The direction is first snapped with `Nearest8`, so a
+continuous vector maps to the row of its **nearest canonical** direction. Canonical cardinals
+return their own row; canonical diagonals have no dedicated sheet row and deliberately fall back
+to their **horizontal** component's row (`DownLeft`/`UpLeft` → 1, `DownRight`/`UpRight` → 2),
+so a diagonally-facing character renders with the side-view row.
 
 ```csharp
-Console.WriteLine(Direction.Up.RowIndex());     // 3
-Console.WriteLine(Direction.UpRight.RowIndex()); // 2 — the Right (side-view) row
+Console.WriteLine(Direction.Up.RowIndex());        // 3
+Console.WriteLine(Direction.UpRight.RowIndex());   // 2 — the Right (side-view) row
+Console.WriteLine(new Direction(0.9, 0.2).RowIndex());    // 2 — nearest canonical is Right
+Console.WriteLine(new Direction(-0.9, 0.2).RowIndex());   // 1 — nearest canonical is Left
 ```
 
-### `bool IsHorizontal(this Direction d)`
+### `Direction Opposite(this Direction d)`
 
-Returns whether the direction is horizontal (`Left` or `Right`). Diagonals are neither
-horizontal nor vertical.
-
-```csharp
-Console.WriteLine(Direction.Left.IsHorizontal());  // True
-Console.WriteLine(Direction.Up.IsHorizontal());    // False
-Console.WriteLine(Direction.UpRight.IsHorizontal()); // False
-```
-
-### `bool IsVertical(this Direction d)`
-
-Returns whether the direction is vertical (`Down` or `Up`). Diagonals are neither horizontal nor
-vertical.
+Returns the direction opposite to this one. This is exactly the vector negation `-d`: for the
+eight canonical directions it matches the enum's historical opposite (`Down` ↔ `Up`,
+`Left` ↔ `Right`, `DownLeft` ↔ `UpRight`, `DownRight` ↔ `UpLeft`), and it remains well-defined
+for any continuous direction.
 
 ```csharp
-Console.WriteLine(Direction.Left.IsVertical());  // False
-Console.WriteLine(Direction.Up.IsVertical());    // True
-Console.WriteLine(Direction.UpRight.IsVertical()); // False
-```
-
-### `bool IsDiagonal(this Direction d)`
-
-Returns whether the direction is one of the four diagonal directions (`DownLeft`, `DownRight`,
-`UpLeft` or `UpRight`).
-
-```csharp
-Console.WriteLine(Direction.UpRight.IsDiagonal()); // True
-Console.WriteLine(Direction.Up.IsDiagonal());      // False
+Console.WriteLine(Direction.Up.Opposite());        // Down
+Console.WriteLine(Direction.UpRight.Opposite());   // DownLeft
+Console.WriteLine(new Direction(0.6, 0.8).Opposite()); // (-0.6, -0.8)
 ```

--- a/docs/api/GameConfig.md
+++ b/docs/api/GameConfig.md
@@ -70,10 +70,13 @@ Returns the movement direction to use for the given set of currently pressed key
 when no movement should happen (no bound key, or the bound directions cancel out, e.g. Up+Down
 or Left+Right held together).
 
-Every pressed key bound to a movement direction contributes its unit delta; the deltas are
-summed, normalized and quantized to the **nearest of the eight `Direction` values** by dot
-product against each direction's unit delta. This is what makes diagonal movement work: `W`+`D`
-resolves to `UpRight`, while `W`+`A`+`D` resolves to `Up` because A and D cancel.
+`Direction` is a continuous 2-D vector (see `Direction.md`), but key input always maps to the
+eight canonical unit directions: every pressed key bound to a movement direction contributes its
+own canonical unit vector; the vectors are summed, normalized and snapped to the **nearest of the
+eight canonical directions in `Direction.All`** by dot product (`DirectionExtensions.Nearest8`).
+A non-null result is therefore always one of the eight canonical directions. This is what makes
+diagonal movement work: `W`+`D` resolves to `UpRight`, while `W`+`A`+`D` resolves to `Up`
+because A and D cancel.
 
 ```csharp
 var config = new GameConfig();

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -34,9 +34,12 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   to the viewer) is drawn last and appears on top of the others, so the player may be drawn
   behind an NPC whose Y is higher. Without a map the canvas is left untouched and only the
   characters (Y-sorted) are drawn.
-- Movement input combines every held bound key into a single 8-direction vector: opposite keys
-  cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines into a diagonal (`W`+`D` → up-right)
-  at the same speed as cardinal movement (see [Architecture](../Architecture.md)).
+- Movement input combines every held bound key into a single direction vector (`Direction` is a
+  continuous 2-D vector, see `Direction.md`) which is then snapped to the nearest of the eight
+  canonical directions: opposite keys cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines
+  into a canonical diagonal (`W`+`D` → up-right) at the same speed as cardinal movement. Key
+  input always yields one of the eight canonical directions; sprites render 8 directions
+  (see [Architecture](../Architecture.md)).
 - **Click-to-move** (auto-walk): `Click(surfaceX, surfaceY)` converts a host-surface click on the
   main canvas (using the canvas size recorded by the most recent `Render`) to a world position,
   computes an **A*** tile path from the player's tile to the clicked tile over the non-solid

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -33,7 +33,7 @@ The player exposes a **movement-state machine** through two events:
   - click-to-move: the last auto-walk step is reached (the path completes);
   - the player is blocked by a collision (a fully blocked move).
 
-Both events carry only the facing `Direction`, which is all a host needs to mirror the player
+Both events carry only the facing `Direction` — the direction **vector** — which is all a host needs to mirror the player
 on other clients via `Character.StartMoving` / `Character.StopMoving`.
 
 ## Fields
@@ -85,9 +85,10 @@ player.Position = new Position(6, 6); // feet at the centre of tile (6, 6)
 
 ### `Direction Direction`
 
-Gets or sets the direction the player is facing. Forwards to `Character.Direction` and keeps
-the movement event state in sync so `OnStartMoving` / `OnStopMoving` report the correct facing
-direction.
+Gets or sets the direction the player is facing: a continuous 2-D direction vector (`X`, `Y`
+doubles, Y grows down; see `Direction.md`). Forwards to `Character.Direction` and keeps the
+movement event state in sync so `OnStartMoving` / `OnStopMoving` report the correct facing
+direction vector. Defaults to `Direction.Down` via the underlying `Character`.
 
 ```csharp
 player.Direction = Direction.Up;
@@ -122,7 +123,7 @@ Occurs when the player **starts moving in a new direction**, **before the positi
   once **per auto-walk step** (once per waypoint in the path), and the event is raised before
   that step's displacement is applied.
 
-The event carries the `Direction` the player is moving in.
+The event carries the direction **vector** (`Direction`) the player is moving in.
 
 ```csharp
 var player = new Player();
@@ -149,7 +150,7 @@ Occurs when the player **stops moving**:
   `OnStartMoving` then `OnStopMoving` in the same frame. The reported direction is the
   direction the player tried to move in (the player turns to face the wall).
 
-The event carries the `Direction` the player was last moving in. Stopping does not change the
+The event carries the direction **vector** (`Direction`) the player was last moving in. Stopping does not change the
 facing direction.
 
 ```csharp
@@ -167,7 +168,7 @@ player.Stop();                                       // prints "stopped moving R
 // when the player is blocked; keeping D held against the same wall raises nothing more.
 ```
 
-Both events carry the facing `Direction` directly — the previous
+Both events carry the facing direction **vector** (`Direction`) directly — the previous
 `PlayerMoveEventArgs` wrapper was removed, so a handler reads the direction from the event's
 second argument:
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -17,7 +17,7 @@ documented**. Every page below includes a commented, compilable example; the tes
 | `GameConfig` | class | [GameConfig.md](GameConfig.md) |
 | `Character` | class | [Character.md](Character.md) |
 | `Player` | class | [Player.md](Player.md) |
-| `Direction` | enum | [Direction.md](Direction.md) |
+| `Direction` | readonly record struct | [Direction.md](Direction.md) |
 | `DirectionExtensions` | static class | [DirectionExtensions.md](DirectionExtensions.md) |
 | `Position` | readonly record struct | [Position.md](Position.md) |
 | `Vector2` | readonly record struct | [Vector2.md](Vector2.md) |

--- a/docs/api/SpriteSheet.md
+++ b/docs/api/SpriteSheet.md
@@ -63,8 +63,11 @@ and disposes. Throws `ArgumentOutOfRangeException` when `characterIndex` is outs
 
 Character `i` is located at `charCol = (i - 1) % 4`, `charRow = (i - 1) / 4`; its cell
 `(frame, direction)` is at column `charCol * 3 + frame` and row `charRow * 4 + direction.RowIndex()`.
-Row selection uses `DirectionExtensions.RowIndex`, so diagonal directions (which have no dedicated
-sheet row) fall back to the side-view row of their horizontal component.
+`direction` is a continuous 2-D vector (see `Direction.md`); `DirectionExtensions.RowIndex`
+snaps it to the nearest of the eight canonical directions first, so a continuous facing renders
+with the row of its nearest canonical direction. Canonical cardinals map to their own row and
+canonical diagonals (which have no dedicated sheet row) fall back to the side-view row of their
+horizontal component.
 
 ```csharp
 using var sprite = sheet.GetSprite(characterIndex: 1, Direction.Down, frame: 1);

--- a/docs/api/Vector2.md
+++ b/docs/api/Vector2.md
@@ -1,7 +1,8 @@
 # Vector2
 
 Namespace: `RPGEngine` — a two-dimensional vector with double-precision components, used for
-screen-space offsets, deltas and distances.
+screen-space offsets, deltas and distances. It is a `readonly record struct Vector2(double X,
+double Y)`.
 
 ```csharp
 var v = new Vector2(3, -4);
@@ -28,12 +29,16 @@ Returns the negation of `v`.
 ### `static Vector2 operator *(Vector2 v, double scalar)` / `static Vector2 operator *(double scalar, Vector2 v)`
 
 Returns the component-wise product of the vector and the scalar. Used by movement logic to scale
-a direction delta by a distance.
+a vector by a distance.
 
 ```csharp
-var delta = Direction.Up.Delta();         // (0, -1)
-var step = delta * (2 * 1 * 0.5);         // (0, -1) — 1 tile up at 2 tiles/s for 0.5 s
+var direction = new Vector2(0, -1);   // up
+var step = direction * (2 * 1 * 0.5); // (0, -1) — 1 tile up at 2 tiles/s for 0.5 s
 ```
+
+> `Direction` (the continuous direction type) implicitly converts to a `Vector2` with the same
+> components, so a direction can be used wherever a `Vector2` offset is expected (e.g. adding a
+> scaled direction to a `Position`). See `Direction.md`.
 
 ## Example
 

--- a/src/RPGEngine/Character.cs
+++ b/src/RPGEngine/Character.cs
@@ -48,7 +48,7 @@ public sealed class Character
     /// <summary>The middle column of the 3-frame walk cycle: the standing frame in RPG Maker MZ.</summary>
     private const int StandingFrame = 1;
 
-    /// <summary>The number of frame steps in one complete walk cycle: <c>0 &#8594; 1 &#8594; 2 &#8594; 1</c>.</summary>
+    /// <summary>The number of frame steps in one complete walk cycle: <c>0 → 1 → 2 → 1</c>.</summary>
     private const int FramesPerCycle = 4;
 
     private readonly CharacterSpriteCompositor _compositor = new();
@@ -73,8 +73,23 @@ public sealed class Character
     /// </summary>
     public Position Position { get; set; }
 
-    /// <summary>Gets or sets the direction the character is facing.</summary>
-    public Direction Direction { get; set; }
+    /// <summary>
+    /// Gets or sets the direction the character is facing: a 2-D vector (see
+    /// <see cref="Direction"/>), typically one of the eight canonical unit directions
+    /// (<see cref="Direction.Down"/>, …) but allowed to be any continuous unit vector.
+    /// Defaults to <see cref="Direction.Down"/> (the historical default facing), even though the
+    /// zero vector <c>(0, 0)</c> is <c>default(Direction)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Movement assumes a unit-length direction: the displacement applied by
+    /// <see cref="Move(Direction, double, double)"/> (and by the autonomous
+    /// <see cref="Update(double, TileMap)"/> path) is <c>Direction * BaseSpeed * factor * dt</c>,
+    /// so a non-unit vector scales the displacement by its length. All engine-produced directions
+    /// are unit vectors. When rendering, the (possibly continuous) facing is snapped to the
+    /// nearest canonical 8 direction for the sprite row (see
+    /// <see cref="DirectionExtensions.Nearest8"/>), so sprites stay 8-direction.
+    /// </remarks>
+    public Direction Direction { get; set; } = RPGEngine.Direction.Down;
 
     /// <summary>Gets or sets the movement speed of the character in tiles per second.</summary>
     public double BaseSpeed { get; set; }
@@ -99,7 +114,7 @@ public sealed class Character
     /// cycle per second. Defaults to 2, matching <see cref="Player.DefaultBaseSpeed"/>.
     /// </summary>
     /// <remarks>
-    /// The walk cycle is the bounce <c>0 &#8594; 1 &#8594; 2 &#8594; 1</c>, i.e.
+    /// The walk cycle is the bounce <c>0 → 1 → 2 → 1</c>, i.e.
     /// <see cref="FramesPerCycle"/> frame steps. The time per frame is
     /// <c>secondsPerFrame = AnimationCycleSpeed / (BaseSpeed * FramesPerCycle)</c>, so at
     /// <c>BaseSpeed == AnimationCycleSpeed == 2</c> one frame lasts 0.25 s (4 frames/s =
@@ -173,8 +188,7 @@ public sealed class Character
             return;
         }
 
-        var delta = direction.Delta() * (BaseSpeed * speedFactor * dt);
-        Position = Position + delta;
+        Position += direction * (BaseSpeed * speedFactor * dt);
     }
 
     /// <summary>
@@ -245,7 +259,7 @@ public sealed class Character
     {
         if (IsMoving)
         {
-            var delta = Direction.Delta() * (BaseSpeed * dt);
+            var delta = Direction * (BaseSpeed * dt);
             Position = map is null
                 ? Position + delta
                 : MovementCollisionResolver.ResolveDisplacement(
@@ -307,7 +321,10 @@ public sealed class Character
     /// </exception>
     internal void Draw(SKCanvas canvas, Position anchorPosition, double dt, SpriteSheetManager spriteSheetManager, IconSet? iconSet)
     {
-        _compositor.Draw(canvas, anchorPosition, _spriteSheets, Direction, _animationFrame, spriteSheetManager, iconSet, IconIndex);
+        // Snap at the draw boundary: the compositor (and its direction == Direction.Up-style
+        // checks) always receives a canonical 8 direction. This is the single place that turns
+        // the character's (possibly continuous) facing into the 8-direction sprite facing.
+        _compositor.Draw(canvas, anchorPosition, _spriteSheets, Direction.Nearest8(), _animationFrame, spriteSheetManager, iconSet, IconIndex);
     }
 
     /// <summary>

--- a/src/RPGEngine/Direction.cs
+++ b/src/RPGEngine/Direction.cs
@@ -1,39 +1,184 @@
 namespace RPGEngine;
 
 /// <summary>
-/// The eight facing directions used throughout the engine.
+/// A direction in the game world, expressed as a 2-D screen-space vector with
+/// double-precision components (X grows right, Y grows down) — the same double model as
+/// <see cref="Position"/>. This replaces the historical 8-value enum: a direction is now any
+/// unit-length 2-D vector, so facing can be continuous (not just one of eight discrete values).
 /// </summary>
+/// <param name="X">The horizontal component of the direction (grows right).</param>
+/// <param name="Y">The vertical component of the direction (grows down).</param>
 /// <remarks>
-/// The cardinal values match the RPG Maker MZ character sheet row order
-/// (<c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>) and the diagonal values
-/// follow them (<c>4..7</c>). Diagonals have no dedicated sprite-sheet row: a diagonally-facing
-/// character renders with the side-view row of its horizontal component (see
-/// <see cref="DirectionExtensions.RowIndex"/>). This enum is the single source of truth used by
-/// sprite cropping and rendering.
+/// <para>
+/// Movement assumes a <em>unit-length</em> direction: the displacement applied is
+/// <c>direction * BaseSpeed * factor * dt</c>, so a non-unit vector scales the displacement by
+/// its <see cref="Length"/>. All engine-produced directions (key input, auto-walk facing) are
+/// unit vectors; the eight canonical unit directions remain available as static members
+/// (<see cref="Down"/>, <see cref="Left"/>, <see cref="Right"/>, <see cref="Up"/>,
+/// <see cref="DownLeft"/>, <see cref="DownRight"/>, <see cref="UpLeft"/>,
+/// <see cref="UpRight"/>), and <see cref="All"/> lists them in the historical enum order.
+/// Sprites are still 8-direction: a (possibly continuous) facing is adapted to the nearest
+/// canonical direction for the sheet row (see <see cref="DirectionExtensions.Nearest8"/> and
+/// <see cref="DirectionExtensions.RowIndex"/>).
+/// </para>
+/// <para>
+/// The default <c>default(Direction)</c> is the zero vector <c>(0, 0)</c>. Consumers that need
+/// a facing default (e.g. <c>Character.Direction</c>) initialize it explicitly to
+/// <see cref="Down"/> to preserve the historical default facing.
+/// </para>
 /// </remarks>
-public enum Direction
+public readonly record struct Direction(double X, double Y)
 {
-    /// <summary>Facing down (row 0 of an RPG Maker MZ character sheet).</summary>
-    Down = 0,
+    /// <summary>The magnitude of a normalized diagonal component: √½ ≈ 0.7071067811865476.</summary>
+    private const double RootHalf = 0.7071067811865476;
 
-    /// <summary>Facing left (row 1 of an RPG Maker MZ character sheet).</summary>
-    Left = 1,
+    /// <summary>Gets the canonical unit direction facing down: <c>(0, +1)</c> (row 0 of an RPG Maker MZ character sheet).</summary>
+    public static Direction Down { get; } = new(0, 1);
 
-    /// <summary>Facing right (row 2 of an RPG Maker MZ character sheet).</summary>
-    Right = 2,
+    /// <summary>Gets the canonical unit direction facing left: <c>(-1, 0)</c> (row 1 of an RPG Maker MZ character sheet).</summary>
+    public static Direction Left { get; } = new(-1, 0);
 
-    /// <summary>Facing up (row 3 of an RPG Maker MZ character sheet).</summary>
-    Up = 3,
+    /// <summary>Gets the canonical unit direction facing right: <c>(1, 0)</c> (row 2 of an RPG Maker MZ character sheet).</summary>
+    public static Direction Right { get; } = new(1, 0);
 
-    /// <summary>Facing down-left (renders with the Left/row-1 sprite).</summary>
-    DownLeft = 4,
+    /// <summary>Gets the canonical unit direction facing up: <c>(0, -1)</c> (row 3 of an RPG Maker MZ character sheet).</summary>
+    public static Direction Up { get; } = new(0, -1);
 
-    /// <summary>Facing down-right (renders with the Right/row-2 sprite).</summary>
-    DownRight = 5,
+    /// <summary>Gets the canonical unit direction facing down-left: <c>(-√½, +√½)</c>.</summary>
+    public static Direction DownLeft { get; } = new(-RootHalf, RootHalf);
 
-    /// <summary>Facing up-left (renders with the Left/row-1 sprite).</summary>
-    UpLeft = 6,
+    /// <summary>Gets the canonical unit direction facing down-right: <c>(+√½, +√½)</c>.</summary>
+    public static Direction DownRight { get; } = new(RootHalf, RootHalf);
 
-    /// <summary>Facing up-right (renders with the Right/row-2 sprite).</summary>
-    UpRight = 7,
+    /// <summary>Gets the canonical unit direction facing up-left: <c>(-√½, -√½)</c>.</summary>
+    public static Direction UpLeft { get; } = new(-RootHalf, -RootHalf);
+
+    /// <summary>Gets the canonical unit direction facing up-right: <c>(+√½, -√½)</c>.</summary>
+    public static Direction UpRight { get; } = new(RootHalf, -RootHalf);
+
+    /// <summary>
+    /// Gets the eight canonical unit directions (the &quot;old 8 directions&quot;), in the
+    /// historical enum order: <see cref="Down"/>, <see cref="Left"/>, <see cref="Right"/>,
+    /// <see cref="Up"/>, <see cref="DownLeft"/>, <see cref="DownRight"/>, <see cref="UpLeft"/>,
+    /// <see cref="UpRight"/>. Key input always yields one of these, and sprites adapt a
+    /// continuous facing to the nearest of them (see <see cref="DirectionExtensions.Nearest8"/>).
+    /// </summary>
+    public static IReadOnlyList<Direction> All { get; } = [Down, Left, Right, Up, DownLeft, DownRight, UpLeft, UpRight];
+
+    /// <summary>
+    /// Returns the opposite direction: the component-wise negation <c>(-X, -Y)</c>. For the
+    /// eight canonical directions this matches the enum's historical opposite
+    /// (<see cref="Down"/> ↔ <see cref="Up"/>, <see cref="Left"/> ↔
+    /// <see cref="Right"/>, and each diagonal flips both signs), and it stays well-defined for
+    /// any continuous direction.
+    /// </summary>
+    /// <param name="d">The direction to negate.</param>
+    /// <returns>The opposite direction.</returns>
+    public static Direction operator -(Direction d) => new(-d.X, -d.Y);
+
+    /// <summary>
+    /// Returns the component-wise product of the direction and the scalar. Movement multiplies
+    /// the (unit) direction vector by the travelled distance: <c>direction * (BaseSpeed *
+    /// factor * dt)</c>.
+    /// </summary>
+    /// <param name="d">The direction.</param>
+    /// <param name="scalar">The scalar multiplier.</param>
+    /// <returns>The scaled direction.</returns>
+    public static Direction operator *(Direction d, double scalar) => new(d.X * scalar, d.Y * scalar);
+
+    /// <summary>Returns the component-wise product of the scalar and the direction.</summary>
+    /// <param name="scalar">The scalar multiplier.</param>
+    /// <param name="d">The direction.</param>
+    /// <returns>The scaled direction.</returns>
+    public static Direction operator *(double scalar, Direction d) => d * scalar;
+
+    /// <summary>
+    /// Converts the direction to the equivalent <see cref="Vector2"/> with the same components.
+    /// A direction <em>is</em> a 2-D vector, so this makes the direction directly usable wherever
+    /// a <see cref="Vector2"/> offset is expected (e.g. adding a scaled direction to a
+    /// <see cref="Position"/>).
+    /// </summary>
+    /// <param name="d">The direction to convert.</param>
+    /// <returns>The equivalent <see cref="Vector2"/>.</returns>
+    public static implicit operator Vector2(Direction d) => new(d.X, d.Y);
+
+    /// <summary>
+    /// Gets the Euclidean length (magnitude) of the direction. The canonical unit directions all
+    /// have length 1, so their displacement equals <c>BaseSpeed * factor * dt</c>.
+    /// </summary>
+    public double Length => Math.Sqrt((X * X) + (Y * Y));
+
+    /// <summary>Gets whether the direction is the zero vector <c>(0, 0)</c> (the default <c>default(Direction)</c>).</summary>
+    public bool IsZero => X == 0 && Y == 0;
+
+    /// <summary>
+    /// Gets this direction normalized to unit length (its <see cref="Length"/> becomes 1), with
+    /// its direction unchanged. Use this before movement to guarantee an exact
+    /// <c>BaseSpeed * dt</c> displacement regardless of the input vector's length.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The direction is the zero vector <c>(0, 0)</c>, which has no direction to normalize.</exception>
+    public Direction Normalized
+    {
+        get
+        {
+            if (IsZero)
+            {
+                throw new InvalidOperationException("Cannot normalize the zero direction (0, 0).");
+            }
+
+            var length = Length;
+            return new Direction(X / length, Y / length);
+        }
+    }
+
+    /// <summary>
+    /// Returns the canonical name (e.g. <c>&quot;Up&quot;</c>) when the direction equals one of
+    /// the eight canonical unit directions in <see cref="All"/>, for readability and logging;
+    /// otherwise returns <c>&quot;(X, Y)&quot;</c> with the numeric components.
+    /// </summary>
+    /// <returns>The canonical name for a canonical direction, else the component pair.</returns>
+    public override string ToString()
+    {
+        if (this == Down)
+        {
+            return nameof(Down);
+        }
+
+        if (this == Left)
+        {
+            return nameof(Left);
+        }
+
+        if (this == Right)
+        {
+            return nameof(Right);
+        }
+
+        if (this == Up)
+        {
+            return nameof(Up);
+        }
+
+        if (this == DownLeft)
+        {
+            return nameof(DownLeft);
+        }
+
+        if (this == DownRight)
+        {
+            return nameof(DownRight);
+        }
+
+        if (this == UpLeft)
+        {
+            return nameof(UpLeft);
+        }
+
+        if (this == UpRight)
+        {
+            return nameof(UpRight);
+        }
+
+        return $"({X}, {Y})";
+    }
 }

--- a/src/RPGEngine/DirectionExtensions.cs
+++ b/src/RPGEngine/DirectionExtensions.cs
@@ -1,104 +1,109 @@
 namespace RPGEngine;
 
 /// <summary>
-/// Provides convenience members for the <see cref="Direction"/> enum: screen-space deltas,
-/// opposites, sprite-sheet row indices and axis classification.
+/// Provides the 8-direction adaptation layer for the <see cref="Direction"/> vector type: it
+/// adapts a (possibly continuous) direction to the nearest of the eight canonical unit
+/// directions (<see cref="Nearest8"/>), maps a direction to its RPG Maker MZ character-sheet
+/// row (<see cref="RowIndex"/>) and returns its opposite (<see cref="Opposite"/>).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Direction"/> is a continuous 2-D vector (see its documentation). Key input still
+/// yields one of the eight canonical unit directions (see
+/// <see cref="GameConfig.GetMovementDirection(System.Collections.Generic.IEnumerable{Key})"/>),
+/// but a facing direction may in general be continuous. Sprites remain 8-direction: the
+/// direction vector is adapted to the nearest of the eight canonical directions
+/// (<see cref="Nearest8"/>) and then to a sheet row (<see cref="RowIndex"/>) — the epic's
+/// &quot;the direction vector is adapted to the old 8 directions&quot;.
+/// </para>
+/// </remarks>
 public static class DirectionExtensions
 {
     /// <summary>
-    /// Returns the screen-space unit delta for the direction. Screen coordinates grow Y
-    /// downward, so <see cref="Direction.Down"/> is <c>(0, +1)</c> and
-    /// <see cref="Direction.Up"/> is <c>(0, -1)</c>. Diagonal deltas are normalized (magnitude 1,
-    /// not &#8730;2), so diagonal movement is exactly as fast as cardinal movement.
-    /// </summary>
-    /// <param name="d">The direction.</param>
-    /// <returns>The unit vector the direction points to.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="d"/> is not a defined <see cref="Direction"/>.</exception>
-    public static Vector2 Delta(this Direction d) => d switch
-    {
-        Direction.Down => new Vector2(0, 1),
-        Direction.Left => new Vector2(-1, 0),
-        Direction.Right => new Vector2(1, 0),
-        Direction.Up => new Vector2(0, -1),
-        Direction.DownLeft => new Vector2(-RootHalf, RootHalf),
-        Direction.DownRight => new Vector2(RootHalf, RootHalf),
-        Direction.UpLeft => new Vector2(-RootHalf, -RootHalf),
-        Direction.UpRight => new Vector2(RootHalf, -RootHalf),
-        _ => throw new ArgumentOutOfRangeException(nameof(d), d, "Unknown direction."),
-    };
-
-    /// <summary>
-    /// Returns the direction opposite to this one: <see cref="Direction.Down"/> &#8596;
-    /// <see cref="Direction.Up"/>, <see cref="Direction.Left"/> &#8596;
-    /// <see cref="Direction.Right"/>, <see cref="Direction.DownLeft"/> &#8596;
-    /// <see cref="Direction.UpRight"/> and <see cref="Direction.DownRight"/> &#8596;
-    /// <see cref="Direction.UpLeft"/>.
-    /// </summary>
-    /// <param name="d">The direction.</param>
-    /// <returns>The opposite direction.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="d"/> is not a defined <see cref="Direction"/>.</exception>
-    public static Direction Opposite(this Direction d) => d switch
-    {
-        Direction.Down => Direction.Up,
-        Direction.Left => Direction.Right,
-        Direction.Right => Direction.Left,
-        Direction.Up => Direction.Down,
-        Direction.DownLeft => Direction.UpRight,
-        Direction.DownRight => Direction.UpLeft,
-        Direction.UpLeft => Direction.DownRight,
-        Direction.UpRight => Direction.DownLeft,
-        _ => throw new ArgumentOutOfRangeException(nameof(d), d, "Unknown direction."),
-    };
-
-    /// <summary>
-    /// Returns the RPG Maker MZ character sheet row for this direction
-    /// (<c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>).
+    /// Returns the closest of the eight canonical unit directions in <see cref="Direction.All"/>
+    /// to this direction, chosen by dot product against each canonical unit vector after
+    /// normalizing <paramref name="d"/> (so only the direction matters, not its length). The zero
+    /// vector <c>(0, 0)</c> has no direction and snaps to <see cref="Direction.Down"/>.
     /// </summary>
     /// <remarks>
-    /// Cardinal directions return their enum value (<c>0..3</c>). Diagonal directions have no
-    /// dedicated sheet row, so they deliberately fall back to their <em>horizontal</em>
-    /// component's row: <see cref="Direction.DownLeft"/> and <see cref="Direction.UpLeft"/> map to
-    /// row 1 (the Left row) and <see cref="Direction.DownRight"/> and
-    /// <see cref="Direction.UpRight"/> map to row 2 (the Right row). A diagonally-facing
-    /// character therefore renders with the side-view row, which reads better than the front or
-    /// back rows for an oblique facing.
+    /// This is the &quot;adapt the direction vector to the old 8 directions&quot; operation used
+    /// at the sprite boundary: a continuous facing such as <c>(0.9, 0.2)</c> maps to
+    /// <see cref="Direction.Right"/>.
+    /// </remarks>
+    /// <param name="d">The direction to snap.</param>
+    /// <returns>The nearest canonical unit direction (one of <see cref="Direction.All"/>).</returns>
+    public static Direction Nearest8(this Direction d)
+    {
+        if (d.IsZero)
+        {
+            return Direction.Down;
+        }
+
+        // The canonical directions are all unit vectors, so after normalizing d the dot product
+        // with each candidate is exactly the cosine of the angle between them: the largest dot
+        // product is the closest direction. Ties (vectors exactly between two directions) are
+        // resolved by All's order (the first best wins).
+        var normalized = d.Normalized;
+        Direction best = Direction.Down;
+        var bestDot = double.NegativeInfinity;
+        foreach (var candidate in Direction.All)
+        {
+            var dot = (normalized.X * candidate.X) + (normalized.Y * candidate.Y);
+            if (dot > bestDot)
+            {
+                bestDot = dot;
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Returns the RPG Maker MZ character-sheet row the character should render with for this
+    /// direction: <c>0 = down</c>, <c>1 = left</c>, <c>2 = right</c>, <c>3 = up</c>.
+    /// </summary>
+    /// <remarks>
+    /// The direction is first snapped with <see cref="Nearest8"/>, so a continuous vector maps
+    /// to the row of its nearest canonical direction. Cardinal directions return their own row;
+    /// canonical diagonals have no dedicated sheet row, so they deliberately fall back to their
+    /// <em>horizontal</em> component's row (<see cref="Direction.DownLeft"/> and
+    /// <see cref="Direction.UpLeft"/> → 1, <see cref="Direction.DownRight"/> and
+    /// <see cref="Direction.UpRight"/> → 2): a diagonally-facing character renders with the
+    /// side-view row, which reads better than the front or back rows for an oblique facing.
     /// </remarks>
     /// <param name="d">The direction.</param>
     /// <returns>The 0-based sprite-sheet row (0..3).</returns>
-    public static int RowIndex(this Direction d) => d switch
+    public static int RowIndex(this Direction d)
     {
-        Direction.DownLeft or Direction.UpLeft => 1,
-        Direction.DownRight or Direction.UpRight => 2,
-        _ => (int)d,
-    };
+        var nearest = d.Nearest8();
+
+        if (nearest == Direction.Left || nearest == Direction.DownLeft || nearest == Direction.UpLeft)
+        {
+            return 1;
+        }
+
+        if (nearest == Direction.Right || nearest == Direction.DownRight || nearest == Direction.UpRight)
+        {
+            return 2;
+        }
+
+        if (nearest == Direction.Up)
+        {
+            return 3;
+        }
+
+        return 0; // Direction.Down
+    }
 
     /// <summary>
-    /// Returns whether the direction is horizontal (<see cref="Direction.Left"/> or
-    /// <see cref="Direction.Right"/>). Diagonals are neither horizontal nor vertical.
+    /// Returns the direction opposite to this one. This is exactly the vector negation
+    /// <c>-d</c>: for the eight canonical directions it matches the enum's historical opposite
+    /// (<see cref="Direction.Down"/> ↔ <see cref="Direction.Up"/>,
+    /// <see cref="Direction.Left"/> ↔ <see cref="Direction.Right"/>, and each diagonal
+    /// flips both signs), and it remains well-defined for any continuous direction.
     /// </summary>
     /// <param name="d">The direction.</param>
-    /// <returns><see langword="true"/> when the direction is horizontal; otherwise <see langword="false"/>.</returns>
-    public static bool IsHorizontal(this Direction d) => d is Direction.Left or Direction.Right;
-
-    /// <summary>
-    /// Returns whether the direction is vertical (<see cref="Direction.Down"/> or
-    /// <see cref="Direction.Up"/>). Diagonals are neither horizontal nor vertical.
-    /// </summary>
-    /// <param name="d">The direction.</param>
-    /// <returns><see langword="true"/> when the direction is vertical; otherwise <see langword="false"/>.</returns>
-    public static bool IsVertical(this Direction d) => d is Direction.Down or Direction.Up;
-
-    /// <summary>
-    /// Returns whether the direction is one of the four diagonal directions
-    /// (<see cref="Direction.DownLeft"/>, <see cref="Direction.DownRight"/>,
-    /// <see cref="Direction.UpLeft"/> or <see cref="Direction.UpRight"/>).
-    /// </summary>
-    /// <param name="d">The direction.</param>
-    /// <returns><see langword="true"/> when the direction is diagonal; otherwise <see langword="false"/>.</returns>
-    public static bool IsDiagonal(this Direction d)
-        => d is Direction.DownLeft or Direction.DownRight or Direction.UpLeft or Direction.UpRight;
-
-    /// <summary>The magnitude of a normalized diagonal component: &#8730;&#189; &#8776; 0.7071067811865476.</summary>
-    private const double RootHalf = 0.7071067811865476;
+    /// <returns>The opposite direction.</returns>
+    public static Direction Opposite(this Direction d) => -d;
 }

--- a/src/RPGEngine/GameConfig.cs
+++ b/src/RPGEngine/GameConfig.cs
@@ -121,10 +121,13 @@ public sealed class GameConfig
     /// direction or the bound directions cancel out (e.g. Up+Down or Left+Right held together).
     /// </returns>
     /// <remarks>
-    /// Every pressed key bound to a movement direction (via <see cref="GetDirection(Key)"/>)
-    /// contributes its unit delta; the deltas are summed, normalized and quantized to the nearest
-    /// of the eight <see cref="Direction"/> values by dot product against each direction's unit
-    /// delta. This is what makes diagonal movement work: <c>W</c>+<c>D</c> resolves to
+    /// <see cref="Direction"/> is a continuous 2-D vector, but key input always maps to the
+    /// eight canonical unit directions: every pressed key bound to a movement direction (via
+    /// <see cref="GetDirection(Key)"/>) contributes its own canonical unit vector; the vectors
+    /// are summed, normalized and snapped to the nearest of the eight canonical directions in
+    /// <see cref="Direction.All"/> by dot product (<see cref="DirectionExtensions.Nearest8"/>).
+    /// A non-null result is therefore always one of the eight canonical unit directions. This is
+    /// what makes diagonal movement work: <c>W</c>+<c>D</c> resolves to
     /// <see cref="Direction.UpRight"/>, while <c>W</c>+<c>A</c>+<c>D</c> resolves to
     /// <see cref="Direction.Up"/> because A and D cancel. The configuration is read at input time
     /// and never cached, so rebinding takes effect immediately.
@@ -133,7 +136,10 @@ public sealed class GameConfig
     {
         ArgumentNullException.ThrowIfNull(pressedKeys);
 
-        var sum = new Vector2(0, 0);
+        // Sum the canonical unit vectors of every held bound key. Each canonical direction is its
+        // own unit vector, so this replaces the old sum of Direction.Delta() deltas 1:1.
+        var sumX = 0d;
+        var sumY = 0d;
         var hasBoundKey = false;
 
         foreach (var key in pressedKeys)
@@ -141,36 +147,22 @@ public sealed class GameConfig
             var direction = GetDirection(key);
             if (direction.HasValue)
             {
-                sum += direction.Value.Delta();
+                sumX += direction.Value.X;
+                sumY += direction.Value.Y;
                 hasBoundKey = true;
             }
         }
 
-        if (!hasBoundKey || (sum.X == 0 && sum.Y == 0))
+        if (!hasBoundKey || (sumX == 0 && sumY == 0))
         {
             return null;
         }
 
-        // Normalize the combined vector, then pick the direction whose unit delta is closest
-        // (largest dot product). For key input the sum always lands exactly on one of the eight
-        // directions, but the dot product makes the quantization robust for arbitrary vectors.
-        var length = Math.Sqrt((sum.X * sum.X) + (sum.Y * sum.Y));
-        var normalized = new Vector2(sum.X / length, sum.Y / length);
-
-        Direction? best = null;
-        var bestDot = double.NegativeInfinity;
-        foreach (var direction in Enum.GetValues<Direction>())
-        {
-            var delta = direction.Delta();
-            var dot = (normalized.X * delta.X) + (normalized.Y * delta.Y);
-            if (dot > bestDot)
-            {
-                bestDot = dot;
-                best = direction;
-            }
-        }
-
-        return best;
+        // Snap the summed vector to the nearest canonical direction (Nearest8 normalizes it
+        // first and picks the largest dot product). For key input the sum always lands exactly
+        // on one of the eight canonical directions, but the dot product makes the quantization
+        // robust for arbitrary vectors.
+        return new Direction(sumX, sumY).Nearest8();
     }
 
     /// <summary>

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -51,11 +51,13 @@ namespace RPGEngine;
 /// Without a map the canvas is left untouched and only the characters (Y-sorted) are drawn.
 /// </para>
 /// <para>
-/// Movement input combines every held bound key into a single 8-direction vector: each key that
-/// is bound to a movement direction contributes its unit delta, opposite keys cancel
-/// (<c>W</c>+<c>S</c> or <c>A</c>+<c>D</c>), and the resulting direction can be diagonal
-/// (<c>W</c>+<c>D</c> resolves to up-right). When no bound key is held the player stops and its
-/// animation snaps back to the standing frame.
+/// Movement input combines every held bound key into a single direction vector: each key that
+/// is bound to a movement direction contributes its canonical unit direction vector, opposite
+/// keys cancel (<c>W</c>+<c>S</c> or <c>A</c>+<c>D</c>), and the resulting direction can be a
+/// canonical diagonal (<c>W</c>+<c>D</c> resolves to up-right). The summed vector is snapped to
+/// the nearest of the eight canonical directions, so key input always yields one of the eight
+/// canonical directions. When no bound key is held the player stops and its animation snaps back
+/// to the standing frame.
 /// </para>
 /// <para>
 /// Click input drives the player with <em>auto-walk</em>: <see cref="Click"/> converts a
@@ -1165,37 +1167,23 @@ public sealed class GameEngine : IDisposable
     }
 
     /// <summary>
-    /// Returns the <see cref="Direction"/> closest to <paramref name="vector"/>: the vector is
-    /// normalized and the direction whose unit delta has the largest dot product with it wins,
+    /// Returns the canonical <see cref="Direction"/> closest to <paramref name="vector"/>: the
+    /// vector is normalized and snapped to the nearest of the eight canonical unit directions in
+    /// <see cref="Direction.All"/> by dot product (<see cref="DirectionExtensions.Nearest8"/>),
     /// mirroring <see cref="GameConfig.GetMovementDirection(System.Collections.Generic.IEnumerable{Key})"/>'s
-    /// quantization. Used by the auto-walk to face the waypoint it is moving toward.
+    /// quantization. Used by the auto-walk to face the waypoint it is moving toward; the facing
+    /// (and the event payloads) stay one of the eight canonical directions in this story.
     /// </summary>
     /// <param name="vector">The movement vector (never the zero vector when called).</param>
-    /// <returns>The closest of the eight <see cref="Direction"/> values.</returns>
+    /// <returns>The closest of the eight canonical <see cref="Direction"/> values.</returns>
     private static Direction DirectionFromVector(Vector2 vector)
     {
-        var length = Math.Sqrt((vector.X * vector.X) + (vector.Y * vector.Y));
-        if (length <= 0)
+        if (vector.X == 0 && vector.Y == 0)
         {
             return Direction.Down;
         }
 
-        var normalized = new Vector2(vector.X / length, vector.Y / length);
-
-        Direction? best = null;
-        var bestDot = double.NegativeInfinity;
-        foreach (var direction in Enum.GetValues<Direction>())
-        {
-            var delta = direction.Delta();
-            var dot = (normalized.X * delta.X) + (normalized.Y * delta.Y);
-            if (dot > bestDot)
-            {
-                bestDot = dot;
-                best = direction;
-            }
-        }
-
-        return best!.Value;
+        return new Direction(vector.X, vector.Y).Nearest8();
     }
 
     /// <summary>
@@ -1252,7 +1240,7 @@ public sealed class GameEngine : IDisposable
         // resolution so a fully blocked move (no net displacement) can be reported as a
         // collision stop below.
         var before = Player.Position;
-        var delta = direction.Delta() * (Player.Character.BaseSpeed * dt);
+        var delta = direction * (Player.Character.BaseSpeed * dt);
 
         // Report the start of movement BEFORE the position update. When the player is already
         // resting idle against a wall in the same direction (the previous frame ended in a

--- a/src/RPGEngine/Player.cs
+++ b/src/RPGEngine/Player.cs
@@ -22,8 +22,8 @@ namespace RPGEngine;
 /// <para>
 /// The player exposes a movement-state machine through two events: <see cref="OnStartMoving"/>
 /// fires <em>before</em> the position is updated, exactly when the player <em>begins</em> moving
-/// in a new direction (idle &#8594; moving for key movement, a direction change while moving &#8212;
-/// e.g. pressing a second key so the player moves diagonally &#8212; and once per auto-walk step for
+/// in a new direction (idle → moving for key movement, a direction change while moving —
+/// e.g. pressing a second key so the player moves diagonally — and once per auto-walk step for
 /// click-to-move), and never per frame. <see cref="OnStopMoving"/> fires when the player stops
 /// moving: every movement key is released, the last auto-walk step is reached, or the player is
 /// blocked by a collision. Both events carry only the facing <see cref="Direction"/>, which is
@@ -48,22 +48,22 @@ public sealed class Player
     // event machinery reported, used to report the facing direction in OnStopMoving when the
     // player stops and to detect direction changes while moving (a new direction is a new start).
     private bool _isMoving;
-    private Direction _lastDirection = Direction.Down;
+    private Direction _lastDirection = RPGEngine.Direction.Down;
 
     /// <summary>
-    /// Occurs when the player starts moving in a new direction: from idle &#8594; moving for key
+    /// Occurs when the player starts moving in a new direction: from idle → moving for key
     /// movement, when the movement direction changes while already moving (e.g. a second key is
     /// pressed so the player moves diagonally), and once per auto-walk step for click-to-move.
-    /// The event is raised <em>before</em> the position is updated and carries the
-    /// <see cref="Direction"/> the player is moving in. It is not raised per frame: a move that
-    /// keeps the same direction while already moving raises nothing.
+    /// The event is raised <em>before</em> the position is updated and carries the direction
+    /// <em>vector</em> (see <see cref="Direction"/>) the player is moving in. It is not raised
+    /// per frame: a move that keeps the same direction while already moving raises nothing.
     /// </summary>
     public event EventHandler<Direction>? OnStartMoving;
 
     /// <summary>
     /// Occurs when the player stops moving: when every movement key is released, when the last
     /// auto-walk step is reached, or when the player is blocked by a collision. The event carries
-    /// the <see cref="Direction"/> the player was last moving in.
+    /// the direction <em>vector</em> (see <see cref="Direction"/>) the player was last moving in.
     /// </summary>
     public event EventHandler<Direction>? OnStopMoving;
 
@@ -114,10 +114,11 @@ public sealed class Player
     }
 
     /// <summary>
-    /// Gets or sets the direction the player is facing. Forwards to
-    /// <see cref="Character.Direction"/> and keeps the movement event state in sync so
-    /// <see cref="OnStartMoving"/> / <see cref="OnStopMoving"/> report the correct facing
-    /// direction.
+    /// Gets or sets the direction the player is facing: a continuous 2-D direction vector (see
+    /// <see cref="Direction"/>). Forwards to <see cref="Character.Direction"/> and keeps the
+    /// movement event state in sync so <see cref="OnStartMoving"/> / <see cref="OnStopMoving"/>
+    /// report the correct facing direction vector. Defaults to <see cref="Direction.Down"/> via
+    /// the underlying <see cref="Character"/>.
     /// </summary>
     public Direction Direction
     {
@@ -148,8 +149,8 @@ public sealed class Player
     /// This method also drives the movement-state machine: with <paramref name="speedFactor"/>
     /// greater than zero the player is considered <em>moving</em> (it actually moves), so
     /// <see cref="OnStartMoving"/> fires <em>before</em> the displacement when the player starts
-    /// moving in a new direction &#8212; from idle &#8594; moving, or when the direction changes while
-    /// already moving (e.g. right &#8594; up-right when a second key is pressed). A move while already
+    /// moving in a new direction — from idle → moving, or when the direction changes while
+    /// already moving (e.g. right → up-right when a second key is pressed). A move while already
     /// moving in the <em>same</em> direction raises nothing (no per-frame events).
     /// </para>
     /// <para>
@@ -216,8 +217,8 @@ public sealed class Player
     /// <summary>
     /// Records that the player moved in <paramref name="direction"/> and raises
     /// <see cref="OnStartMoving"/> when the player begins moving in a new direction: from idle
-    /// &#8594; moving, or when the direction changes while already moving (a direction change while
-    /// moving is a new start, e.g. right &#8594; up-right when a second key is pressed). A move in the
+    /// → moving, or when the direction changes while already moving (a direction change while
+    /// moving is a new start, e.g. right → up-right when a second key is pressed). A move in the
     /// same direction while already moving raises nothing.
     /// </summary>
     /// <remarks>

--- a/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
+++ b/src/RPGEngine/Sprites/CharacterSpriteCompositor.cs
@@ -71,7 +71,9 @@ internal sealed class CharacterSpriteCompositor
     /// the sprite is drawn above and centered on this point, so its top-left is at
     /// <c>(anchorPosition.X - width/2, anchorPosition.Y - height)</c>.</param>
     /// <param name="spriteSheetRefs">The spritesheet references to use (sheet name + character index).</param>
-    /// <param name="direction">The direction the character faces.</param>
+    /// <param name="direction">The direction the character faces. The character renderer passes
+    /// <c>Direction.Nearest8()</c> here, so this is always one of the eight canonical directions
+    /// (the 8-direction sprite rules, including the facing-up hair adjustment, stay exact).</param>
     /// <param name="frame">The animation frame (0..2).</param>
     /// <param name="manager">Resolves sheet names to <see cref="SpriteSheet"/> instances.</param>
     /// <param name="iconSet">The icon set loaded into the engine, or <see langword="null"/> when

--- a/src/RPGEngine/Sprites/SpriteSheet.cs
+++ b/src/RPGEngine/Sprites/SpriteSheet.cs
@@ -103,9 +103,11 @@ public sealed class SpriteSheet
     /// sheet this is a 48×48 crop; for a 936×864 sheet it is 78×108.
     /// </summary>
     /// <param name="characterIndex">The 1-based index (1..8) of the character in the sheet.</param>
-    /// <param name="direction">The direction the sprite faces. Cardinal directions map to
-    /// their own sheet row; diagonal directions map to the side-view row of their horizontal
-    /// component (see <see cref="DirectionExtensions.RowIndex"/>).</param>
+    /// <param name="direction">The direction the sprite faces: a continuous 2-D direction
+    /// vector (see <see cref="Direction"/>), adapted to the nearest of the eight canonical
+    /// directions for the sheet row via <see cref="DirectionExtensions.RowIndex"/>. Cardinal
+    /// canonical directions map to their own row; canonical diagonals map to the side-view row
+    /// of their horizontal component.</param>
     /// <param name="frame">The animation frame (0..2).</param>
     /// <returns>
     /// An <see cref="SKImage"/> cropped from the decoded source. The caller owns and disposes it.
@@ -116,7 +118,8 @@ public sealed class SpriteSheet
     /// <remarks>
     /// Character <c>i</c> is located at <c>charCol = (i - 1) % 4</c>, <c>charRow = (i - 1) / 4</c>;
     /// its cell <c>(frame, direction)</c> is at column <c>charCol * 3 + frame</c> and row
-    /// <c>charRow * 4 + direction.RowIndex()</c>.
+    /// <c>charRow * 4 + direction.RowIndex()</c> (the row computation snaps a continuous
+    /// direction to its nearest canonical direction first).
     /// <para>
     /// The returned image is an independent <see cref="CellWidth"/>×<see cref="CellHeight"/>
     /// raster crop of the decoded source, produced with nearest-neighbour sampling (a 1:1 pixel

--- a/src/RPGEngine/Vector2.cs
+++ b/src/RPGEngine/Vector2.cs
@@ -19,8 +19,9 @@ public readonly record struct Vector2(double X, double Y)
 
     /// <summary>
     /// Returns the component-wise product of <paramref name="v"/> and the scalar
-    /// <paramref name="scalar"/>. Used by movement logic to scale a direction delta by a
-    /// distance (<c>direction.Delta() * (BaseSpeed * factor * dt)</c>).
+    /// <paramref name="scalar"/>. Used by movement logic to scale a direction vector by a
+    /// distance (a <see cref="Direction"/> scaled by <c>BaseSpeed * factor * dt</c> and added to
+    /// a <see cref="Position"/>).
     /// </summary>
     public static Vector2 operator *(Vector2 v, double scalar) => new(v.X * scalar, v.Y * scalar);
 

--- a/tests/RPGEngine.Tests/CharacterTestHelper.cs
+++ b/tests/RPGEngine.Tests/CharacterTestHelper.cs
@@ -109,7 +109,9 @@ internal static class CharacterTestHelper
         var charCol = (characterIndex - 1) % 4;
         var charRow = (characterIndex - 1) / 4;
         var col = (charCol * 3) + frame;
-        var row = (charRow * 4) + (int)direction;
+        // Direction is now a vector: its sprite row is the row of its (nearest canonical)
+        // direction, exactly as SpriteSheet.GetSprite computes it.
+        var row = (charRow * 4) + direction.RowIndex();
         return (row, col);
     }
 

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -49,10 +49,7 @@ public class CharacterTests
     // ---------------------------------------------------------------------
     /// <summary>Verifies Move(direction, factor, dt) moves exactly BaseSpeed × factor × dt tiles along the correct axis and direction, and sets Direction.</summary>
     [Theory]
-    [InlineData(Direction.Down, 0.0, 100.0)]
-    [InlineData(Direction.Up, 0.0, -100.0)]
-    [InlineData(Direction.Left, -100.0, 0.0)]
-    [InlineData(Direction.Right, 100.0, 0.0)]
+    [MemberData(nameof(CardinalMoveCases))]
     public void Move_WithDirectionFactorAndDt_MovesExactly(
         Direction direction,
         double expectedX,
@@ -782,6 +779,15 @@ public class CharacterTests
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
+
+    /// <summary>The cardinal directions and the exact X/Y displacement Move(d, 2, 0.5) must produce at BaseSpeed 100.</summary>
+    public static TheoryData<Direction, double, double> CardinalMoveCases => new()
+    {
+        { Direction.Down, 0.0, 100.0 },
+        { Direction.Up, 0.0, -100.0 },
+        { Direction.Left, -100.0, 0.0 },
+        { Direction.Right, 100.0, 0.0 },
+    };
 
     /// <summary>Moves the character one step (dt = 1) and updates it, advancing the walk cycle.</summary>
     private static void MoveAndUpdate(Character character, Direction direction)

--- a/tests/RPGEngine.Tests/Core/DirectionTests.cs
+++ b/tests/RPGEngine.Tests/Core/DirectionTests.cs
@@ -4,126 +4,204 @@ using Xunit;
 namespace RPGEngine.Tests.Core;
 
 /// <summary>
-/// Acceptance tests for <see cref="Direction"/> and <see cref="DirectionExtensions"/>
-/// (stories 4 and 21: core primitives — Direction and Position, plus 8-direction support).
+/// Acceptance tests for <see cref="Direction"/> and <see cref="DirectionExtensions"/> after the
+/// Direction rework (story 74): <see cref="Direction"/> is an immutable 2-D vector value type
+/// whose eight canonical unit directions (<see cref="Direction.All"/>) preserve the old 8
+/// directions, and <see cref="DirectionExtensions.Nearest8"/>/<see cref="DirectionExtensions.RowIndex"/>/
+/// <see cref="DirectionExtensions.Opposite"/> adapt it to the 8-direction sprite/key model.
 /// </summary>
 public class DirectionTests
 {
+    /// <summary>The exact √½ diagonal component shared with the library's canonical diagonals.</summary>
+    private const double RootHalf = 0.7071067811865476;
+
     /// <summary>
-    /// Verifies <see cref="DirectionExtensions.Delta"/> returns the correct screen-space unit
-    /// vector for every direction. Cardinal values are exact; diagonal values are normalized
-    /// (each component is ±√½) so their magnitude is 1 and diagonal movement is exactly as fast
-    /// as cardinal movement.
+    /// Verifies the eight canonical unit directions have exactly the documented components:
+    /// cardinals are exact axis vectors and diagonals are <c>(±√½, ±√½)</c>
+    /// (normalized, so diagonal movement is as fast as cardinal movement).
     /// </summary>
     [Theory]
-    [InlineData(Direction.Down, 0, 1, false)]
-    [InlineData(Direction.Left, -1, 0, false)]
-    [InlineData(Direction.Right, 1, 0, false)]
-    [InlineData(Direction.Up, 0, -1, false)]
-    [InlineData(Direction.DownLeft, -1, 1, true)]
-    [InlineData(Direction.DownRight, 1, 1, true)]
-    [InlineData(Direction.UpLeft, -1, -1, true)]
-    [InlineData(Direction.UpRight, 1, -1, true)]
-    public void Delta_IsCorrect_ForAllDirections(Direction direction, int signX, int signY, bool isDiagonal)
+    [MemberData(nameof(CanonicalComponents))]
+    public void CanonicalStatics_HaveExactUnitComponents(Direction direction, double expectedX, double expectedY)
     {
-        var delta = direction.Delta();
+        Assert.Equal(expectedX, direction.X);
+        Assert.Equal(expectedY, direction.Y);
 
-        if (isDiagonal)
-        {
-            var component = Math.Sqrt(0.5);
-            Assert.Equal(signX * component, delta.X, precision: 9);
-            Assert.Equal(signY * component, delta.Y, precision: 9);
-        }
-        else
-        {
-            Assert.Equal(signX, delta.X);
-            Assert.Equal(signY, delta.Y);
-        }
-
-        // Every delta is a unit vector, so diagonal movement is no faster than cardinal movement.
-        Assert.Equal(1, Magnitude(delta), precision: 9);
-    }
-
-    /// <summary>Verifies <see cref="DirectionExtensions.Opposite"/> returns the opposite direction for every direction.</summary>
-    [Theory]
-    [InlineData(Direction.Down, Direction.Up)]
-    [InlineData(Direction.Left, Direction.Right)]
-    [InlineData(Direction.Right, Direction.Left)]
-    [InlineData(Direction.Up, Direction.Down)]
-    [InlineData(Direction.DownLeft, Direction.UpRight)]
-    [InlineData(Direction.DownRight, Direction.UpLeft)]
-    [InlineData(Direction.UpLeft, Direction.DownRight)]
-    [InlineData(Direction.UpRight, Direction.DownLeft)]
-    public void Opposite_IsCorrect_ForAllDirections(Direction direction, Direction expected)
-    {
-        Assert.Equal(expected, direction.Opposite());
+        // Every canonical direction is a unit vector.
+        Assert.Equal(1, direction.Length, precision: 12);
+        Assert.False(direction.IsZero);
     }
 
     /// <summary>
-    /// Verifies <see cref="DirectionExtensions.RowIndex"/> equals the RPG Maker MZ sprite-sheet
-    /// row (0/1/2/3) for Down/Left/Right/Up and falls back to the horizontal component's row for
-    /// diagonals (DownLeft/UpLeft → 1, DownRight/UpRight → 2) so a diagonally-facing character
-    /// renders with the side-view row.
+    /// Verifies <see cref="Direction.All"/> contains exactly the eight canonical unit directions,
+    /// in the historical enum order (Down, Left, Right, Up, DownLeft, DownRight, UpLeft, UpRight).
+    /// </summary>
+    [Fact]
+    public void All_ContainsExactlyTheEightCanonicalDirectionsInHistoricalOrder()
+    {
+        Assert.Equal(
+            new[]
+            {
+                Direction.Down,
+                Direction.Left,
+                Direction.Right,
+                Direction.Up,
+                Direction.DownLeft,
+                Direction.DownRight,
+                Direction.UpLeft,
+                Direction.UpRight,
+            },
+            Direction.All);
+
+        // All eight are distinct and unit-length.
+        Assert.Equal(8, Direction.All.Distinct().Count());
+        Assert.All(Direction.All, d => Assert.Equal(1, d.Length, precision: 12));
+    }
+
+    /// <summary>Verifies vector negation / <see cref="DirectionExtensions.Opposite"/>: canonical opposites and exact continuous negation.</summary>
+    [Fact]
+    public void Negation_AndOpposite_AreExact()
+    {
+        Assert.Equal(Direction.Up, -Direction.Down); // negation of Down is Up
+        Assert.Equal(Direction.Up, Direction.Down.Opposite());
+        Assert.Equal(Direction.Down, Direction.Up.Opposite());
+        Assert.Equal(Direction.Right, Direction.Left.Opposite());
+        Assert.Equal(Direction.Left, Direction.Right.Opposite());
+
+        // Diagonals flip both signs (DownLeft <-> UpRight, DownRight <-> UpLeft).
+        Assert.Equal(Direction.UpRight, Direction.DownLeft.Opposite());
+        Assert.Equal(Direction.DownLeft, Direction.UpRight.Opposite());
+        Assert.Equal(Direction.UpLeft, Direction.DownRight.Opposite());
+        Assert.Equal(Direction.DownRight, Direction.UpLeft.Opposite());
+
+        // operator - negates each component exactly, so it stays well-defined for continuous vectors.
+        Assert.Equal(new Direction(-0.6, 0.8), -new Direction(0.6, -0.8));
+        Assert.Equal(new Direction(-0.6, 0.8), new Direction(0.6, -0.8).Opposite());
+        Assert.Equal(new Direction(0, 0), -new Direction(0, 0));
+    }
+
+    /// <summary>
+    /// Verifies <see cref="DirectionExtensions.Nearest8"/> snaps continuous vectors to the closest
+    /// canonical unit direction and maps the zero vector to <see cref="Direction.Down"/>.
     /// </summary>
     [Theory]
-    [InlineData(Direction.Down, 0)]
-    [InlineData(Direction.Left, 1)]
-    [InlineData(Direction.Right, 2)]
-    [InlineData(Direction.Up, 3)]
-    [InlineData(Direction.DownLeft, 1)]
-    [InlineData(Direction.DownRight, 2)]
-    [InlineData(Direction.UpLeft, 1)]
-    [InlineData(Direction.UpRight, 2)]
-    public void RowIndex_EqualsSpriteSheetRow_ForAllDirections(Direction direction, int expectedRow)
+    [MemberData(nameof(Nearest8Cases))]
+    public void Nearest8_SnapsToExpectedCanonicalDirection(Direction input, Direction expected)
+    {
+        Assert.Equal(expected, input.Nearest8());
+    }
+
+    /// <summary>Verifies <see cref="DirectionExtensions.Nearest8"/> leaves each canonical direction unchanged.</summary>
+    [Fact]
+    public void Nearest8_LeavesCanonicalDirectionsUnchanged()
+    {
+        foreach (var canonical in Direction.All)
+        {
+            Assert.Equal(canonical, canonical.Nearest8());
+        }
+    }
+
+    /// <summary>
+    /// Verifies <see cref="DirectionExtensions.RowIndex"/> maps the canonical directions to the
+    /// RPG Maker MZ sheet rows 0/1/2/3/1/2/1/2 (diagonals fall back to their horizontal
+    /// component's row) and maps continuous vectors to the row of their nearest canonical direction.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(RowIndexCases))]
+    public void RowIndex_IsCorrect(Direction direction, int expectedRow)
     {
         Assert.Equal(expectedRow, direction.RowIndex());
     }
 
-    /// <summary>Verifies <see cref="DirectionExtensions.IsHorizontal"/> distinguishes horizontal from vertical and diagonal directions.</summary>
-    [Theory]
-    [InlineData(Direction.Down, false)]
-    [InlineData(Direction.Left, true)]
-    [InlineData(Direction.Right, true)]
-    [InlineData(Direction.Up, false)]
-    [InlineData(Direction.DownLeft, false)]
-    [InlineData(Direction.DownRight, false)]
-    [InlineData(Direction.UpLeft, false)]
-    [InlineData(Direction.UpRight, false)]
-    public void IsHorizontal_IsCorrect_ForAllDirections(Direction direction, bool expected)
+    /// <summary>
+    /// Verifies <see cref="Direction.Length"/>, <see cref="Direction.IsZero"/> and
+    /// <see cref="Direction.Normalized"/>: the zero vector is zero (and throws on
+    /// <c>Normalized</c>), and a non-unit vector normalizes to unit length with the same direction.
+    /// </summary>
+    [Fact]
+    public void Length_IsZero_AndNormalized()
     {
-        Assert.Equal(expected, direction.IsHorizontal());
+        var zero = new Direction(0, 0);
+        Assert.True(zero.IsZero);
+        Assert.Equal(0, zero.Length);
+        Assert.Throws<InvalidOperationException>(() => zero.Normalized);
+
+        var vector = new Direction(3, 4);
+        Assert.False(vector.IsZero);
+        Assert.Equal(5, vector.Length, precision: 12);
+
+        var normalized = vector.Normalized;
+        Assert.Equal(1, normalized.Length, precision: 12);
+        Assert.Equal(0.6, normalized.X, precision: 12);
+        Assert.Equal(0.8, normalized.Y, precision: 12);
     }
 
-    /// <summary>Verifies <see cref="DirectionExtensions.IsVertical"/> distinguishes vertical from horizontal and diagonal directions.</summary>
-    [Theory]
-    [InlineData(Direction.Down, true)]
-    [InlineData(Direction.Left, false)]
-    [InlineData(Direction.Right, false)]
-    [InlineData(Direction.Up, true)]
-    [InlineData(Direction.DownLeft, false)]
-    [InlineData(Direction.DownRight, false)]
-    [InlineData(Direction.UpLeft, false)]
-    [InlineData(Direction.UpRight, false)]
-    public void IsVertical_IsCorrect_ForAllDirections(Direction direction, bool expected)
+    /// <summary>
+    /// Verifies <see cref="Direction.ToString"/> returns the canonical name for each canonical
+    /// direction and the component pair for a continuous direction.
+    /// </summary>
+    [Fact]
+    public void ToString_ReturnsCanonicalNameForCanonicalDirections()
     {
-        Assert.Equal(expected, direction.IsVertical());
+        Assert.Equal("Down", Direction.Down.ToString());
+        Assert.Equal("Left", Direction.Left.ToString());
+        Assert.Equal("Right", Direction.Right.ToString());
+        Assert.Equal("Up", Direction.Up.ToString());
+        Assert.Equal("DownLeft", Direction.DownLeft.ToString());
+        Assert.Equal("DownRight", Direction.DownRight.ToString());
+        Assert.Equal("UpLeft", Direction.UpLeft.ToString());
+        Assert.Equal("UpRight", Direction.UpRight.ToString());
+
+        // A continuous (non-canonical) vector prints its components.
+        Assert.Equal("(0.6, 0.8)", new Direction(0.6, 0.8).ToString());
+
+        // A vector numerically equal to a canonical diagonal prints the canonical name (the
+        // components are bit-exact with the canonical constant).
+        Assert.Equal("UpRight", new Direction(RootHalf, -RootHalf).ToString());
     }
 
-    /// <summary>Verifies <see cref="DirectionExtensions.IsDiagonal"/> is true for the four diagonals and false for the cardinals.</summary>
-    [Theory]
-    [InlineData(Direction.Down, false)]
-    [InlineData(Direction.Left, false)]
-    [InlineData(Direction.Right, false)]
-    [InlineData(Direction.Up, false)]
-    [InlineData(Direction.DownLeft, true)]
-    [InlineData(Direction.DownRight, true)]
-    [InlineData(Direction.UpLeft, true)]
-    [InlineData(Direction.UpRight, true)]
-    public void IsDiagonal_IsCorrect_ForAllDirections(Direction direction, bool expected)
+    /// <summary>The canonical directions and their exact components.</summary>
+    public static TheoryData<Direction, double, double> CanonicalComponents => new()
     {
-        Assert.Equal(expected, direction.IsDiagonal());
-    }
+        { Direction.Down, 0, 1 },
+        { Direction.Left, -1, 0 },
+        { Direction.Right, 1, 0 },
+        { Direction.Up, 0, -1 },
+        { Direction.DownLeft, -RootHalf, RootHalf },
+        { Direction.DownRight, RootHalf, RootHalf },
+        { Direction.UpLeft, -RootHalf, -RootHalf },
+        { Direction.UpRight, RootHalf, -RootHalf },
+    };
 
-    /// <summary>Returns the Euclidean magnitude of <paramref name="v"/>.</summary>
-    private static double Magnitude(Vector2 v) => Math.Sqrt((v.X * v.X) + (v.Y * v.Y));
+    /// <summary>Continuous vectors and the canonical direction <see cref="DirectionExtensions.Nearest8"/> must snap them to.</summary>
+    public static TheoryData<Direction, Direction> Nearest8Cases => new()
+    {
+        { new Direction(0.9, 0.2), Direction.Right },
+        { new Direction(-0.9, 0.2), Direction.Left },
+        { new Direction(0.03, -0.99), Direction.Up },
+        { new Direction(-0.03, -0.99), Direction.Up },
+        { new Direction(0.9, -0.2), Direction.Right },
+        { new Direction(-0.9, -0.2), Direction.Left },
+        { new Direction(0.2, 0.9), Direction.Down },
+        { new Direction(0.2, -0.9), Direction.Up },
+        { new Direction(0, 0), Direction.Down }, // the zero vector snaps to Down
+    };
+
+    /// <summary>Directions and their expected RPG Maker MZ sprite-sheet rows (canonical and continuous).</summary>
+    public static TheoryData<Direction, int> RowIndexCases => new()
+    {
+        { Direction.Down, 0 },
+        { Direction.Left, 1 },
+        { Direction.Right, 2 },
+        { Direction.Up, 3 },
+        { Direction.DownLeft, 1 },
+        { Direction.DownRight, 2 },
+        { Direction.UpLeft, 1 },
+        { Direction.UpRight, 2 },
+        // A continuous vector maps to the row of its nearest canonical direction.
+        { new Direction(0.9, 0.2), 2 },        // -> Right
+        { new Direction(-0.9, 0.2), 1 },       // -> Left
+        { new Direction(0.03, -0.99), 3 },     // -> Up
+        { new Direction(0.2, 0.9), 0 },        // -> Down
+    };
 }

--- a/tests/RPGEngine.Tests/Core/GameConfigTests.cs
+++ b/tests/RPGEngine.Tests/Core/GameConfigTests.cs
@@ -48,10 +48,7 @@ public class GameConfigTests
 
     /// <summary>Verifies that reassigning any direction key takes effect immediately and unbinds the previous key.</summary>
     [Theory]
-    [InlineData("UpKey", Key.P, Direction.Up, Key.W)]
-    [InlineData("DownKey", Key.P, Direction.Down, Key.S)]
-    [InlineData("LeftKey", Key.P, Direction.Left, Key.A)]
-    [InlineData("RightKey", Key.P, Direction.Right, Key.D)]
+    [MemberData(nameof(ReassignKeyCases))]
     public void ReassigningAnyDirectionKey_TakesEffectImmediately(
         string propertyName,
         Key newKey,
@@ -86,14 +83,7 @@ public class GameConfigTests
     // ---------------------------------------------------------------------
     /// <summary>Verifies that binding an already-used key throws ArgumentException and leaves the configuration unchanged.</summary>
     [Theory]
-    [InlineData("UpKey", Key.S, Direction.Down)]    // S is bound to Down
-    [InlineData("UpKey", Key.A, Direction.Left)]    // A is bound to Left
-    [InlineData("DownKey", Key.W, Direction.Up)]    // W is bound to Up
-    [InlineData("DownKey", Key.D, Direction.Right)] // D is bound to Right
-    [InlineData("LeftKey", Key.W, Direction.Up)]    // W is bound to Up
-    [InlineData("LeftKey", Key.S, Direction.Down)]  // S is bound to Down
-    [InlineData("RightKey", Key.S, Direction.Down)] // S is bound to Down
-    [InlineData("RightKey", Key.A, Direction.Left)] // A is bound to Left
+    [MemberData(nameof(ConflictingKeyCases))]
     public void AssigningKeyAlreadyUsedByAnotherDirection_ThrowsAndLeavesConfigUnchanged(
         string propertyName,
         Key conflictingKey,
@@ -275,6 +265,28 @@ public class GameConfigTests
 
         Assert.Throws<ArgumentNullException>(() => config.GetMovementDirection(null!));
     }
+
+    /// <summary>The rebind cases: property, new key, the bound direction and the previous key it replaces.</summary>
+    public static TheoryData<string, Key, Direction, Key> ReassignKeyCases => new()
+    {
+        { "UpKey", Key.P, Direction.Up, Key.W },
+        { "DownKey", Key.P, Direction.Down, Key.S },
+        { "LeftKey", Key.P, Direction.Left, Key.A },
+        { "RightKey", Key.P, Direction.Right, Key.D },
+    };
+
+    /// <summary>The conflicting-binding cases: property, the key that is already bound and the direction it is bound to.</summary>
+    public static TheoryData<string, Key, Direction> ConflictingKeyCases => new()
+    {
+        { "UpKey", Key.S, Direction.Down },    // S is bound to Down
+        { "UpKey", Key.A, Direction.Left },    // A is bound to Left
+        { "DownKey", Key.W, Direction.Up },    // W is bound to Up
+        { "DownKey", Key.D, Direction.Right }, // D is bound to Right
+        { "LeftKey", Key.W, Direction.Up },    // W is bound to Up
+        { "LeftKey", Key.S, Direction.Down },  // S is bound to Down
+        { "RightKey", Key.S, Direction.Down }, // S is bound to Down
+        { "RightKey", Key.A, Direction.Left }, // A is bound to Left
+    };
 
     private static void Set(GameConfig config, string propertyName, Key key)
     {

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -450,26 +450,27 @@ public class DocsExamplesTests
         Assert.Equal(5, distance, precision: 10);
     }
 
-    /// <summary>Verifies the Direction extension examples (deltas, opposites, rows, diagonals).</summary>
+    /// <summary>Verifies the Direction example (a continuous vector next to the canonical 8 directions, opposites and rows).</summary>
     [Fact]
-    public void Direction_DeltasOppositesAndRows()
+    public void Direction_VectorsOppositesAndRows()
     {
-        Assert.Equal(new Vector2(0, -1), Direction.Up.Delta());
+        // A direction is a 2-D vector; the eight canonical unit directions are static members.
         Assert.Equal(Direction.Down, Direction.Up.Opposite());
         Assert.Equal(3, Direction.Up.RowIndex()); // RPG Maker MZ row 3
-        Assert.True(Direction.Left.IsHorizontal());
-        Assert.False(Direction.Left.IsVertical());
 
-        // Diagonal support: normalized delta, diagonal opposite, side-view row fallback and the
-        // IsDiagonal classification.
-        var upRight = Direction.UpRight.Delta();
-        Assert.Equal(Math.Sqrt(0.5), upRight.X, precision: 9);
-        Assert.Equal(-Math.Sqrt(0.5), upRight.Y, precision: 9);
-        Assert.Equal(Direction.DownLeft, Direction.UpRight.Opposite());
-        Assert.Equal(2, Direction.UpRight.RowIndex()); // falls back to the Right (side-view) row
-        Assert.True(Direction.UpRight.IsDiagonal());
-        Assert.False(Direction.UpRight.IsHorizontal());
-        Assert.False(Direction.UpRight.IsVertical());
+        // A continuous direction is adapted to the nearest canonical direction and its sheet row.
+        var diagonal = new Direction(0.7071067811865476, -0.7071067811865476); // == Direction.UpRight
+        Assert.Equal(Direction.UpRight, diagonal.Nearest8());
+        Assert.Equal(2, diagonal.RowIndex()); // falls back to the Right (side-view) row
+        Assert.Equal(Direction.DownLeft, diagonal.Opposite());
+
+        // The same continuous facing math applies to a non-canonical vector.
+        var continuous = new Direction(0.6, 0.8);
+        Assert.Equal(1, continuous.Length, precision: 9); // after normalization below
+        Assert.Equal(0.6, continuous.Normalized.X, precision: 9);
+        Assert.Equal(0.8, continuous.Normalized.Y, precision: 9);
+        Assert.Equal(Direction.DownRight, continuous.Nearest8()); // (0.6, 0.8) is closest to DownRight
+        Assert.Equal(2, continuous.RowIndex());                   // ... which renders on the Right (side-view) row
     }
 
     // ---------------------------------------------------------------------

--- a/tests/RPGEngine.Tests/PlayerTests.cs
+++ b/tests/RPGEngine.Tests/PlayerTests.cs
@@ -96,10 +96,7 @@ public class PlayerTests
     // ---------------------------------------------------------------------
     /// <summary>Verifies Move(direction, factor, dt) moves the underlying Character exactly BaseSpeed × factor × dt tiles along the right axis and updates its Direction.</summary>
     [Theory]
-    [InlineData(Direction.Down, 0.0, 100.0)]
-    [InlineData(Direction.Up, 0.0, -100.0)]
-    [InlineData(Direction.Left, -100.0, 0.0)]
-    [InlineData(Direction.Right, 100.0, 0.0)]
+    [MemberData(nameof(CardinalMoveCases))]
     public void Move_WithDirectionFactorAndDt_MovesUnderlyingCharacter(
         Direction direction,
         double expectedX,
@@ -231,7 +228,7 @@ public class PlayerTests
 
     /// <summary>
     /// Verifies a Move that changes direction while moving raises OnStartMoving with the new
-    /// direction (e.g. right &#8594; down-right, the diagonal produced when a second key is pressed),
+    /// direction (e.g. right → down-right, the diagonal produced when a second key is pressed),
     /// and no OnStopMoving: a direction change while moving is a new start, not a stop.
     /// </summary>
     [Fact]
@@ -326,4 +323,13 @@ public class PlayerTests
         Assert.Equal(new[] { Direction.Right, Direction.Down }, starts);
         Assert.Equal(new[] { Direction.Down }, stops);
     }
+
+    /// <summary>The cardinal directions and the exact X/Y displacement Move(d, 2, 0.5) must produce at BaseSpeed 100.</summary>
+    public static TheoryData<Direction, double, double> CardinalMoveCases => new()
+    {
+        { Direction.Down, 0.0, 100.0 },
+        { Direction.Up, 0.0, -100.0 },
+        { Direction.Left, -100.0, 0.0 },
+        { Direction.Right, 100.0, 0.0 },
+    };
 }

--- a/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
+++ b/tests/RPGEngine.Tests/Sprites/SpriteSheetTests.cs
@@ -46,12 +46,9 @@ public class SpriteSheetTests
         }
     }
 
-    /// <summary>Verifies the four direction rows map to rows 0..3 within a character block.</summary>
+    /// <summary>Verifies the four canonical direction rows map to rows 0..3 within a character block.</summary>
     [Theory]
-    [InlineData(Direction.Down, 0)]
-    [InlineData(Direction.Left, 1)]
-    [InlineData(Direction.Right, 2)]
-    [InlineData(Direction.Up, 3)]
+    [MemberData(nameof(DirectionRowCases))]
     public void GetSprite_MapsDirectionsToRows(Direction direction, int expectedRow)
     {
         var manager = new SpriteSheetManager();
@@ -61,6 +58,15 @@ public class SpriteSheetTests
         using var sprite = sheet.GetSprite(1, direction, frame: 0);
         AssertCell(sprite, expectedRow, col: 0);
     }
+
+    /// <summary>The four canonical directions and their sheet rows within a character block.</summary>
+    public static TheoryData<Direction, int> DirectionRowCases => new()
+    {
+        { Direction.Down, 0 },
+        { Direction.Left, 1 },
+        { Direction.Right, 2 },
+        { Direction.Up, 3 },
+    };
 
     // ---------------------------------------------------------------------
     // Acceptance (story 23): a 936×864 sheet derives 78×108 cells and


### PR DESCRIPTION
Closes #74 (Direction rework 1/2).

## Summary

Representation half of the Direction rework: the public `Direction` type changed from an 8-value enum to an immutable `readonly record struct Direction(double X, double Y)` (2-D vector, doubles, Y grows down). The whole solution is mechanically rewired to the new type so it compiles and every existing behaviour is preserved; no continuous-direction *behaviour* is activated yet (auto-walk still snaps to the eight canonical directions) — it is only made possible.

### Core type
- `Direction.cs`: record struct with the 8 canonical unit vectors as statics (`Direction.Down`, …, diagonals `(±√½, ±√½)`), `Direction.All` (historical order), vector operators (`-`, `*`, implicit `→ Vector2`), `Length`/`IsZero`/`Normalized` (throws on zero)/`ToString` (canonical name or `(X, Y)`).
- `DirectionExtensions.cs`: the 8-direction adaptation layer — `Nearest8` (dot product, zero → Down), `RowIndex` (snaps first; canonical rows 0/1/2/3 and diagonal side-view fallbacks 1/2), `Opposite` (`-d`); removed `Delta` and the axis classifiers.

### Mechanical rewiring (behaviour preserved)
- `GameConfig`: key input still yields canonical 8 directions (sum canonical unit vectors, `Nearest8`); all existing key-combination tests pass.
- `Character`/`Player`/`GameEngine`: movement is now `Direction × (BaseSpeed × factor × dt)`; `Character.Direction` defaults to `Direction.Down`; `Character.Draw` snaps `Direction.Nearest8()` at the draw boundary so sprite composition keeps exact 8-direction rules; `DirectionFromVector`/auto-walk still produce canonical directions.
- `SpriteSheet`: row selection goes through `DirectionExtensions.RowIndex` (continuous directions snap); sprites stay 8-direction.

### Tests & docs
- Rewrote `DirectionTests`; converted enum-valued `InlineData` theories to `MemberData` (Character/Player/SpriteSheet/GameConfig); updated `DocsExamplesTests`; updated API docs (`Direction.md`, `DirectionExtensions.md`, API index and wording in GameConfig/SpriteSheet/Vector2/Character/Player/GameEngine/README/Architecture).

### Verification
- `dotnet build RPGEngine.sln -c Release` → **0 warnings / 0 errors** (CS1591 documented).
- `dotnet test tests/RPGEngine.Tests -c Release` → **414 passed, 0 failed**.
- Focused filter (Direction|Character|Player|GameConfig|SpriteSheet|GameEngine|DocsExamples|SampleScene|Icon) → green.