### PR TITLE
Story 75: continuous movement — click-to-move and Player events use the direction vector

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -229,6 +229,14 @@ There are **two ways a character moves**, and both go through the same `Characte
    `Update(dt, map)` on every character each frame (supplying the current map), so a started
    character moves automatically with no per-frame host code.
 
+Every displacement is the direction **vector** scaled by the speed: `Direction * BaseSpeed *
+factor * dt` (`Move`) or `Direction * BaseSpeed * dt` (`Update`). `Direction` is a continuous
+unit vector, so a host can feed any unit vector (a future analogue-stick input, a normalized
+touch delta) into `Move`/`StartMoving` and the character moves along it — movement is no longer
+limited to 8 directions. Key input keeps producing the eight canonical unit directions (item 1);
+the sprite pipeline keeps consuming 8 directions by snapping the continuous facing at draw time
+(see `Character.Draw` → `Direction.Nearest8`).
+
 **Autonomous movement is collision-resolved exactly like the player's key-driven movement**: the
 engine passes the map to every character's `Update`, so a started character's displacement is
 resolved against the map's solid tiles and the map edge with the same footprint and the same
@@ -387,16 +395,26 @@ engine walks the player to the clicked tile.
 **Auto-walk** (inside `GameEngine.Update`): the engine keeps an internal queue of target tile
 waypoints (the A* path). When there is **no manual key movement** this frame and the path is
 non-empty, it moves the player toward the center of the next waypoint tile
-(`(tileX + 0.5, tileY + 0.5)`) at `BaseSpeed` (tile units). When the distance to the waypoint
-center is ≤ the frame's step, the player snaps to the center, the waypoint is popped, and the
-walk continues; when the queue empties, the engine calls `Player.Stop()`. The path is computed
-over walkable tiles (no corner cutting), so between tile centres the movement is clear; to cover
-the case where the player starts a walk from a **non-tile-centred** position (e.g. a key-movement
-boundary beside a wall), each auto-walk displacement is resolved with the **same per-axis
-slide-to-boundary clamping** as key movement (see `MovementCollisionResolver`). A displacement
-that would cross a solid corner is clamped, and because the waypoint then cannot be reached
-without crossing a solid tile, the walk is **cancelled** and the player is not displaced — the
-auto-walk never moves the player through or into a solid tile.
+(`(tileX + 0.5, tileY + 0.5)`) at `BaseSpeed` (tile units). Each leg's facing direction is the
+**exact continuous unit vector** toward that waypoint center — `new Direction(toTarget.X /
+distance, toTarget.Y / distance)` — used both as the player's facing and as the
+`Player.ReportAutoWalkStep` argument (the `OnStartMoving` payload). It is **never quantized** to
+the nearest of the 8 canonical directions (the old `DirectionFromVector` helper is gone from the
+auto-walk path); the displacement moves along the same leg vector (`toTarget * (step /
+distance)`) and the player still stops exactly centered on the clicked tile. Sprites adapt the
+continuous facing to the nearest canonical 8 direction only at draw time (`Character.Draw`
+snaps via `Direction.Nearest8`), so the rendered sprite row stays one of the classic 8
+directions. When the distance to the waypoint center is ≤ the frame's step, the player snaps to
+the center, the waypoint is popped, and the walk continues; when the queue empties, the engine
+calls `Player.Stop()` (which raises `Player.OnStopMoving` with the last, possibly continuous,
+leg direction). The path is computed over walkable tiles (no corner cutting), so between tile
+centres the movement is clear; to cover the case where the player starts a walk from a
+**non-tile-centred** position (e.g. a key-movement boundary beside a wall), each auto-walk
+displacement is resolved with the **same per-axis slide-to-boundary clamping** as key movement
+(see `MovementCollisionResolver`). A displacement that would cross a solid corner is clamped, and
+because the waypoint then cannot be reached without crossing a solid tile, the walk is
+**cancelled** and the player is not displaced — the auto-walk never moves the player through or
+into a solid tile.
 
 **Input precedence during auto-walk**:
 
@@ -420,7 +438,8 @@ the last auto-walk step is reached (the path completes), and when the player is 
 collision. The engine drives the events through the internal bridges `Player.ReportMovement`
 (key movement, start on idle → moving or on a direction change while moving, called before the
 displacement), `Player.ReportAutoWalkStep` (auto-walk, start every call, once per step boundary
-before that step's position update) and `Player.ReportBlockedMove` (a collision stop), so a fully
+before that step's position update — each call carries the exact continuous unit vector toward
+the next waypoint centre) and `Player.ReportBlockedMove` (a collision stop), so a fully
 blocked move from idle fires start then stop in the same frame while a held key against the same
 wall fires nothing more. `Player.Stop()` raises `OnStopMoving` only when the player was moving;
 the engine calls it when there is no input and no auto-walk target.

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,22 @@ foreach (var layer in engine.Map?.ObjectLayers ?? [])
 > clears its canvas to **black** first (like the main camera), so the unused margins are black
 > (see `docs/api/GameEngine.md`).
 >
+> **Movement & direction model:** `Direction` is a **continuous 2-D vector** (X, Y doubles, Y
+> grows down; see `docs/api/Direction.md`), and every character moves by `Direction *
+> (BaseSpeed * factor * dt)` along whatever unit vector it faces. Three surfaces consume the
+> type:
+> - **Key input** maps to the **8 canonical unit directions** (`W`+`D` → up-right, opposites
+>   cancel), so keyboard movement is unchanged.
+> - **Click-to-move** uses **continuous directions**: each auto-walk leg faces and reports the
+>   exact unit vector toward the next waypoint centre (never quantized), while displacement still
+>   ends centred on the clicked tile.
+> - **Sprites stay 8-direction**: at draw time a (possibly continuous) facing is adapted to the
+>   nearest canonical 8 direction for the sheet row (`Direction.Nearest8` / `RowIndex`).
+>
+> `Player.OnStartMoving` / `Player.OnStopMoving` carry the movement/facing direction **vector**
+> (X, Y) — canonical for key movement, exact-continuous for click-to-move legs and for any
+> host-driven continuous `Move`/`StartMoving`.
+>
 > **Click-to-move (optional demo):** after at least one `Render` (so the engine knows the canvas
 > size), the host can pass a mouse click to `engine.Click(surfaceX, surfaceY)` and the player
 > **auto-walks** along an A* tile path to the clicked tile, stopping centered on it. Clicking a

--- a/docs/api/Character.md
+++ b/docs/api/Character.md
@@ -151,9 +151,22 @@ direction. When `speedFactor` is zero the character only turns to face the direc
 moving. `dt` defaults to 1, so `Move(d, factor)` moves `BaseSpeed * factor` tiles (per-second
 semantics).
 
+`direction` is a **continuous unit vector** (`Direction.md`): the displacement is exactly
+`direction * (BaseSpeed * factor * dt)`, so any unit vector moves the character in that
+direction at the same speed, and a non-unit vector scales the displacement by its length. The
+engine always produces unit vectors (`Direction.Normalized`); key input yields the eight
+canonical unit directions, and click-to-move yields the exact unit vector toward each waypoint.
+
 ```csharp
 var character = new Character { BaseSpeed = 2 };
-character.Move(Direction.Right, speedFactor: 1, dt: 0.5); // 1 tile right
+character.Move(Direction.Right, speedFactor: 1, dt: 0.5); // 1 tile right (a canonical vector)
+
+// A continuous direction moves along the same vector * speed formula: (0.6, 0.8) * (2 * 1 * 1)
+// = (1.2, 1.6) tiles. 0.6^2 + 0.8^2 = 1, so the vector is unit length.
+character.Move(new Direction(0.6, 0.8), speedFactor: 1, dt: 1); // feet end at (1.2, 1.6)
+
+// A speed-factor-zero Move only turns to face the continuous direction.
+character.Move(new Direction(0.8, 0.6), speedFactor: 0); // faces (0.8, 0.6), never moves
 ```
 
 ### `void Move(double speedFactor = 1, double dt = 1)`
@@ -177,9 +190,18 @@ against the map's solid tiles and the map edge when the engine supplies a map, e
 player's key-driven movement; a fully blocked character simply stays put. Do not combine
 `StartMoving` on the player's character with the engine's key-driven player movement.
 
+`direction` is a **continuous unit vector** (see `Direction.md`): while `IsMoving`, every
+`Update(dt)` displaces the character by `Direction * (BaseSpeed * dt)` along that vector —
+continuous directions move exactly like the canonical ones.
+
 ```csharp
 var npc = new Character { BaseSpeed = 2, Position = new Position(3, 4) };
 npc.StartMoving(Direction.Right); // faces right and begins moving on the next Update
+
+// A continuous direction is equally valid: the NPC faces (0.6, 0.8) and each Update(dt) moves
+// it by (0.6, 0.8) * (BaseSpeed * dt) — a host can feed any unit vector (e.g. a future
+// analogue-stick input) straight into StartMoving.
+npc.StartMoving(new Direction(0.6, 0.8));
 ```
 
 ### `void StopMoving()`

--- a/docs/api/Direction.md
+++ b/docs/api/Direction.md
@@ -88,6 +88,28 @@ Returns the canonical name (e.g. `"Up"`) when the direction equals one of the ei
 directions in `All`, for readability and logging; otherwise returns the component pair
 `"(X, Y)"`.
 
+## Continuous movement
+
+A character moves by `Direction * (BaseSpeed * factor * dt)` (or `Direction * (BaseSpeed * dt)`
+inside `Update`), where `Direction` is a **unit** vector. Because `Direction` is a vector, any
+unit vector produces continuous movement — the engine no longer limits facing to 8 directions.
+A non-unit vector scales the displacement by its length, so always move with unit vectors: use
+`Normalized` to turn a raw delta (e.g. a touch/analogue-stick vector or a mouse drag) into a
+unit direction first. Sprites stay 8-direction by adapting the continuous facing with
+`DirectionExtensions.Nearest8` at draw time.
+
+```csharp
+// A raw delta (not necessarily unit length) is normalized before movement.
+var rawDelta = new Direction(30, 40);     // e.g. a stick vector or mouse drag
+var direction = rawDelta.Normalized;      // (0.6, 0.8) — unit length
+var character = new Character { BaseSpeed = 2 };
+character.Move(direction, speedFactor: 1, dt: 1); // moves (1.2, 1.6) tiles: direction * 2
+
+// Sprites adapt the (possibly continuous) facing to the nearest canonical 8-direction row.
+var nearest = direction.Nearest8();       // DownRight
+Console.WriteLine(nearest.RowIndex());    // 2 — the Right (side-view) row
+```
+
 ## Example
 
 ```csharp

--- a/docs/api/DirectionExtensions.md
+++ b/docs/api/DirectionExtensions.md
@@ -52,3 +52,24 @@ Console.WriteLine(Direction.Up.Opposite());        // Down
 Console.WriteLine(Direction.UpRight.Opposite());   // DownLeft
 Console.WriteLine(new Direction(0.6, 0.8).Opposite()); // (-0.6, -0.8)
 ```
+
+## Continuous movement with the 8-direction layer
+
+`Direction` is a continuous 2-D vector (see `Direction.md`). Movement uses the vector directly —
+`Direction * (BaseSpeed * factor * dt)` — while these helpers keep the two 8-direction surfaces
+working: sprites adapt a continuous facing with `Nearest8` / `RowIndex`, and `Normalized`
+produces the unit vector to move with from a raw delta.
+
+```csharp
+// Normalize a raw delta to a unit direction before moving with it.
+var rawDelta = new Direction(3, 4);   // length 5 — not a unit vector
+var unit = rawDelta.Normalized;       // (0.6, 0.8)
+var character = new Character { BaseSpeed = 2 };
+character.Move(unit, speedFactor: 1, dt: 1); // moves (1.2, 1.6) tiles
+
+// At draw time the continuous facing snaps to the nearest canonical 8 direction / sheet row,
+// so sprites keep the classic 8-direction look even for continuous facing.
+var facing = new Direction(0.9, 0.7); // continuous, closest to DownRight
+Console.WriteLine(facing.Nearest8());  // DownRight
+Console.WriteLine(facing.RowIndex());  // 2 — the DownRight (side-view) row
+```

--- a/docs/api/GameEngine.md
+++ b/docs/api/GameEngine.md
@@ -38,7 +38,10 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   continuous 2-D vector, see `Direction.md`) which is then snapped to the nearest of the eight
   canonical directions: opposite keys cancel (`W`+`S` or `A`+`D`), and a diagonal pair combines
   into a canonical diagonal (`W`+`D` → up-right) at the same speed as cardinal movement. Key
-  input always yields one of the eight canonical directions; sprites render 8 directions
+  input always yields one of the eight canonical unit directions; each character then moves by
+  `Direction * (BaseSpeed * dt)`. Sprites render 8 directions at the draw boundary: a continuous
+  facing (key movement is always canonical, but click-to-move and host-driven continuous moves
+  are not) is adapted to the nearest canonical 8 direction for the sheet row
   (see [Architecture](../Architecture.md)).
 - **Click-to-move** (auto-walk): `Click(surfaceX, surfaceY)` converts a host-surface click on the
   main canvas (using the canvas size recorded by the most recent `Render`) to a world position,
@@ -47,7 +50,14 @@ registry and the pressed-keys state, and exposes the game-loop entry points `Upd
   waypoint at `BaseSpeed`, popping waypoints as they are reached and calling `Player.Stop()` when
   the path completes. Each auto-walk step begins with `Player.OnStartMoving` **before** that
   step's position update (once per waypoint), and the completed path stops the player with
-  `Player.OnStopMoving` exactly once. Clicking a **solid tile** or an **unreachable target** cancels the walk
+  `Player.OnStopMoving` exactly once. Auto-walk uses **continuous directions**: every leg faces
+  the player toward and reports the exact (continuous) **unit vector** to the next waypoint
+  center — never quantized to the nearest of the 8 directions — and the displacement moves
+  along that same leg vector (the player still stops exactly centered on the clicked tile). The
+  sprite still adapts the continuous facing to the nearest canonical 8 direction at draw time,
+  and both `Player.OnStartMoving`/`Player.OnStopMoving` carry that direction vector. Key movement
+  is untouched: it still maps to the eight canonical unit directions (see the movement-input
+  bullet above). Clicking a **solid tile** or an **unreachable target** cancels the walk
   without moving; a click that yields a path **replaces** the current walk even mid-walk. Each
   auto-walk displacement is resolved against the map's solid tiles like key movement, so the
   auto-walk never moves the player through (or into) a solid tile: when the direct displacement

--- a/docs/api/Player.md
+++ b/docs/api/Player.md
@@ -33,8 +33,12 @@ The player exposes a **movement-state machine** through two events:
   - click-to-move: the last auto-walk step is reached (the path completes);
   - the player is blocked by a collision (a fully blocked move).
 
-Both events carry only the facing `Direction` — the direction **vector** — which is all a host needs to mirror the player
-on other clients via `Character.StartMoving` / `Character.StopMoving`.
+Both events carry only the movement/facing direction **vector** (`Direction`, X and Y) —
+which is all a host needs to mirror the player on other clients via
+`Character.StartMoving` / `Character.StopMoving`. The payload is never quantized to an
+8-direction bucket: key input produces one of the eight canonical unit vectors, a host-driven
+continuous `Move` produces that exact continuous vector, and click-to-move produces the exact
+unit vector toward each waypoint.
 
 ## Fields
 
@@ -121,9 +125,14 @@ Occurs when the player **starts moving in a new direction**, **before the positi
 - **Click-to-move** (auto-walk): each time a new auto-walk step begins — the first step, and
   every time the next waypoint is reached while another remains. `OnStartMoving` therefore fires
   once **per auto-walk step** (once per waypoint in the path), and the event is raised before
-  that step's displacement is applied.
+  that step's displacement is applied. Each step's payload is the exact **continuous** unit
+  vector from the player's current position to the next waypoint centre (see
+  `GameEngine.md`) — never quantized to the nearest of the 8 directions. Sprites still adapt
+  that continuous facing to the nearest canonical 8 direction at draw time.
 
-The event carries the direction **vector** (`Direction`) the player is moving in.
+The event carries the movement/facing direction **vector** (`Direction`, X and Y) the player is
+moving in. Key movement reports one of the eight canonical unit vectors; a host that drives a
+continuous move (e.g. a future analogue-stick input) reports that exact continuous vector.
 
 ```csharp
 var player = new Player();
@@ -132,9 +141,12 @@ player.OnStartMoving += (_, direction) =>
     Console.WriteLine($"started moving {direction}");
 };
 
-player.Move(Direction.Right, speedFactor: 1, dt: 1); // prints "started moving Right"
+player.Move(Direction.Right, speedFactor: 1, dt: 1); // prints "started moving Right" (canonical key vector)
 player.Move(Direction.UpRight, speedFactor: 1, dt: 1); // direction change: prints "started moving UpRight"
 player.Move(Direction.UpRight, speedFactor: 1, dt: 1); // same direction: nothing
+
+// A host-driven continuous move reports the exact vector (no 8-direction quantization):
+player.Move(new Direction(0.6, 0.8), speedFactor: 1, dt: 1); // prints "started moving (0.6, 0.8)"
 ```
 
 ### `event EventHandler<Direction>? OnStopMoving`
@@ -150,8 +162,9 @@ Occurs when the player **stops moving**:
   `OnStartMoving` then `OnStopMoving` in the same frame. The reported direction is the
   direction the player tried to move in (the player turns to face the wall).
 
-The event carries the direction **vector** (`Direction`) the player was last moving in. Stopping does not change the
-facing direction.
+The event carries the direction **vector** (`Direction`, X and Y) the player was last moving
+in — the exact last vector, which may be continuous (a host-driven move or an auto-walk leg).
+Stopping does not change the facing direction.
 
 ```csharp
 var player = new Player();
@@ -193,9 +206,17 @@ direction changes while already moving (e.g. right → up-right). A move while a
 the *same* direction raises nothing (no per-frame events). With `speedFactor == 0` the player
 only turns: no event is raised (a turn is neither a start nor a stop).
 
+`direction` is a continuous unit vector: the displacement is `direction * (BaseSpeed *
+speedFactor * dt)`. Key input supplies one of the eight canonical unit vectors; a host may also
+drive any continuous unit vector (the events and `Direction` carry it exactly, and the sprite
+still renders with the nearest canonical 8-direction row).
+
 ```csharp
 player.Move(Direction.Right, dt: 1.0 / 60);
 player.Move(Direction.Up, speedFactor: 0); // turn only: no event
+
+// A host-driven continuous move: displacement (0.6, 0.8) * BaseSpeed * factor * dt.
+player.Move(new Direction(0.6, 0.8), speedFactor: 1, dt: 1);
 ```
 
 ### `void Move(double speedFactor = 1, double dt = 1)`

--- a/src/RPGEngine/Direction.cs
+++ b/src/RPGEngine/Direction.cs
@@ -1,4 +1,5 @@
 namespace RPGEngine;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// A direction in the game world, expressed as a 2-D screen-space vector with
@@ -117,6 +118,7 @@ public readonly record struct Direction(double X, double Y)
     /// <c>BaseSpeed * dt</c> displacement regardless of the input vector's length.
     /// </summary>
     /// <exception cref="InvalidOperationException">The direction is the zero vector <c>(0, 0)</c>, which has no direction to normalize.</exception>
+    [JsonIgnore]
     public Direction Normalized
     {
         get

--- a/src/RPGEngine/GameEngine.cs
+++ b/src/RPGEngine/GameEngine.cs
@@ -1049,7 +1049,12 @@ public sealed class GameEngine : IDisposable
     /// auto-walk step (a waypoint leg) begins with <see cref="Player.OnStartMoving"/> via
     /// <see cref="Player.ReportAutoWalkStep(Direction)"/> <em>before</em> that step's position
     /// update: on the first frame of the walk and every time a waypoint is reached while another
-    /// remains. The last step's completion stops the player (<see cref="Player.OnStopMoving"/>).
+    /// remains. Each step's direction — the facing and the <see cref="Player.OnStartMoving"/>
+    /// payload — is the exact (continuous) unit vector from the player's current position to
+    /// the next waypoint center, never quantized to the eight canonical directions; sprites still
+    /// adapt it to the nearest canonical 8 direction at draw time. The last step's completion
+    /// stops the player (<see cref="Player.OnStopMoving"/>), carrying that step's (continuous)
+    /// leg direction as the last facing vector.
     /// When a map is set the displacement is resolved with the same per-axis slide-to-boundary
     /// clamping as key movement (see <see cref="MovementCollisionResolver"/>), so the auto-walk
     /// never moves the player through a solid tile: if the direct displacement toward the
@@ -1094,9 +1099,15 @@ public sealed class GameEngine : IDisposable
             }
 
             // A waypoint was reached and another remains: the next auto-walk step begins now,
-            // before any of its displacements (which happen on the following frames).
+            // before any of its displacements (which happen on the following frames). The next
+            // leg's direction is the exact unit vector from the (just-snapped) current position
+            // to the following waypoint center — continuous, never quantized to the 8
+            // directions. Sprites still adapt it to the nearest canonical 8 direction at draw
+            // time (Character.Draw snaps via Direction.Nearest8).
             var (nextTargetX, nextTargetY) = _autoWalkPath.Peek();
-            var nextDirection = DirectionFromVector(new Position(nextTargetX + 0.5, nextTargetY + 0.5) - Player.Position);
+            var toNextTarget = new Position(nextTargetX + 0.5, nextTargetY + 0.5) - Player.Position;
+            var nextDistance = Math.Sqrt((toNextTarget.X * toNextTarget.X) + (toNextTarget.Y * toNextTarget.Y));
+            var nextDirection = new Direction(toNextTarget.X / nextDistance, toNextTarget.Y / nextDistance);
             Player.ReportAutoWalkStep(nextDirection);
             _autoWalkStepStarted = true;
             return true;
@@ -1110,7 +1121,13 @@ public sealed class GameEngine : IDisposable
         // non-tile-centred) position, so the walk is cancelled and the player is not displaced at
         // all, rather than sliding through (or getting stuck at) a wall.
         var before = Player.Position;
-        var direction = DirectionFromVector(toTarget);
+        // The leg's facing is the exact unit vector toward the waypoint center (toTarget is the
+        // leg vector, so dividing by its length normalizes it): continuous, never quantized to
+        // the 8 directions. The displacement below already moves along this same leg vector
+        // (toTarget * (step / distance)); the displacement is unchanged, only the facing/event
+        // payload stops being quantized. Sprites still adapt it to the nearest canonical 8
+        // direction at draw time (Character.Draw snaps via Direction.Nearest8).
+        var legDirection = new Direction(toTarget.X / distance, toTarget.Y / distance);
         var move = toTarget * (step / distance);
         var destination = before + move;
 
@@ -1119,7 +1136,7 @@ public sealed class GameEngine : IDisposable
         // set when the step begins and stays set until the next waypoint is reached).
         if (!_autoWalkStepStarted)
         {
-            Player.ReportAutoWalkStep(direction);
+            Player.ReportAutoWalkStep(legDirection);
             _autoWalkStepStarted = true;
         }
 
@@ -1164,26 +1181,6 @@ public sealed class GameEngine : IDisposable
     {
         _autoWalkStepStarted = false;
         _autoWalkPath.Clear();
-    }
-
-    /// <summary>
-    /// Returns the canonical <see cref="Direction"/> closest to <paramref name="vector"/>: the
-    /// vector is normalized and snapped to the nearest of the eight canonical unit directions in
-    /// <see cref="Direction.All"/> by dot product (<see cref="DirectionExtensions.Nearest8"/>),
-    /// mirroring <see cref="GameConfig.GetMovementDirection(System.Collections.Generic.IEnumerable{Key})"/>'s
-    /// quantization. Used by the auto-walk to face the waypoint it is moving toward; the facing
-    /// (and the event payloads) stay one of the eight canonical directions in this story.
-    /// </summary>
-    /// <param name="vector">The movement vector (never the zero vector when called).</param>
-    /// <returns>The closest of the eight canonical <see cref="Direction"/> values.</returns>
-    private static Direction DirectionFromVector(Vector2 vector)
-    {
-        if (vector.X == 0 && vector.Y == 0)
-        {
-            return Direction.Down;
-        }
-
-        return new Direction(vector.X, vector.Y).Nearest8();
     }
 
     /// <summary>

--- a/tests/RPGEngine.Tests/CharacterTests.cs
+++ b/tests/RPGEngine.Tests/CharacterTests.cs
@@ -777,6 +777,161 @@ public class CharacterTests
     }
 
     // ---------------------------------------------------------------------
+    // Story 75 (direction rework 2/2): continuous movement is activated and
+    // locked in. Character.Move / StartMoving / Update displace along an
+    // arbitrary (continuous) unit vector by Direction * (BaseSpeed * factor *
+    // dt), a direction-less Move reuses the previous (continuous) direction,
+    // a speed-factor-zero Move only turns, and sprites still adapt a
+    // continuous facing to the nearest canonical 8-direction row at draw time.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies a continuous (non-canonical) Move from the origin at BaseSpeed 2 displaces
+    /// exactly <c>Direction * (BaseSpeed * factor * dt) = (0.6, 0.8) * (2 * 1 * 1) = (1.2, 1.6)</c>
+    /// tiles and keeps the continuous facing vector.
+    /// </summary>
+    [Fact]
+    public void Move_ContinuousDirection_MovesExactlyDirectionTimesSpeed()
+    {
+        var character = new Character { BaseSpeed = 2, Position = new Position(0, 0) };
+        var continuous = new Direction(0.6, 0.8);
+
+        character.Move(continuous, speedFactor: 1, dt: 1);
+
+        Assert.Equal(1.2, character.Position.X, precision: 9);
+        Assert.Equal(1.6, character.Position.Y, precision: 9);
+        Assert.Equal(continuous, character.Direction);
+    }
+
+    /// <summary>
+    /// Verifies a direction-less Move reuses the previous (continuous) Direction: after facing
+    /// and moving along (0.6, 0.8), a <c>Move(dt: 1)</c> continues along the same continuous
+    /// vector by <c>Direction * BaseSpeed * dt</c>.
+    /// </summary>
+    [Fact]
+    public void Move_WithoutDirection_ReusesPreviousContinuousDirection()
+    {
+        var character = new Character { BaseSpeed = 2, Position = new Position(0, 0) };
+        var continuous = new Direction(0.6, 0.8);
+        character.Move(continuous, speedFactor: 1, dt: 1); // (1.2, 1.6)
+
+        character.Move(dt: 1); // reuses (0.6, 0.8): another (1.2, 1.6)
+
+        Assert.Equal(2.4, character.Position.X, precision: 9);
+        Assert.Equal(3.2, character.Position.Y, precision: 9);
+        Assert.Equal(continuous, character.Direction);
+    }
+
+    /// <summary>
+    /// Verifies StartMoving with a continuous direction + Update(dt, map: null) displaces along
+    /// the continuous vector by <c>Direction * BaseSpeed * dt</c> (raw, no map).
+    /// </summary>
+    [Fact]
+    public void StartMoving_ContinuousDirection_UpdateNoMap_DisplacesAlongVector()
+    {
+        var character = new Character { BaseSpeed = 2, Position = new Position(0, 0) };
+        var continuous = new Direction(0.6, 0.8);
+
+        character.StartMoving(continuous);
+        character.Update(dt: 1); // no map: raw displacement Direction * BaseSpeed * dt
+
+        Assert.Equal(1.2, character.Position.X, precision: 9);
+        Assert.Equal(1.6, character.Position.Y, precision: 9);
+        Assert.Equal(continuous, character.Direction);
+        Assert.True(character.IsMoving);
+    }
+
+    /// <summary>
+    /// Verifies a speed-factor-zero Move with a continuous direction turns the character to that
+    /// continuous facing without moving.
+    /// </summary>
+    [Fact]
+    public void Move_ContinuousDirection_ZeroSpeedFactor_TurnsWithoutMoving()
+    {
+        var character = new Character { BaseSpeed = 2, Position = new Position(10, 20) };
+        var continuous = new Direction(0.6, 0.8);
+
+        character.Move(continuous, speedFactor: 0);
+
+        Assert.Equal(continuous, character.Direction);
+        Assert.Equal(new Position(10, 20), character.Position);
+    }
+
+    /// <summary>
+    /// Verifies the walk cycle advances while the character moves along a continuous direction
+    /// (the animation logic is independent of the direction vector's quantization).
+    /// </summary>
+    [Fact]
+    public void Update_ContinuousDirection_MovingAdvancesWalkCycle()
+    {
+        var character = new Character { BaseSpeed = 2, Position = new Position(0, 0) };
+        character.StartMoving(new Direction(0.6, 0.8));
+
+        character.Update(dt: 0.25); // (0.6, 0.8) * (2 * 0.25) = (0.3, 0.4) tiles, one frame due
+
+        Assert.Equal(0, character.AnimationFrame);
+        Assert.Equal(0.3, character.Position.X, precision: 9);
+        Assert.Equal(0.4, character.Position.Y, precision: 9);
+    }
+
+    // ---------------------------------------------------------------------
+    // Story 75: sprite 8-direction adaptation of a continuous facing. The
+    // character's facing may be continuous; at draw time Character.Draw snaps
+    // it via Direction.Nearest8, so the sprite renders with the row of the
+    // nearest canonical 8 direction. Mirror the Render/AssertPixel helpers.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies a continuous facing whose nearest canonical direction is DownRight (e.g.
+    /// <c>(0.9, 0.7)</c>) renders the same sheet row as the canonical <see cref="Direction.DownRight"/>
+    /// facing.
+    /// </summary>
+    [Fact]
+    public void Draw_ContinuousFacingNearestDownRight_RendersSameRowAsCanonicalDownRight()
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false));
+
+        // Canonical DownRight facing: renders the DownRight (side-view Right) row.
+        var canonical = new Character();
+        canonical.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        canonical.Move(Direction.DownRight, speedFactor: 0);
+        using var canonicalBitmap = Render(canonical, manager);
+        var expected = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.DownRight, StandingFrame);
+        AssertPixel(canonicalBitmap, expected);
+
+        // Continuous (0.9, 0.7) is closest to DownRight (it is not one of the 8 canonical
+        // directions), so it must render the exact same row.
+        var continuous = new Character();
+        continuous.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        continuous.Move(new Direction(0.9, 0.7), speedFactor: 0);
+        using var continuousBitmap = Render(continuous, manager);
+        AssertPixel(continuousBitmap, expected);
+
+        Assert.NotEqual(Direction.DownRight, new Direction(0.9, 0.7));
+    }
+
+    /// <summary>
+    /// Verifies a continuous facing whose nearest canonical direction is Up (e.g. <c>(0.2, -0.98)</c>)
+    /// renders the Up row (row 3) of the sheet.
+    /// </summary>
+    [Fact]
+    public void Draw_ContinuousFacingNearestUp_RendersUpRow()
+    {
+        var manager = CreateManager(
+            (Name: "hero", PartType: null, Seed: 0, Transparent: false));
+
+        var character = new Character();
+        character.SpriteSheets.Add(new SpriteSheetRef("hero", CharacterIndex: 1));
+        character.Move(new Direction(0.2, -0.98), speedFactor: 0);
+
+        using var bitmap = Render(character, manager);
+
+        var expected = CharacterTestHelper.SpriteColor(seed: 0, characterIndex: 1, Direction.Up, StandingFrame);
+        AssertPixel(bitmap, expected);
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 

--- a/tests/RPGEngine.Tests/DocsExamplesTests.cs
+++ b/tests/RPGEngine.Tests/DocsExamplesTests.cs
@@ -935,4 +935,58 @@ public class DocsExamplesTests
         var expectedSprite = CharacterTestHelper.SpriteColor(seed: 1, characterIndex: 1, Direction.Down, frame: 1);
         Assert.Equal(expectedSprite, bitmap.GetPixel(120, 120));
     }
+
+    // ---------------------------------------------------------------------
+    // Story 75: continuous movement is activated. docs/api/Character.md,
+    // docs/api/Player.md, docs/api/GameEngine.md, docs/api/Direction.md and
+    // docs/api/DirectionExtensions.md show that a character moves by
+    // Direction * (BaseSpeed * factor * dt) along any continuous unit vector,
+    // that Player.OnStartMoving / OnStopMoving carry the direction *vector*,
+    // and that click-to-move legs report the exact (continuous) leg vector
+    // while sprites adapt a continuous facing to the nearest canonical 8
+    // direction at draw time.
+    // ---------------------------------------------------------------------
+    /// <summary>
+    /// Verifies the continuous-movement examples: a character moves along an arbitrary unit
+    /// vector by <c>Direction * (BaseSpeed * factor * dt)</c>, a direction-less Move reuses the
+    /// previous continuous Direction, and the player's movement events carry the exact direction
+    /// vector (X, Y) for a continuous (non-canonical) move.
+    /// </summary>
+    [Fact]
+    public void ContinuousMovement_AndEventsCarryDirectionVectors()
+    {
+        // A character moves along any continuous unit vector: displacement = Direction * speed.
+        var character = new Character { BaseSpeed = 2, Position = new Position(0, 0) };
+        var diagonal = new Direction(0.6, 0.8); // unit length (0.6^2 + 0.8^2 = 1)
+        character.Move(diagonal, speedFactor: 1, dt: 1);
+        Assert.Equal(1.2, character.Position.X, precision: 9); // 2 * 0.6
+        Assert.Equal(1.6, character.Position.Y, precision: 9); // 2 * 0.8
+
+        // StartMoving/Update apply the same vector semantics continuously (no map: raw move).
+        character.StartMoving(new Direction(-0.8, 0.6));
+        character.Update(dt: 0.5); // BaseSpeed * dt = 1 tile along (-0.8, 0.6)
+        Assert.Equal(1.2 - 0.8, character.Position.X, precision: 9);
+        Assert.Equal(1.6 + 0.6, character.Position.Y, precision: 9);
+
+        // The player's events carry the exact direction vector, even for continuous moves.
+        var player = new Player { Position = new Position(10, 20) };
+        player.Character.BaseSpeed = 2;
+        Direction? started = null;
+        Direction? stopped = null;
+        player.OnStartMoving += (_, direction) => started = direction;
+        player.OnStopMoving += (_, direction) => stopped = direction;
+
+        player.Move(new Direction(0.6, 0.8), speedFactor: 1, dt: 1);
+        Assert.Equal(0.6, started!.Value.X, precision: 9);
+        Assert.Equal(0.8, started.Value.Y, precision: 9);
+
+        player.Stop();
+        Assert.Equal(0.6, stopped!.Value.X, precision: 9); // the last (continuous) vector
+        Assert.Equal(0.8, stopped.Value.Y, precision: 9);
+
+        // Sprites stay 8-direction: a continuous facing renders with the nearest canonical row.
+        Assert.Equal(Direction.DownRight, new Direction(0.9, 0.7).Nearest8());
+        Assert.Equal(2, new Direction(0.9, 0.7).RowIndex()); // the Right (side-view) row
+    }
+
 }

--- a/tests/RPGEngine.Tests/GameEngineClickToMoveTests.cs
+++ b/tests/RPGEngine.Tests/GameEngineClickToMoveTests.cs
@@ -73,8 +73,11 @@ public partial class GameEngineTests
 
     /// <summary>
     /// Verifies OnStartMoving fires once per auto-walk step (per waypoint in the A* path) and
-    /// OnStopMoving fires exactly once when the path completes, with the correct facing
-    /// direction.
+    /// OnStopMoving fires exactly once when the path completes. The player starts
+    /// <strong>off-tile-centre</strong> so the first leg is non-canonical: the first
+    /// OnStartMoving payload (and the facing it sets) is the exact continuous unit vector from
+    /// the start position to the first waypoint centre — not quantized to an 8-direction
+    /// bucket — while the per-step count and the single OnStopMoving invariants still hold.
     /// </summary>
     [Fact]
     public void Click_OnStartMoving_FiresPerStep_AndOnStopMovingOnCompletion()
@@ -82,7 +85,10 @@ public partial class GameEngineTests
         using var fixture = CreateFilledMapFixture(10, 10);
         var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
         ConfigurePlayerSprite(engine, seed: 1);
-        engine.Player.Position = new Position(0.5, 1.5);
+        // Off-tile-centre (but inside the legal collision bounds, x >= 0.25), so the first leg
+        // is non-canonical.
+        var start = new Position(0.3, 1.8);
+        engine.Player.Position = start;
 
         var starts = new List<Direction>();
         var stops = new List<Direction>();
@@ -106,10 +112,20 @@ public partial class GameEngineTests
         Assert.Equal(target, engine.Player.Position);
 
         // OnStartMoving fires once per auto-walk step (count == path length) and exactly one
-        // OnStopMoving fires at completion, facing the last movement direction (down-right).
+        // OnStopMoving fires at completion.
         Assert.Equal(path.Count, starts.Count);
         Assert.Single(stops);
-        Assert.Equal(Direction.DownRight, stops[^1]);
+
+        // The first step's direction is the exact continuous unit vector from the (off-tile-centre)
+        // start position to the first waypoint centre: it is the same value the engine computed
+        // for the first leg (never an 8-direction bucket).
+        var firstWaypointCentre = new Position(path[0].X + 0.5, path[0].Y + 0.5);
+        var toFirst = firstWaypointCentre - start;
+        var firstDistance = Math.Sqrt((toFirst.X * toFirst.X) + (toFirst.Y * toFirst.Y));
+        var expectedFirst = new Direction(toFirst.X / firstDistance, toFirst.Y / firstDistance);
+        Assert.Equal(expectedFirst.X, starts[0].X, precision: 9);
+        Assert.Equal(expectedFirst.Y, starts[0].Y, precision: 9);
+        Assert.DoesNotContain(starts[0], Direction.All);
     }
 
     /// <summary>
@@ -308,4 +324,117 @@ public partial class GameEngineTests
         // top edge at y = 0).
         Assert.Equal(new Position(0.25, 0.5), engine.Player.Position);
     }
+
+    /// <summary>
+    /// Verifies click-to-move from a non-tile-centred position faces and reports the continuous
+    /// leg direction: <c>engine.Player.Direction</c> and the first <c>OnStartMoving</c> payload
+    /// carry the same continuous vector, and that vector is not one of the 8 canonical
+    /// <c>Direction.All</c> values for a deliberately skewed start.
+    /// </summary>
+    [Fact]
+    public void Click_OnNonCentredStart_FirstStepFacesAndReportsContinuousDirection()
+    {
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        // Deliberately skewed (off-tile-centre, but inside the legal collision bounds) start so
+        // the first leg is strongly non-canonical.
+        var start = new Position(0.3, 1.8);
+        engine.Player.Position = start;
+
+        var starts = new List<Direction>();
+        engine.Player.OnStartMoving += (_, direction) => starts.Add(direction);
+
+        const int canvas = 480;
+        ClickOnTile(engine, 3, 4, canvas, canvas);
+        var path = engine.AutoWalkPath;
+        Assert.True(path.Count >= 1, "The test needs a path.");
+
+        // Advance just far enough for the first auto-walk step to begin (the first frame of the
+        // walk always starts the first leg when the leg is longer than one frame step).
+        engine.Update(FrameDt);
+
+        var first = Assert.Single(starts);
+        Assert.DoesNotContain(first, Direction.All);
+
+        // The facing set by the first step and the event payload are the same continuous vector.
+        Assert.Equal(engine.Player.Direction.X, first.X, precision: 9);
+        Assert.Equal(engine.Player.Direction.Y, first.Y, precision: 9);
+
+        // And that vector is the exact normalized vector toward the first waypoint centre.
+        var firstWaypointCentre = new Position(path[0].X + 0.5, path[0].Y + 0.5);
+        var toFirst = firstWaypointCentre - start;
+        var distance = Math.Sqrt((toFirst.X * toFirst.X) + (toFirst.Y * toFirst.Y));
+        Assert.Equal(toFirst.X / distance, first.X, precision: 9);
+        Assert.Equal(toFirst.Y / distance, first.Y, precision: 9);
+    }
+
+    /// <summary>
+    /// Non-regression: click-to-move from a tile-centred start still faces and reports the
+    /// canonical 8-direction vectors. An axis-aligned path's legs are the exact canonical
+    /// cardinal directions (bit-exact), and a diagonal path's legs are the canonical diagonal
+    /// unit vector within floating-point precision (the continuous normalization of a
+    /// centred-to-centred diagonal leg) — the quantization boundary at the sprite / key-input
+    /// level is untouched by the continuous auto-walk activation.
+    /// </summary>
+    [Fact]
+    public void Click_OnCentredStart_StillYieldsCanonical8Directions()
+    {
+        // Axis-aligned centred path: straight down column 0 from tile (0,1) to tile (0,6).
+        using var fixture = CreateFilledMapFixture(10, 10);
+        var engine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(engine, seed: 1);
+        engine.Player.Position = new Position(0.5, 1.5); // tile-centred start
+
+        var starts = new List<Direction>();
+        engine.Player.OnStartMoving += (_, direction) => starts.Add(direction);
+
+        const int canvas = 480;
+        ClickOnTile(engine, 0, 6, canvas, canvas);
+
+        var target = new Position(0.5, 6.5);
+        for (var frame = 0; frame < 5000 && engine.Player.Position != target; frame++)
+        {
+            engine.Update(FrameDt);
+        }
+
+        Assert.Equal(target, engine.Player.Position);
+        Assert.NotEmpty(starts);
+
+        // Every leg of the centred axis path is exactly the canonical Down direction.
+        foreach (var direction in starts)
+        {
+            Assert.Equal(Direction.Down, direction);
+        }
+        Assert.Contains(Direction.Down, Direction.All);
+
+        // Diagonal centred path: the legs are the canonical diagonal unit vector within
+        // floating-point precision (1/√2 vs the RootHalf constant).
+        var diagonalEngine = new GameEngine { Map = TileMap.Load(fixture.MapPath) };
+        ConfigurePlayerSprite(diagonalEngine, seed: 1);
+        diagonalEngine.Player.Position = new Position(0.5, 1.5);
+
+        var diagonalStarts = new List<Direction>();
+        diagonalEngine.Player.OnStartMoving += (_, direction) => diagonalStarts.Add(direction);
+
+        ClickOnTile(diagonalEngine, 3, 4, canvas, canvas);
+
+        var diagonalTarget = new Position(3.5, 4.5);
+        for (var frame = 0; frame < 5000 && diagonalEngine.Player.Position != diagonalTarget; frame++)
+        {
+            diagonalEngine.Update(FrameDt);
+        }
+
+        Assert.Equal(diagonalTarget, diagonalEngine.Player.Position);
+        Assert.NotEmpty(diagonalStarts);
+        foreach (var direction in diagonalStarts)
+        {
+            // The continuous leg vector is the canonical diagonal within precision, and its
+            // Nearest8 adaptation is exactly the canonical DownRight (sprite/key-input mapping).
+            Assert.Equal(Direction.DownRight.X, direction.X, precision: 9);
+            Assert.Equal(Direction.DownRight.Y, direction.Y, precision: 9);
+            Assert.Equal(Direction.DownRight, direction.Nearest8());
+        }
+    }
+
 }

--- a/tests/RPGEngine.Tests/PlayerBlockedMoveTests.cs
+++ b/tests/RPGEngine.Tests/PlayerBlockedMoveTests.cs
@@ -90,4 +90,27 @@ public class PlayerBlockedMoveTests
         Assert.Equal(new[] { Direction.Right }, starts);
         Assert.Equal(new[] { Direction.Right }, stops);
     }
+
+    /// <summary>
+    /// Verifies ReportBlockedMove raises OnStopMoving with the attempted (possibly continuous)
+    /// direction vector.
+    /// </summary>
+    [Fact]
+    public void ReportBlockedMove_ContinuousDirection_RaisesOnStopMovingWithAttemptedVector()
+    {
+        var player = new Player();
+        var continuous = new Direction(0.6, 0.8);
+        var events = new List<Direction>();
+        player.OnStopMoving += (_, direction) => events.Add(direction);
+
+        player.Move(Direction.Right, speedFactor: 1, dt: 1);
+        events.Clear();
+
+        player.ReportBlockedMove(continuous);
+
+        var raised = Assert.Single(events);
+        Assert.Equal(continuous.X, raised.X, precision: 9);
+        Assert.Equal(continuous.Y, raised.Y, precision: 9);
+        Assert.Equal(continuous, player.Direction);
+    }
 }

--- a/tests/RPGEngine.Tests/PlayerTests.cs
+++ b/tests/RPGEngine.Tests/PlayerTests.cs
@@ -324,6 +324,93 @@ public class PlayerTests
         Assert.Equal(new[] { Direction.Down }, stops);
     }
 
+    // ---------------------------------------------------------------------
+    // Story 75 (direction rework 2/2): Player.OnStartMoving / OnStopMoving
+    // carry the direction *vector* (X, Y), which may be continuous. Key input
+    // yields canonical 8 directions, but a host can drive continuous movement
+    // through Move/StartMoving and the events report the exact continuous
+    // vector; Stop and a blocked move report the last (possibly continuous)
+    // direction vector.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies Move(new Direction(0.6, 0.8), 1, 1) from idle raises OnStartMoving carrying that
+    /// exact continuous vector, before the displacement.
+    /// </summary>
+    [Fact]
+    public void Move_ContinuousDirection_WhenIdle_RaisesOnStartMovingWithExactVector()
+    {
+        var player = new Player { Position = new Position(10, 20) };
+        player.Character.BaseSpeed = 2;
+        var continuous = new Direction(0.6, 0.8);
+        var events = new List<Direction>();
+        player.OnStartMoving += (_, direction) =>
+        {
+            events.Add(direction);
+            // The event fires before the displacement: the handler sees the pre-move position.
+            Assert.Equal(new Position(10, 20), player.Position);
+        };
+
+        player.Move(continuous, speedFactor: 1, dt: 1);
+
+        var raised = Assert.Single(events);
+        Assert.Equal(continuous.X, raised.X, precision: 9);
+        Assert.Equal(continuous.Y, raised.Y, precision: 9);
+        Assert.Equal(new Position(11.2, 21.6), player.Position); // BaseSpeed 2 * (0.6, 0.8)
+    }
+
+    /// <summary>
+    /// Verifies a direction change while moving (host-driven) raises OnStartMoving with the new
+    /// continuous vector, while a same-vector move raises nothing.
+    /// </summary>
+    [Fact]
+    public void Move_ContinuousDirection_DirectionChangeRaisesStart_ButSameVectorRaisesNothing()
+    {
+        var player = new Player();
+        var continuous = new Direction(0.6, 0.8);
+        var other = new Direction(-0.8, 0.6);
+        var starts = new List<Direction>();
+        var stops = new List<Direction>();
+        player.OnStartMoving += (_, direction) => starts.Add(direction);
+        player.OnStopMoving += (_, direction) => stops.Add(direction);
+
+        player.Move(continuous, speedFactor: 1, dt: 1);
+        starts.Clear();
+        stops.Clear();
+
+        // Same continuous vector while moving: no event.
+        player.Move(continuous, speedFactor: 1, dt: 1);
+        Assert.Empty(starts);
+        Assert.Empty(stops);
+
+        // A direction change while moving: a new start with the new continuous vector.
+        player.Move(other, speedFactor: 1, dt: 1);
+        var raised = Assert.Single(starts);
+        Assert.Equal(other.X, raised.X, precision: 9);
+        Assert.Equal(other.Y, raised.Y, precision: 9);
+        Assert.Empty(stops);
+    }
+
+    /// <summary>
+    /// Verifies Stop() raises OnStopMoving with the last (possibly continuous) direction vector.
+    /// </summary>
+    [Fact]
+    public void Stop_ContinuousDirection_RaisesOnStopMovingWithLastContinuousVector()
+    {
+        var player = new Player();
+        var continuous = new Direction(0.6, 0.8);
+        var stops = new List<Direction>();
+        player.OnStopMoving += (_, direction) => stops.Add(direction);
+
+        player.Move(continuous, speedFactor: 1, dt: 1);
+        player.Stop();
+
+        var raised = Assert.Single(stops);
+        Assert.Equal(continuous.X, raised.X, precision: 9);
+        Assert.Equal(continuous.Y, raised.Y, precision: 9);
+        Assert.Equal(continuous, player.Direction);
+    }
+
     /// <summary>The cardinal directions and the exact X/Y displacement Move(d, 2, 0.5) must produce at BaseSpeed 100.</summary>
     public static TheoryData<Direction, double, double> CardinalMoveCases => new()
     {


### PR DESCRIPTION
Closes #75

## Summary

Activates and locks in the continuous behaviour enabled by Story 1/2 (#74): a character moves by `Direction * (BaseSpeed * factor * dt)` along any continuous (unit) 2-D vector, click-to-move auto-walk faces/reports the exact normalized vector toward each waypoint centre (no more 8-direction quantization), and `Player.OnStartMoving` / `OnStopMoving` emit the direction **vector** (X, Y). Key input stays 8-canonical and sprites still adapt a continuous facing to the nearest canonical 8 direction at draw time.

### Source changes
- **`GameEngine.TryAdvanceAutoWalk`** — each auto-walk leg now computes the exact continuous unit vector toward the next waypoint centre (`new Direction(toTarget.X / distance, toTarget.Y / distance)`) and uses it both as the player's facing and as the `Player.ReportAutoWalkStep` argument (both the first-leg branch and the next-waypoint branch). The displacement is unchanged (still along the leg vector via `toTarget * (step / distance)`), so the player still stops exactly centred on the clicked tile. The private `DirectionFromVector` (8-direction quantization) helper was removed from the auto-walk movement/event path; key movement (`MovePlayerWithCollisionResolution`) still receives canonical 8 directions from `GameConfig`.
- **Character / Player** needed no behavioural change (Story 1 already carries vectors); this story documents and tests them as continuous.

### Tests added/updated
- `CharacterTests` — continuous `Move(new Direction(0.6, 0.8), 1, 1)` displacement `(1.2, 1.6)`, direction-less `Move` reusing a continuous `Direction`, `StartMoving` + `Update(map: null)` along a continuous vector, speed-factor-zero turn, walk-cycle advancement along a continuous direction, and pixel-level sprite 8-direction adaptation of continuous facing (nearest DownRight renders the DownRight row; nearest Up renders row 3).
- `PlayerTests` / `PlayerBlockedMoveTests` — `Move` from idle raises `OnStartMoving` with the exact continuous vector before displacement, direction-change vs same-vector events, `Stop()`/`ReportBlockedMove` carry the last/attempted (possibly continuous) vector.
- `GameEngineClickToMoveTests` — `Click_OnStartMoving_FiresPerStep_AndOnStopMovingOnCompletion` starts the player off-tile-centre and asserts the first `OnStartMoving` payload equals the normalized vector to the first waypoint centre (not an 8-direction bucket) with per-step count + single stop invariants; new `Click_OnNonCentredStart_FirstStepFacesAndReportsContinuousDirection` (facing and first event carry the same non-canonical continuous vector) and `Click_OnCentredStart_StillYieldsCanonical8Directions` (axis-aligned centred path → exact canonical cardinals; diagonal centred path → canonical diagonal within precision).
- `DocsExamplesTests` — new `ContinuousMovement_AndEventsCarryDirectionVectors` proving the docs examples compile against the real API.

### Documentation
- `docs/api/Character.md`, `docs/api/Player.md`, `docs/api/GameEngine.md`, `docs/api/Direction.md`, `docs/api/DirectionExtensions.md`, `docs/README.md` and `docs/Architecture.md` rewritten/updated to the continuous-direction movement model (displacement = vector × speed; key input → 8 canonical unit vectors; click-to-move → continuous leg vectors with draw-time sprite snap; events carry the direction vector).

### Verification
- `dotnet build RPGEngine.sln -c Release` — **0 warnings / 0 errors**.
- `dotnet test tests/RPGEngine.Tests -c Release` — **428 passed / 0 failed** (acceptance filter of the issue: 190 passed / 0 failed).

> Note: the issue's example off-tile-centre start `(0.2, 1.8)` is outside the legal collision bounds of a map (the 0.5×0.5 collision box requires `x >= 0.25`), so the click-to-move tests use a legal off-tile-centre start `(0.3, 1.8)` that is still strongly non-canonical; the assertions are identical in intent.